### PR TITLE
fix: correct CF_CNAME_TARGET default from customers to customer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,4 +24,4 @@ CF_API_TOKEN=
 CF_ACCOUNT_ID=
 CF_ZONE_ID=
 CF_KV_NAMESPACE_ID=
-CF_CNAME_TARGET=customers.pixlinks.xyz
+CF_CNAME_TARGET=customer.pixlinks.xyz

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	CFAccountID     string `env:"CF_ACCOUNT_ID"`
 	CFZoneID        string `env:"CF_ZONE_ID"`
 	CFKVNamespaceID string `env:"CF_KV_NAMESPACE_ID"`
-	CFCNAMETarget   string `env:"CF_CNAME_TARGET" envDefault:"customers.pixlinks.xyz"`
+	CFCNAMETarget   string `env:"CF_CNAME_TARGET" envDefault:"customer.pixlinks.xyz"`
 
 	// S3/R2 Storage
 	S3Endpoint  string `env:"S3_ENDPOINT"`


### PR DESCRIPTION
## Summary
- Fix default `CF_CNAME_TARGET` in `config.go` from `customers.pixlinks.xyz` to `customer.pixlinks.xyz`
- Update `.env.example` to match the actual DNS record name

## Test plan
- [x] `go vet ./...` passes
- [x] Frontend builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)