### PR TITLE
fix: deploy-verify skipped due to upstream always() condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           echo "All jobs passed or were skipped"
 
   deploy-verify:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.ci-gate.result == 'success'
     needs: ci-gate
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- `deploy-verify` ถูก skip เพราะ `ci-gate` ใช้ `if: always()` ทำให้ GitHub Actions propagate skipped status จาก upstream jobs (backend/frontend/sdk) ลงมาที่ downstream
- แก้โดยเพิ่ม `always()` ใน condition ของ `deploy-verify` พร้อมตรวจ `needs.ci-gate.result == 'success'` เพื่อให้แน่ใจว่ารันเฉพาะเมื่อ ci-gate ผ่านจริง

## Test plan
- [ ] PR: deploy-verify ถูก skip (ไม่ใช่ push to main) ✓
- [ ] หลัง merge: deploy-verify รันจริงและ health check ผ่าน

🤖 Generated with [Claude Code](https://claude.com/claude-code)