### PR TITLE
fix: prevent silent logout on F5 and add toast notifications

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-hook-form": "^7.71.2",
         "react-router": "^7.13.0",
         "recharts": "^3.7.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.0",
         "zod": "^4.3.6",
@@ -5152,6 +5153,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-hook-form": "^7.71.2",
     "react-router": "^7.13.0",
     "recharts": "^3.7.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.0",
     "zod": "^4.3.6",

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router'
+import { NavLink, useNavigate } from 'react-router'
 import {
   LayoutDashboard,
   Radio,
@@ -9,6 +9,7 @@ import {
   Settings,
   LogOut,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { useAuthStore } from '@/stores/auth-store'
 
 const navItems = [
@@ -23,6 +24,13 @@ const navItems = [
 
 export function Sidebar() {
   const logout = useAuthStore((s) => s.logout)
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    toast.success('ออกจากระบบสำเร็จ')
+    navigate('/login', { replace: true })
+  }
 
   return (
     <aside className="fixed inset-y-0 left-0 z-50 w-[260px] border-r border-neutral-200 bg-white flex flex-col">
@@ -54,7 +62,7 @@ export function Sidebar() {
 
       <div className="border-t border-neutral-200 p-3">
         <button
-          onClick={logout}
+          onClick={handleLogout}
           className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-neutral-600 hover:bg-neutral-100 hover:text-neutral-900 transition-colors"
         >
           <LogOut className="h-5 w-5" />

--- a/frontend/src/components/shared/ProtectedRoute.tsx
+++ b/frontend/src/components/shared/ProtectedRoute.tsx
@@ -12,34 +12,50 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const hasHydrated = useAuthStore((s) => s._hasHydrated)
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const setCustomer = useAuthStore((s) => s.setCustomer)
   const logout = useAuthStore((s) => s.logout)
-  const [isVerifying, setIsVerifying] = useState(true)
+  const [isVerifying, setIsVerifying] = useState(
+    () => !!localStorage.getItem('access_token')
+  )
   const [isValid, setIsValid] = useState(false)
 
-  const token = localStorage.getItem('access_token')
-
   useEffect(() => {
-    if (!hasHydrated || !token) return
+    if (!hasHydrated) return
 
-    // Verify token with server and fetch fresh customer data
+    const token = localStorage.getItem('access_token')
+    if (!token) return
+
+    const controller = new AbortController()
+
     api
-      .get<APIResponse<Customer>>('/auth/me')
+      .get<APIResponse<Customer>>('/auth/me', { signal: controller.signal })
       .then(({ data }) => {
+        if (controller.signal.aborted) return
         if (data.data) {
           setCustomer(data.data)
           setIsValid(true)
         } else {
           logout()
+          setIsValid(false)
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        if (err.code === 'ERR_CANCELED') return
         logout()
+        setIsValid(false)
       })
-      .finally(() => setIsVerifying(false))
-  }, [hasHydrated, token]) // eslint-disable-line react-hooks/exhaustive-deps
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsVerifying(false)
+        }
+      })
 
-  if (!hasHydrated) {
+    return () => controller.abort()
+  }, [hasHydrated, setCustomer, logout])
+
+  if (!hasHydrated || isVerifying) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
         <div style={{ color: '#666', fontSize: '14px' }}>Loading...</div>
@@ -47,19 +63,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     )
   }
 
-  if (!token) {
-    return <Navigate to="/login" replace />
-  }
-
-  if (isVerifying) {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
-        <div style={{ color: '#666', fontSize: '14px' }}>Loading...</div>
-      </div>
-    )
-  }
-
-  if (!isValid) {
+  if (!isValid || !isAuthenticated) {
     return <Navigate to="/login" replace />
   }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Toaster } from 'sonner'
 import { router } from './router'
 import './index.css'
 
@@ -18,6 +19,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <Toaster richColors position="top-right" />
     </QueryClientProvider>
   </StrictMode>
 )

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { toast } from 'sonner'
 import { AuthLayout } from '@/components/layout/AuthLayout'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -33,9 +34,12 @@ export function LoginPage() {
     setError('')
     try {
       await login.mutateAsync(data)
+      toast.success('เข้าสู่ระบบสำเร็จ')
       navigate('/dashboard')
     } catch {
-      setError('Invalid email or password')
+      const msg = 'อีเมลหรือรหัสผ่านไม่ถูกต้อง'
+      setError(msg)
+      toast.error(msg)
     }
   }
 


### PR DESCRIPTION
## Summary

- **แก้ F5 logout**: ProtectedRoute ใช้ `AbortController` จัดการ StrictMode double-mount, subscribe `isAuthenticated` จาก Zustand เพื่อ re-render เมื่อ logout, และ lazy-init `isVerifying` เพื่อ skip verification เมื่อไม่มี token
- **แก้ Sidebar logout**: เพิ่ม `useNavigate` เพื่อ redirect ไป `/login` พร้อม toast notification
- **เพิ่ม Toast notifications**: ติดตั้ง `sonner` พร้อมแสดง feedback เมื่อ login/logout สำเร็จหรือล้มเหลว (ภาษาไทย)

## Test plan

- [ ] Login ด้วย credentials ถูก → toast สีเขียว "เข้าสู่ระบบสำเร็จ" + redirect ไป /dashboard
- [ ] Login ด้วย credentials ผิด → toast สีแดง + inline error "อีเมลหรือรหัสผ่านไม่ถูกต้อง"
- [ ] กด F5 ที่หน้า dashboard → ยังอยู่หน้าเดิม ไม่หลุด logout
- [ ] กด Logout ที่ Sidebar → toast สีเขียว "ออกจากระบบสำเร็จ" + redirect ไป /login
- [ ] `cd frontend && npm run lint` — 0 errors
- [ ] `cd frontend && npm run build` — build สำเร็จ

🤖 Generated with [Claude Code](https://claude.com/claude-code)