### PR TITLE
feat: add block-based sale page editor (HeyLink-style)

### DIFF
--- a/backend/internal/domain/sale_page.go
+++ b/backend/internal/domain/sale_page.go
@@ -55,3 +55,30 @@ type ContactInfo struct {
 	Phone      string `json:"phone"`
 	WebsiteURL string `json:"website_url"`
 }
+
+// Block-based content (v2)
+
+type BlockType string
+
+const (
+	BlockTypeImage  BlockType = "image"
+	BlockTypeText   BlockType = "text"
+	BlockTypeButton BlockType = "button"
+)
+
+type Block struct {
+	ID          string    `json:"id"`
+	Type        BlockType `json:"type"`
+	ImageURL    string    `json:"image_url,omitempty"`
+	Text        string    `json:"text,omitempty"`
+	ButtonStyle string    `json:"button_style,omitempty"`
+	ButtonText  string    `json:"button_text,omitempty"`
+	ButtonURL   string    `json:"button_url,omitempty"`
+	ButtonValue string    `json:"button_value,omitempty"`
+}
+
+type BlocksContent struct {
+	Version  int            `json:"version"`
+	Blocks   []Block        `json:"blocks"`
+	Tracking TrackingConfig `json:"tracking"`
+}

--- a/backend/internal/handler/sale_page_handler.go
+++ b/backend/internal/handler/sale_page_handler.go
@@ -38,6 +38,9 @@ func NewSalePageHandler(salePageService *service.SalePageService, logger *slog.L
 	tmplMap["simple"] = template.Must(
 		template.New("simple.html").Funcs(funcMap).ParseFS(templates.SalePageTemplates, "sale_pages/simple.html"),
 	)
+	tmplMap["blocks"] = template.Must(
+		template.New("blocks.html").Funcs(funcMap).ParseFS(templates.SalePageTemplates, "sale_pages/blocks.html"),
+	)
 
 	return &SalePageHandler{
 		salePageService: salePageService,
@@ -48,10 +51,11 @@ func NewSalePageHandler(salePageService *service.SalePageService, logger *slog.L
 }
 
 type salePageTemplateData struct {
-	Page      *domain.SalePage
-	Content   *domain.SimpleContent
-	APIKey    string
-	FBPixelID string
+	Page          *domain.SalePage
+	Content       *domain.SimpleContent
+	BlocksContent *domain.BlocksContent
+	APIKey        string
+	FBPixelID     string
 }
 
 func (h *SalePageHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -115,6 +119,10 @@ func (h *SalePageHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 		if errors.Is(err, service.ErrSalePageNotOwned) {
 			ErrorJSON(w, http.StatusForbidden, "sale page not owned by you")
+			return
+		}
+		if errors.Is(err, service.ErrInvalidContent) {
+			ErrorJSON(w, http.StatusBadRequest, "invalid page content structure")
 			return
 		}
 		if errors.Is(err, service.ErrInvalidSlug) {
@@ -189,23 +197,49 @@ func (h *SalePageHandler) Preview(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *SalePageHandler) renderTemplate(w http.ResponseWriter, page *domain.SalePage, apiKey string, fbPixelID string) {
-	var content domain.SimpleContent
-	if err := json.Unmarshal(page.Content, &content); err != nil {
+	td := salePageTemplateData{
+		Page:      page,
+		APIKey:    apiKey,
+		FBPixelID: fbPixelID,
+	}
+
+	// Detect content version
+	var peek struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(page.Content, &peek); err != nil {
+		h.logger.Error("failed to peek content version", "error", err, "page_id", page.ID)
 		http.Error(w, "invalid page content", http.StatusInternalServerError)
 		return
 	}
 
-	tmpl, ok := h.templates[page.TemplateName]
-	if !ok {
-		h.logger.Warn("unknown template, falling back to simple", "template_name", page.TemplateName, "page_id", page.ID)
-		tmpl = h.templates["simple"]
+	templateName := page.TemplateName
+	if peek.Version == 2 {
+		var blocks domain.BlocksContent
+		if err := json.Unmarshal(page.Content, &blocks); err != nil {
+			http.Error(w, "invalid page content", http.StatusInternalServerError)
+			return
+		}
+		td.BlocksContent = &blocks
+		templateName = "blocks"
+	} else {
+		var content domain.SimpleContent
+		if err := json.Unmarshal(page.Content, &content); err != nil {
+			http.Error(w, "invalid page content", http.StatusInternalServerError)
+			return
+		}
+		td.Content = &content
 	}
 
-	td := salePageTemplateData{
-		Page:      page,
-		Content:   &content,
-		APIKey:    apiKey,
-		FBPixelID: fbPixelID,
+	tmpl, ok := h.templates[templateName]
+	if !ok {
+		if peek.Version == 2 {
+			h.logger.Error("blocks template not found", "page_id", page.ID)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		h.logger.Warn("unknown template, falling back to simple", "template_name", templateName, "page_id", page.ID)
+		tmpl = h.templates["simple"]
 	}
 
 	var buf bytes.Buffer
@@ -216,7 +250,9 @@ func (h *SalePageHandler) renderTemplate(w http.ResponseWriter, page *domain.Sal
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(buf.Bytes())
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		h.logger.Error("failed to write response", "error", err, "page_id", page.ID)
+	}
 }
 
 func (h *SalePageHandler) renderNotFound(w http.ResponseWriter) {

--- a/backend/internal/service/sale_page_service.go
+++ b/backend/internal/service/sale_page_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -85,10 +86,8 @@ func (s *SalePageService) Create(ctx context.Context, customerID string, input C
 		return nil, err
 	}
 
-	// Validate content structure
-	var content domain.SimpleContent
-	if err := json.Unmarshal(input.Content, &content); err != nil {
-		return nil, ErrInvalidContent
+	if err := validateContent(input.Content); err != nil {
+		return nil, err
 	}
 
 	exists, err := s.salePageRepo.SlugExists(ctx, input.Slug)
@@ -188,6 +187,9 @@ func (s *SalePageService) Update(ctx context.Context, customerID, pageID string,
 		page.TemplateName = *input.TemplateName
 	}
 	if input.Content != nil {
+		if err := validateContent(*input.Content); err != nil {
+			return nil, err
+		}
 		page.Content = *input.Content
 	}
 	if input.IsPublished != nil {
@@ -262,4 +264,72 @@ func (s *SalePageService) GetPublishData(ctx context.Context, slug string) (*Sal
 		APIKey:    customer.APIKey,
 		FBPixelID: fbPixelID,
 	}, nil
+}
+
+func validateSafeURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: invalid URL", ErrInvalidContent)
+	}
+	if u.Scheme != "" && u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: URL must use http or https scheme", ErrInvalidContent)
+	}
+	return nil
+}
+
+func validateContent(raw json.RawMessage) error {
+	var peek struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return ErrInvalidContent
+	}
+
+	if peek.Version == 2 {
+		var content domain.BlocksContent
+		if err := json.Unmarshal(raw, &content); err != nil {
+			return ErrInvalidContent
+		}
+		if len(content.Blocks) == 0 {
+			return fmt.Errorf("%w: blocks content must have at least one block", ErrInvalidContent)
+		}
+		if len(content.Blocks) > 100 {
+			return fmt.Errorf("%w: too many blocks (max 100)", ErrInvalidContent)
+		}
+		for i, b := range content.Blocks {
+			if b.ID == "" {
+				return fmt.Errorf("%w: block at index %d missing ID", ErrInvalidContent, i)
+			}
+			switch b.Type {
+			case domain.BlockTypeImage:
+				if err := validateSafeURL(b.ImageURL); err != nil {
+					return err
+				}
+			case domain.BlockTypeText:
+				// text can be empty (draft)
+			case domain.BlockTypeButton:
+				if b.ButtonStyle != "line" && b.ButtonStyle != "website" && b.ButtonStyle != "custom" {
+					return fmt.Errorf("%w: block at index %d has invalid button_style", ErrInvalidContent, i)
+				}
+				if b.ButtonStyle == "website" || b.ButtonStyle == "custom" {
+					if err := validateSafeURL(b.ButtonURL); err != nil {
+						return err
+					}
+				}
+			default:
+				return fmt.Errorf("%w: block at index %d has unknown type %q", ErrInvalidContent, i, b.Type)
+			}
+		}
+		return nil
+	}
+
+	// Default: v1 SimpleContent
+	var content domain.SimpleContent
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return ErrInvalidContent
+	}
+	return nil
 }

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Page.Name}}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: 'Noto Sans Thai', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #1a1a2e;
+            background: #f8f9fa;
+            min-height: 100vh;
+        }
+        .page-wrapper {
+            max-width: 480px;
+            margin: 0 auto;
+            background: #ffffff;
+            min-height: 100vh;
+            box-shadow: 0 0 20px rgba(0,0,0,0.05);
+        }
+        .block-image {
+            width: 100%;
+            display: block;
+            object-fit: cover;
+        }
+        .block-text {
+            padding: 1.25rem 1.5rem;
+            text-align: center;
+            font-size: 0.95rem;
+            color: #4a4a6a;
+            white-space: pre-line;
+        }
+        .block-button {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            width: calc(100% - 3rem);
+            margin: 0.5rem 1.5rem;
+            padding: 0.875rem 1.5rem;
+            border: none;
+            border-radius: 12px;
+            font-family: 'Noto Sans Thai', sans-serif;
+            font-size: 1rem;
+            font-weight: 600;
+            color: #ffffff;
+            text-decoration: none;
+            cursor: pointer;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .block-button:hover {
+            transform: translateY(-2px);
+        }
+        .block-button--line {
+            background-color: #06C755;
+            box-shadow: 0 4px 12px rgba(6, 199, 85, 0.3);
+        }
+        .block-button--line:hover {
+            box-shadow: 0 6px 16px rgba(6, 199, 85, 0.4);
+        }
+        .block-button--website {
+            background-color: #7c3aed;
+            box-shadow: 0 4px 12px rgba(124, 58, 237, 0.3);
+        }
+        .block-button--website:hover {
+            box-shadow: 0 6px 16px rgba(124, 58, 237, 0.4);
+        }
+        .block-button--custom {
+            background-color: #4f46e5;
+            box-shadow: 0 4px 12px rgba(79, 70, 229, 0.3);
+        }
+        .block-button--custom:hover {
+            box-shadow: 0 6px 16px rgba(79, 70, 229, 0.4);
+        }
+        .block-button svg {
+            width: 20px;
+            height: 20px;
+            fill: currentColor;
+            flex-shrink: 0;
+        }
+        .footer {
+            padding: 1rem 1.5rem;
+            text-align: center;
+            font-size: 0.75rem;
+            color: #aaa;
+        }
+    </style>
+</head>
+<body>
+    <div class="page-wrapper">
+        {{range .BlocksContent.Blocks}}
+            {{if eq .Type "image"}}
+            <img src="{{.ImageURL}}" alt="" class="block-image">
+            {{end}}
+
+            {{if eq .Type "text"}}
+            <div class="block-text">{{.Text}}</div>
+            {{end}}
+
+            {{if eq .Type "button"}}
+                {{if eq .ButtonStyle "line"}}
+                <a href="https://line.me/ti/p/~{{.ButtonValue}}" target="_blank" rel="noopener" class="block-button block-button--line" data-track-cta>
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M19.365 9.864c.018 0 .032.003.046.007a.096.096 0 0 1 .076.093v.598c0 .044-.028.082-.068.094l-.008.002H17.91v.473h1.501a.098.098 0 0 1 .068.028l.005.006a.09.09 0 0 1 .023.063v.598a.098.098 0 0 1-.096.096H17.31a.098.098 0 0 1-.096-.096V9.964a.098.098 0 0 1 .096-.096h2.055v-.004zm-3.478 0a.098.098 0 0 1 .096.1v.598a.098.098 0 0 1-.096.096h-1.501v.473h1.501a.098.098 0 0 1 .096.096v.598a.098.098 0 0 1-.096.096h-2.052a.1.1 0 0 1-.098-.096V9.964a.098.098 0 0 1 .098-.096h2.052v-.004zM12 3C6.48 3 2 6.58 2 10.94c0 3.49 2.88 6.49 7.03 7.44.27.06.64.18.73.42.08.22.05.56.03.78l-.12.7c-.04.2-.16.78.68.43.84-.36 4.54-2.67 6.19-4.57h.01C18.41 14.15 22 12.72 22 10.94 22 6.58 17.52 3 12 3z"/></svg>
+                    {{.ButtonText}}
+                </a>
+                {{end}}
+
+                {{if eq .ButtonStyle "website"}}
+                <a href="{{.ButtonURL}}" target="_blank" rel="noopener" class="block-button block-button--website" data-track-cta>
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+                    {{.ButtonText}}
+                </a>
+                {{end}}
+
+                {{if eq .ButtonStyle "custom"}}
+                <a href="{{.ButtonURL}}" target="_blank" rel="noopener" class="block-button block-button--custom" data-track-cta>
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>
+                    {{.ButtonText}}
+                </a>
+                {{end}}
+            {{end}}
+        {{end}}
+
+        <div class="footer">
+            Powered by Pixlinks
+        </div>
+    </div>
+
+    {{if .FBPixelID}}
+    <!-- Meta Pixel Code -->
+    <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window,document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '{{.FBPixelID}}');
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id={{.FBPixelID}}&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
+    {{end}}
+
+    {{if and .APIKey .Page.PixelID}}
+    <script src="/sdk/pixlinks.min.js"
+            data-pixlinks-key="{{.APIKey}}"
+            data-pixlinks-pixel-id="{{deref .Page.PixelID}}">
+    </script>
+    {{end}}
+
+    <script>
+    (function() {
+        var ctaEventName = '{{.BlocksContent.Tracking.CTAEventName}}' || 'Lead';
+        var contentName = '{{.BlocksContent.Tracking.ContentName}}' || document.title;
+        var contentValue = {{.BlocksContent.Tracking.ContentValue}};
+        var currency = '{{.BlocksContent.Tracking.Currency}}' || 'THB';
+
+        function dualTrack(eventName, params) {
+            if (typeof fbq === 'function') {
+                fbq('track', eventName, params);
+            }
+            if (window.pixlinks) {
+                window.pixlinks.track(eventName, params);
+            }
+        }
+
+        function buildParams(extra) {
+            var params = { content_name: contentName, content_category: 'sale_page' };
+            if (contentValue > 0) {
+                params.value = contentValue;
+                params.currency = currency;
+            }
+            if (extra) {
+                for (var k in extra) { params[k] = extra[k]; }
+            }
+            return params;
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            dualTrack('ViewContent', buildParams());
+
+            var ctaButtons = document.querySelectorAll('[data-track-cta]');
+            ctaButtons.forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    dualTrack(ctaEventName, buildParams());
+                });
+            });
+        });
+    })();
+    </script>
+</body>
+</html>

--- a/frontend/src/components/sale-pages/BlockEditor.tsx
+++ b/frontend/src/components/sale-pages/BlockEditor.tsx
@@ -1,0 +1,229 @@
+import { useRef } from 'react'
+import { ChevronUp, ChevronDown, Trash2, Image, Type, MessageCircle, Globe, Link, Upload, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { useUploadImage, useUploadImages } from '@/hooks/use-upload'
+import type { Block, ButtonStyle } from '@/types'
+
+interface BlockEditorProps {
+  blocks: Block[]
+  onChange: (blocks: Block[]) => void
+}
+
+export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
+  const uploadImage = useUploadImage()
+  const uploadImages = useUploadImages()
+  const imageFileRef = useRef<HTMLInputElement>(null)
+
+  const addBlock = (block: Block) => onChange([...blocks, block])
+
+  const updateBlock = (index: number, updates: Partial<Block>) => {
+    const updated = blocks.map((b, i) => i === index ? { ...b, ...updates } as Block : b)
+    onChange(updated)
+  }
+
+  const removeBlock = (index: number) => onChange(blocks.filter((_, i) => i !== index))
+
+  const moveBlock = (index: number, direction: -1 | 1) => {
+    const newIndex = index + direction
+    if (newIndex < 0 || newIndex >= blocks.length) return
+    const updated = blocks.map((b, i) => {
+      if (i === index) return blocks[newIndex]!
+      if (i === newIndex) return blocks[index]!
+      return b
+    })
+    onChange(updated)
+  }
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+    const urls = await uploadImages.mutateAsync(Array.from(files))
+    const newBlocks: Block[] = urls.map(url => ({
+      id: crypto.randomUUID(),
+      type: 'image' as const,
+      image_url: url,
+    }))
+    onChange([...blocks, ...newBlocks])
+    if (imageFileRef.current) imageFileRef.current.value = ''
+  }
+
+  const handleSingleImageUpload = async (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const url = await uploadImage.mutateAsync(file)
+    updateBlock(index, { image_url: url })
+  }
+
+  const addTextBlock = () => addBlock({ id: crypto.randomUUID(), type: 'text', text: '' })
+  const addButtonBlock = (style: ButtonStyle) => addBlock({
+    id: crypto.randomUUID(),
+    type: 'button',
+    button_style: style,
+    button_text: style === 'line' ? 'แอดไลน์' : style === 'website' ? 'เยี่ยมชมเว็บไซต์' : 'คลิกที่นี่',
+    button_url: '',
+    button_value: '',
+  })
+
+  const getTypeBadge = (type: string) => {
+    switch (type) {
+      case 'image': return <Badge variant="secondary">รูปภาพ</Badge>
+      case 'text': return <Badge variant="secondary">ข้อความ</Badge>
+      case 'button': return <Badge variant="secondary">ปุ่ม</Badge>
+      default: return null
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {blocks.map((block, index) => (
+        <div key={block.id} className="border border-neutral-200 rounded-lg p-4 bg-white">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              {getTypeBadge(block.type)}
+            </div>
+            <div className="flex items-center gap-1">
+              <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === 0} onClick={() => moveBlock(index, -1)}>
+                <ChevronUp className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="icon" className="h-7 w-7" disabled={index === blocks.length - 1} onClick={() => moveBlock(index, 1)}>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => removeBlock(index)}>
+                <Trash2 className="h-4 w-4 text-red-500" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Type-specific fields */}
+          {block.type === 'image' && (
+            <div className="space-y-2">
+              {block.image_url ? (
+                <img src={block.image_url} alt="" className="w-full max-h-48 object-cover rounded-md border border-neutral-200" />
+              ) : (
+                <div className="w-full h-32 bg-neutral-100 rounded-md flex items-center justify-center text-neutral-400 text-sm">
+                  ยังไม่มีรูป
+                </div>
+              )}
+              <div className="flex gap-2">
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  id={`img-upload-${block.id}`}
+                  onChange={(e) => handleSingleImageUpload(index, e)}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={uploadImage.isPending}
+                  onClick={() => document.getElementById(`img-upload-${block.id}`)?.click()}
+                >
+                  {uploadImage.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
+                  {block.image_url ? 'เปลี่ยนรูป' : 'อัพโหลดรูป'}
+                </Button>
+              </div>
+              <Input
+                placeholder="หรือวาง URL รูปภาพ"
+                value={block.image_url || ''}
+                onChange={(e) => updateBlock(index, { image_url: e.target.value })}
+                className="text-xs"
+              />
+            </div>
+          )}
+
+          {block.type === 'text' && (
+            <Textarea
+              placeholder="พิมพ์ข้อความ..."
+              value={block.text || ''}
+              onChange={(e) => updateBlock(index, { text: e.target.value })}
+              rows={3}
+            />
+          )}
+
+          {block.type === 'button' && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">ประเภทปุ่ม</Label>
+                <select
+                  className="flex h-9 w-full rounded-md border border-neutral-200 bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-600"
+                  value={block.button_style || 'line'}
+                  onChange={(e) => updateBlock(index, { button_style: e.target.value as ButtonStyle })}
+                >
+                  <option value="line">LINE</option>
+                  <option value="website">เว็บไซต์</option>
+                  <option value="custom">ลิงก์ทั่วไป</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">ข้อความบนปุ่ม</Label>
+                <Input
+                  placeholder="เช่น แอดไลน์, ซื้อเลย"
+                  value={block.button_text || ''}
+                  onChange={(e) => updateBlock(index, { button_text: e.target.value })}
+                />
+              </div>
+              {block.button_style === 'line' ? (
+                <div className="space-y-1.5">
+                  <Label className="text-xs">LINE ID</Label>
+                  <Input
+                    placeholder="@yourlineid"
+                    value={block.button_value || ''}
+                    onChange={(e) => updateBlock(index, { button_value: e.target.value })}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <Label className="text-xs">URL</Label>
+                  <Input
+                    placeholder="https://..."
+                    value={block.button_url || ''}
+                    onChange={(e) => updateBlock(index, { button_url: e.target.value })}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Add Block Buttons */}
+      <div className="border-2 border-dashed border-neutral-200 rounded-lg p-4">
+        <p className="text-xs font-medium text-neutral-500 mb-3 text-center">เพิ่มบล็อก</p>
+        <div className="flex flex-wrap justify-center gap-2">
+          <input ref={imageFileRef} type="file" accept="image/*" multiple className="hidden" onChange={handleImageUpload} />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={uploadImages.isPending}
+            onClick={() => imageFileRef.current?.click()}
+          >
+            {uploadImages.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Image className="h-3.5 w-3.5" />}
+            รูปภาพ
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={addTextBlock}>
+            <Type className="h-3.5 w-3.5" />
+            ข้อความ
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => addButtonBlock('line')}>
+            <MessageCircle className="h-3.5 w-3.5" />
+            LINE
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => addButtonBlock('website')}>
+            <Globe className="h-3.5 w-3.5" />
+            เว็บไซต์
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => addButtonBlock('custom')}>
+            <Link className="h-3.5 w-3.5" />
+            ลิงก์
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/sale-pages/BlockPreview.tsx
+++ b/frontend/src/components/sale-pages/BlockPreview.tsx
@@ -1,0 +1,79 @@
+import { MessageCircle, Globe, Link } from 'lucide-react'
+import type { Block } from '@/types'
+
+interface BlockPreviewProps {
+  blocks: Block[]
+  ctaEventName?: string
+}
+
+export function BlockPreview({ blocks, ctaEventName }: BlockPreviewProps) {
+  return (
+    <div className="max-w-[375px] mx-auto rounded-2xl border border-neutral-200 shadow-lg overflow-hidden bg-white">
+      {/* Blocks */}
+      <div>
+        {blocks.length === 0 && (
+          <div className="px-6 py-16 text-center text-neutral-300 text-sm">
+            เพิ่มบล็อกเพื่อเริ่มสร้างหน้าเพจ
+          </div>
+        )}
+        {blocks.map((block) => {
+          if (block.type === 'image') {
+            return block.image_url ? (
+              <img
+                key={block.id}
+                src={block.image_url}
+                alt=""
+                className="w-full block object-cover"
+                style={{ aspectRatio: '1/1' }}
+              />
+            ) : (
+              <div key={block.id} className="w-full bg-neutral-100 flex items-center justify-center text-neutral-400 text-xs" style={{ aspectRatio: '1/1' }}>
+                รูปภาพ
+              </div>
+            )
+          }
+
+          if (block.type === 'text') {
+            return (
+              <div key={block.id} className="px-5 py-4 text-center">
+                <p className="text-sm text-neutral-700 whitespace-pre-line leading-relaxed">
+                  {block.text || <span className="text-neutral-300">ข้อความ...</span>}
+                </p>
+              </div>
+            )
+          }
+
+          if (block.type === 'button') {
+            const bgColor = block.button_style === 'line' ? '#06C755' : block.button_style === 'website' ? '#7c3aed' : '#4f46e5'
+            const Icon = block.button_style === 'line' ? MessageCircle : block.button_style === 'website' ? Globe : Link
+            return (
+              <div key={block.id} className="px-5 py-1.5">
+                <div className="relative">
+                  <div
+                    className="w-full flex items-center justify-center gap-2 py-3 rounded-xl text-white text-sm font-semibold"
+                    style={{ backgroundColor: bgColor }}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{block.button_text || 'ปุ่ม'}</span>
+                  </div>
+                  {ctaEventName && (
+                    <span className="absolute -top-1.5 -right-1.5 px-1.5 py-0.5 text-[9px] font-medium bg-amber-100 text-amber-700 rounded-full border border-amber-200">
+                      {ctaEventName}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          }
+
+          return null
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="px-6 py-3 bg-neutral-50 text-center mt-2">
+        <p className="text-[10px] text-neutral-400">Powered by Pixlinks</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,0 +1,26 @@
+import { useState, type ReactNode } from 'react'
+import { ChevronDown } from 'lucide-react'
+
+interface CollapsibleProps {
+  title: string
+  children: ReactNode
+  defaultOpen?: boolean
+}
+
+export function Collapsible({ title, children, defaultOpen = false }: CollapsibleProps) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <div className="border border-neutral-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium text-neutral-900 bg-neutral-50 hover:bg-neutral-100 transition-colors"
+        onClick={() => setOpen(!open)}
+      >
+        {title}
+        <ChevronDown className={`h-4 w-4 text-neutral-500 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+      {open && <div className="px-4 py-4 space-y-4">{children}</div>}
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-sale-pages.ts
+++ b/frontend/src/hooks/use-sale-pages.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '@/lib/api'
-import type { APIResponse, SalePage, SalePageContent } from '@/types'
+import type { APIResponse, SalePage, SalePageContent, SalePageContentV2 } from '@/types'
 
 export function useSalePages() {
   return useQuery({
@@ -20,7 +20,7 @@ export function useCreateSalePage() {
       slug: string
       pixel_id?: string
       template_name: string
-      content: SalePageContent
+      content: SalePageContent | SalePageContentV2
       is_published: boolean
     }) => {
       const { data } = await api.post<APIResponse<SalePage>>('/sale-pages', input)
@@ -44,7 +44,7 @@ export function useUpdateSalePage() {
       slug?: string
       pixel_id?: string
       template_name?: string
-      content?: SalePageContent
+      content?: SalePageContent | SalePageContentV2
       is_published?: boolean
     }) => {
       const { data } = await api.put<APIResponse<SalePage>>(`/sale-pages/${id}`, input)

--- a/frontend/src/pages/BlockEditorPage.tsx
+++ b/frontend/src/pages/BlockEditorPage.tsx
@@ -1,0 +1,379 @@
+import { useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router'
+import { ArrowLeft, Copy, Check, ExternalLink, Info, Eye, Pencil } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Collapsible } from '@/components/ui/collapsible'
+import { BlockEditor } from '@/components/sale-pages/BlockEditor'
+import { BlockPreview } from '@/components/sale-pages/BlockPreview'
+import { useSalePages, useCreateSalePage, useUpdateSalePage } from '@/hooks/use-sale-pages'
+import { usePixels } from '@/hooks/use-pixels'
+import type { Block, SalePage, SalePageContentV2 } from '@/types'
+
+const CTA_EVENT_OPTIONS = [
+  { value: 'Lead', label: 'Lead — ลูกค้าสนใจ ต้องการข้อมูลเพิ่ม' },
+  { value: 'Purchase', label: 'Purchase — ลูกค้าซื้อสินค้า/บริการ' },
+  { value: 'InitiateCheckout', label: 'InitiateCheckout — ลูกค้าเริ่มชำระเงิน' },
+  { value: 'AddToCart', label: 'AddToCart — ลูกค้าเพิ่มสินค้าลงตะกร้า' },
+  { value: 'CompleteRegistration', label: 'CompleteRegistration — ลูกค้าสมัครสมาชิกสำเร็จ' },
+  { value: 'Schedule', label: 'Schedule — ลูกค้าจองนัดหมาย' },
+  { value: 'SubmitApplication', label: 'SubmitApplication — ลูกค้าส่งใบสมัคร' },
+] as const
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+// Wrapper: handles data loading and v1→v2 redirect
+export function BlockEditorPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const isEditing = !!id
+  const { data: salePages, isLoading } = useSalePages()
+
+  if (isEditing) {
+    if (isLoading) {
+      return <div className="text-center py-12 text-neutral-500">Loading...</div>
+    }
+    const page = salePages?.find((p) => p.id === id)
+    if (!page) {
+      return <div className="text-center py-12 text-neutral-500">Page not found</div>
+    }
+    const content = page.content as SalePageContentV2
+    if (content.version !== 2) {
+      // v1 page — redirect to classic editor
+      navigate(`/sale-pages/${id}/edit`, { replace: true })
+      return null
+    }
+    return <BlockEditorInner key={id} existingPage={page} />
+  }
+
+  return <BlockEditorInner key="new" />
+}
+
+// Inner: pure editor component with stable initial state
+function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
+  const navigate = useNavigate()
+  const isEditing = !!existingPage
+
+  const { data: pixels } = usePixels()
+  const createSalePage = useCreateSalePage()
+  const updateSalePage = useUpdateSalePage()
+
+  // Parse existing v2 content for initial values
+  const v2 = existingPage ? (existingPage.content as SalePageContentV2) : null
+
+  // Page settings
+  const [name, setName] = useState(existingPage?.name ?? '')
+  const [slug, setSlug] = useState(existingPage?.slug ?? '')
+  const [slugTouched, setSlugTouched] = useState(isEditing)
+  const [pixelId, setPixelId] = useState(existingPage?.pixel_id ?? '')
+
+  // Blocks
+  const [blocks, setBlocks] = useState<Block[]>(v2?.blocks ?? [])
+
+  // Tracking
+  const [ctaEventName, setCtaEventName] = useState(v2?.tracking?.cta_event_name || 'Lead')
+  const [trackingContentName, setTrackingContentName] = useState(v2?.tracking?.content_name || '')
+  const [trackingContentValue, setTrackingContentValue] = useState(v2?.tracking?.content_value || 0)
+  const [trackingCurrency, setTrackingCurrency] = useState(v2?.tracking?.currency || 'THB')
+
+  // UI state
+  const [mobileView, setMobileView] = useState<'edit' | 'preview'>('edit')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [publishedDialog, setPublishedDialog] = useState<{ slug: string } | null>(null)
+  const [copiedUrl, setCopiedUrl] = useState(false)
+
+  const handleNameChange = (value: string) => {
+    setName(value)
+    if (!slugTouched) {
+      setSlug(generateSlug(value))
+    }
+  }
+
+  const buildContent = (): SalePageContentV2 => ({
+    version: 2,
+    blocks,
+    tracking: {
+      cta_event_name: ctaEventName || 'Lead',
+      content_name: trackingContentName || '',
+      content_value: trackingContentValue || 0,
+      currency: trackingCurrency || 'THB',
+    },
+  })
+
+  const isSubmitting = createSalePage.isPending || updateSalePage.isPending
+
+  const onSubmit = async (isPublished: boolean) => {
+    setSubmitError(null)
+    if (!name.trim() || !slug.trim()) {
+      setSubmitError('กรุณากรอกชื่อหน้าเพจและ URL')
+      return
+    }
+    if (blocks.length === 0) {
+      setSubmitError('กรุณาเพิ่มบล็อกอย่างน้อย 1 อัน')
+      return
+    }
+    try {
+      const content = buildContent()
+      const payload = {
+        name,
+        slug,
+        pixel_id: pixelId || undefined,
+        template_name: 'blocks',
+        content,
+        is_published: isPublished,
+      }
+
+      if (isEditing && existingPage) {
+        await updateSalePage.mutateAsync({ id: existingPage.id, ...payload })
+      } else {
+        await createSalePage.mutateAsync(payload)
+      }
+
+      if (isPublished) {
+        setPublishedDialog({ slug })
+      } else {
+        navigate('/sale-pages')
+      }
+    } catch {
+      setSubmitError('บันทึกไม่สำเร็จ กรุณาลองใหม่อีกครั้ง')
+    }
+  }
+
+  const copyUrl = (pageSlug: string) => {
+    navigator.clipboard.writeText(`${window.location.origin}/p/${pageSlug}`)
+    setCopiedUrl(true)
+    setTimeout(() => setCopiedUrl(false), 2000)
+  }
+
+  return (
+    <div>
+      {/* Top Bar */}
+      <div className="flex items-center justify-between mb-6">
+        <Link
+          to="/sale-pages"
+          className="flex items-center gap-1.5 text-sm text-neutral-600 hover:text-neutral-900 transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Sale Pages
+        </Link>
+        <div className="flex items-center gap-2">
+          {/* Mobile toggle */}
+          <div className="flex lg:hidden border border-neutral-200 rounded-md overflow-hidden">
+            <button
+              type="button"
+              className={`px-3 py-1.5 text-xs font-medium ${mobileView === 'edit' ? 'bg-neutral-900 text-white' : 'text-neutral-600'}`}
+              onClick={() => setMobileView('edit')}
+            >
+              <Pencil className="h-3 w-3 inline mr-1" />
+              แก้ไข
+            </button>
+            <button
+              type="button"
+              className={`px-3 py-1.5 text-xs font-medium ${mobileView === 'preview' ? 'bg-neutral-900 text-white' : 'text-neutral-600'}`}
+              onClick={() => setMobileView('preview')}
+            >
+              <Eye className="h-3 w-3 inline mr-1" />
+              พรีวิว
+            </button>
+          </div>
+          <Button
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={() => onSubmit(false)}
+          >
+            {isSubmitting ? 'กำลังบันทึก...' : 'บันทึกแบบร่าง'}
+          </Button>
+          <Button
+            disabled={isSubmitting}
+            onClick={() => onSubmit(true)}
+          >
+            {isSubmitting ? 'กำลังเผยแพร่...' : isEditing && existingPage?.is_published ? 'อัพเดท' : 'เผยแพร่'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {submitError && (
+        <div className="mb-4 p-3 rounded-md bg-red-50 border border-red-200 text-sm text-red-700">
+          {submitError}
+        </div>
+      )}
+
+      {/* 2-Column Layout */}
+      <div className="flex gap-8">
+        {/* Left Column - Editor */}
+        <div className={`flex-1 lg:w-2/3 space-y-4 ${mobileView === 'preview' ? 'hidden lg:block' : ''}`}>
+          {/* Settings */}
+          <Collapsible title="ตั้งค่าหน้าเพจ" defaultOpen={!isEditing}>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="page-name">ชื่อหน้าเพจ</Label>
+                <Input
+                  id="page-name"
+                  placeholder="เช่น โปรโมชั่นครีมหน้าใส"
+                  value={name}
+                  onChange={(e) => handleNameChange(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="page-slug">URL</Label>
+                <div className="flex">
+                  <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-neutral-200 bg-neutral-50 text-sm text-neutral-500">
+                    /p/
+                  </span>
+                  <Input
+                    id="page-slug"
+                    className="rounded-l-none"
+                    placeholder="my-page"
+                    value={slug}
+                    onChange={(e) => { setSlug(e.target.value); setSlugTouched(true) }}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="pixel-select">Pixel (ไม่บังคับ)</Label>
+                <select
+                  id="pixel-select"
+                  className="flex h-9 w-full rounded-md border border-neutral-200 bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-600"
+                  value={pixelId}
+                  onChange={(e) => setPixelId(e.target.value)}
+                >
+                  <option value="">ไม่เลือก pixel</option>
+                  {pixels?.map((pixel) => (
+                    <option key={pixel.id} value={pixel.id}>
+                      {pixel.name} ({pixel.fb_pixel_id})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </Collapsible>
+
+          {/* Block Editor */}
+          <BlockEditor blocks={blocks} onChange={setBlocks} />
+
+          {/* Tracking Settings */}
+          <Collapsible title="ตั้งค่าการติดตาม">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cta-event">เมื่อกดปุ่ม CTA ให้ยิงอีเวนต์</Label>
+                <select
+                  id="cta-event"
+                  className="flex h-9 w-full rounded-md border border-neutral-200 bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-600"
+                  value={ctaEventName}
+                  onChange={(e) => setCtaEventName(e.target.value)}
+                >
+                  {CTA_EVENT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="content-name">ชื่อสินค้า (ไม่บังคับ)</Label>
+                <Input
+                  id="content-name"
+                  placeholder="เช่น ครีมหน้าใส, คอร์สออนไลน์"
+                  value={trackingContentName}
+                  onChange={(e) => setTrackingContentName(e.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="content-value">ราคาสินค้า (ไม่บังคับ)</Label>
+                  <Input
+                    id="content-value"
+                    type="number"
+                    placeholder="0"
+                    value={trackingContentValue}
+                    onChange={(e) => setTrackingContentValue(Number(e.target.value) || 0)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="currency">สกุลเงิน</Label>
+                  <select
+                    id="currency"
+                    className="flex h-9 w-full rounded-md border border-neutral-200 bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-600"
+                    value={trackingCurrency}
+                    onChange={(e) => setTrackingCurrency(e.target.value)}
+                  >
+                    <option value="THB">THB (บาท)</option>
+                    <option value="USD">USD (ดอลลาร์)</option>
+                  </select>
+                </div>
+              </div>
+              <div className="rounded-md bg-blue-50 border border-blue-200 p-3">
+                <div className="flex items-start gap-2">
+                  <Info className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+                  <div className="text-xs text-blue-700 space-y-1">
+                    <p className="font-medium">อีเวนต์ที่ยิงอัตโนมัติ:</p>
+                    <ul className="space-y-0.5 ml-1">
+                      <li><code className="bg-blue-100 px-1 rounded">PageView</code> — ยิงเมื่อเปิดหน้าเพจ</li>
+                      <li><code className="bg-blue-100 px-1 rounded">ViewContent</code> — ยิงเมื่อเปิดหน้าเพจ</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Collapsible>
+        </div>
+
+        {/* Right Column - Preview */}
+        <div className={`lg:w-1/3 ${mobileView === 'edit' ? 'hidden lg:block' : ''}`}>
+          <div className="sticky top-8">
+            <p className="text-sm font-medium text-neutral-500 mb-3">Preview</p>
+            <BlockPreview blocks={blocks} ctaEventName={ctaEventName} />
+          </div>
+        </div>
+      </div>
+
+      {/* Published Success Dialog */}
+      <Dialog open={!!publishedDialog} onOpenChange={() => setPublishedDialog(null)}>
+        <DialogContent onClose={() => setPublishedDialog(null)}>
+          <DialogHeader>
+            <DialogTitle>เผยแพร่สำเร็จ!</DialogTitle>
+          </DialogHeader>
+          <div className="mt-4 space-y-3">
+            <p className="text-sm text-neutral-600">หน้าเพจของคุณพร้อมใช้งานแล้วที่:</p>
+            <div className="flex items-center gap-2 p-2 bg-neutral-50 rounded-md border border-neutral-200">
+              <code className="text-sm text-indigo-600 flex-1 truncate">
+                {publishedDialog && `${window.location.origin}/p/${publishedDialog.slug}`}
+              </code>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => publishedDialog && copyUrl(publishedDialog.slug)}
+              >
+                {copiedUrl ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+            <p className="text-xs text-neutral-500">
+              แชร์ลิงก์นี้ใน bio link, LINE, หรือ Facebook เพื่อเริ่มเก็บข้อมูล
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => publishedDialog && window.open(`/p/${publishedDialog.slug}`, '_blank')}
+            >
+              <ExternalLink className="h-4 w-4" />
+              เปิดหน้าเพจ
+            </Button>
+            <Button onClick={() => { setPublishedDialog(null); navigate('/sale-pages') }}>
+              กลับไปหน้ารายการ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/pages/SalePageEditorPage.tsx
+++ b/frontend/src/pages/SalePageEditorPage.tsx
@@ -14,7 +14,7 @@ import { SalePagePreview } from '@/components/sale-pages/SalePagePreview'
 import { useSalePages, useCreateSalePage, useUpdateSalePage } from '@/hooks/use-sale-pages'
 import { usePixels } from '@/hooks/use-pixels'
 import { useUploadImage, useUploadImages } from '@/hooks/use-upload'
-import type { SalePageContent } from '@/types'
+import type { SalePageContent, SalePageContentV2 } from '@/types'
 
 const CTA_EVENT_OPTIONS = [
   { value: 'Lead', label: 'Lead — ลูกค้าสนใจ ต้องการข้อมูลเพิ่ม' },
@@ -109,10 +109,14 @@ export function SalePageEditorPage() {
     },
   })
 
-  // Load existing data when editing
+  // Load existing data when editing — redirect to blocks editor if v2
   useEffect(() => {
     if (existingPage) {
-      const c = existingPage.content
+      if ('version' in existingPage.content && (existingPage.content as SalePageContentV2).version === 2) {
+        navigate(`/sale-pages/${id}/edit-blocks`, { replace: true })
+        return
+      }
+      const c = existingPage.content as SalePageContent
       const featuresList = c.body.features.length > 0 ? c.body.features : ['']
       reset({
         name: existingPage.name,
@@ -137,7 +141,7 @@ export function SalePageEditorPage() {
       setBodyImages(c.body.images ?? [])
       setSlugTouched(true)
     }
-  }, [existingPage, reset])
+  }, [existingPage, reset, id, navigate])
 
   // Auto-generate slug from name
   const watchName = watch('name')

--- a/frontend/src/pages/SalePagesPage.tsx
+++ b/frontend/src/pages/SalePagesPage.tsx
@@ -57,6 +57,7 @@ export function SalePagesPage() {
                 <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Name</th>
                 <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">URL</th>
                 <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Pixel</th>
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Template</th>
                 <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Status</th>
                 <th className="text-right text-sm font-medium text-neutral-500 px-4 py-3">Actions</th>
               </tr>
@@ -69,6 +70,11 @@ export function SalePagesPage() {
                     <span className="font-mono truncate max-w-[200px] inline-block">/p/{page.slug}</span>
                   </td>
                   <td className="px-4 py-3 text-sm text-neutral-600">{getPixelName(page.pixel_id)}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={page.template_name === 'blocks' ? 'default' : 'secondary'}>
+                      {page.template_name === 'blocks' ? 'Blocks' : 'Classic'}
+                    </Badge>
+                  </td>
                   <td className="px-4 py-3">
                     <Badge variant={page.is_published ? 'success' : 'secondary'}>
                       {page.is_published ? 'Published' : 'Draft'}
@@ -88,7 +94,11 @@ export function SalePagesPage() {
                         variant="ghost"
                         size="icon"
                         title="Edit"
-                        onClick={() => navigate(`/sale-pages/${page.id}/edit`)}
+                        onClick={() => navigate(
+                          page.template_name === 'blocks'
+                            ? `/sale-pages/${page.id}/edit-blocks`
+                            : `/sale-pages/${page.id}/edit`
+                        )}
                       >
                         <Pencil className="h-4 w-4" />
                       </Button>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,6 +11,7 @@ import { ReplayPage } from '@/pages/ReplayPage'
 import { SettingsPage } from '@/pages/SettingsPage'
 import { SalePagesPage } from '@/pages/SalePagesPage'
 import { SalePageEditorPage } from '@/pages/SalePageEditorPage'
+import { BlockEditorPage } from '@/pages/BlockEditorPage'
 
 export const router = createBrowserRouter([
   {
@@ -33,8 +34,10 @@ export const router = createBrowserRouter([
       { path: 'dashboard', element: <DashboardPage /> },
       { path: 'pixels', element: <PixelsPage /> },
       { path: 'sale-pages', element: <SalePagesPage /> },
-      { path: 'sale-pages/new', element: <SalePageEditorPage /> },
+      { path: 'sale-pages/new', element: <BlockEditorPage /> },
+      { path: 'sale-pages/new-classic', element: <SalePageEditorPage /> },
       { path: 'sale-pages/:id/edit', element: <SalePageEditorPage /> },
+      { path: 'sale-pages/:id/edit-blocks', element: <BlockEditorPage /> },
       { path: 'events/setup', element: <EventSetupPage /> },
       { path: 'events/log', element: <EventLogPage /> },
       { path: 'replay', element: <ReplayPage /> },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -95,6 +95,34 @@ export interface SalePageContent {
   }
 }
 
+// Block-based content (v2)
+export type BlockType = 'image' | 'text' | 'button'
+export type ButtonStyle = 'line' | 'website' | 'custom'
+
+export interface Block {
+  id: string
+  type: BlockType
+  image_url?: string
+  text?: string
+  button_style?: ButtonStyle
+  button_text?: string
+  button_url?: string
+  button_value?: string
+}
+
+export interface TrackingConfig {
+  cta_event_name: string
+  content_name: string
+  content_value: number
+  currency: string
+}
+
+export interface SalePageContentV2 {
+  version: 2
+  blocks: Block[]
+  tracking: TrackingConfig
+}
+
 export interface SalePage {
   id: string
   customer_id: string
@@ -102,7 +130,7 @@ export interface SalePage {
   name: string
   slug: string
   template_name: string
-  content: SalePageContent
+  content: SalePageContent | SalePageContentV2
   is_published: boolean
   created_at: string
   updated_at: string


### PR DESCRIPTION
## Summary

- เพิ่มระบบ block-based content v2 สำหรับ sale pages คู่ไปกับ v1 classic editor เดิม
- ผู้ใช้สามารถจัดเรียง image / text / button blocks ได้อิสระ ตาม workflow ของ HeyLink.me
- ไม่ต้อง migrate database — JSONB รองรับ JSON structure ใหม่โดยตรง
- v1 pages ทำงานปกติ 100% ไม่มี breaking changes

### Backend (4 files)
- **Domain**: `Block`, `BlocksContent`, `BlockType` types
- **Service**: `validateContent()` — version-aware validation, URL scheme enforcement (XSS prevention), block count limit (100)
- **Handler**: version-aware rendering — auto-detect v2 content → `blocks.html` template
- **Template**: `blocks.html` — Noto Sans Thai, image/text/button blocks, Meta Pixel + Pixlinks SDK tracking

### Frontend (9 files)
- **Types**: `Block`, `SalePageContentV2`, `TrackingConfig` + union content type
- **Components**: `BlockEditor` (reorder/add/delete blocks), `BlockPreview` (phone-frame preview), `Collapsible` (lightweight UI)
- **Page**: `BlockEditorPage` — settings collapsible, block editor, tracking collapsible, mobile edit/preview toggle
- **Routing**: `/sale-pages/new` → blocks editor (default), `/sale-pages/new-classic` → classic editor, version guards redirect mismatched editors

### Security
- URL validation: `validateSafeURL()` enforces http/https scheme — blocks `javascript:` URI XSS
- Button style validation: must be `line`, `website`, or `custom`
- Error handling: ignored `json.Unmarshal` error fixed, `w.Write` error logged

## Test plan

- [ ] สร้าง v2 page ใหม่ → upload รูป 3-5 รูป + text + LINE button → publish → เปิด `/p/{slug}` ดู output
- [ ] เปิด v1 page เดิม → ยังแก้ไขและ render ได้ปกติ
- [ ] เปิด v2 page ใน classic editor URL → redirect ไป block editor อัตโนมัติ
- [ ] เปิด v1 page ใน block editor URL → redirect ไป classic editor อัตโนมัติ
- [ ] Mobile view: toggle edit/preview ทำงาน
- [ ] บันทึกโดยไม่ใส่ชื่อ/slug → แสดง error message
- [ ] บันทึกโดยไม่มี blocks → แสดง error message
- [ ] ลอง submit URL ที่มี `javascript:` scheme → backend reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)