### PR TITLE
feat: add OG meta tags and auto-generate slug for sale pages

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,9 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173
 # Rate Limiting
 RATE_LIMIT_RPS=100
 
+# Public base URL
+BASE_URL=https://pixlinks.xyz
+
 # Cloudflare (for custom domains)
 CF_API_TOKEN=
 CF_ACCOUNT_ID=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	CFKVNamespaceID string `env:"CF_KV_NAMESPACE_ID"`
 	CFCNAMETarget   string `env:"CF_CNAME_TARGET" envDefault:"customer.pixlinks.xyz"`
 
+	// Public base URL for sale pages
+	BaseURL string `env:"BASE_URL" envDefault:"https://pixlinks.xyz"`
+
 	// S3/R2 Storage
 	S3Endpoint  string `env:"S3_ENDPOINT"`
 	S3Bucket    string `env:"S3_BUCKET"`

--- a/backend/internal/handler/sale_page_handler.go
+++ b/backend/internal/handler/sale_page_handler.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
@@ -22,13 +23,22 @@ type SalePageHandler struct {
 	validate        *validator.Validate
 	templates       map[string]*template.Template
 	logger          *slog.Logger
+	baseURL         string
 }
 
-func NewSalePageHandler(salePageService *service.SalePageService, logger *slog.Logger) *SalePageHandler {
+func NewSalePageHandler(salePageService *service.SalePageService, baseURL string, logger *slog.Logger) *SalePageHandler {
 	funcMap := template.FuncMap{
 		"deref": func(s *string) string {
 			if s != nil {
 				return *s
+			}
+			return ""
+		},
+		"firstImageURL": func(blocks []domain.Block) string {
+			for _, b := range blocks {
+				if b.Type == "image" && b.ImageURL != "" {
+					return b.ImageURL
+				}
 			}
 			return ""
 		},
@@ -47,6 +57,7 @@ func NewSalePageHandler(salePageService *service.SalePageService, logger *slog.L
 		validate:        validator.New(),
 		templates:       tmplMap,
 		logger:          logger,
+		baseURL:         strings.TrimRight(baseURL, "/"),
 	}
 }
 
@@ -57,6 +68,7 @@ type salePageTemplateData struct {
 	Style         domain.PageStyle
 	APIKey        string
 	FBPixelID     string
+	BaseURL       string
 }
 
 func (h *SalePageHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -202,6 +214,7 @@ func (h *SalePageHandler) renderTemplate(w http.ResponseWriter, page *domain.Sal
 		Page:      page,
 		APIKey:    apiKey,
 		FBPixelID: fbPixelID,
+		BaseURL:   h.baseURL,
 	}
 
 	// Detect content version

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -68,7 +68,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool) http.Handl
 	replayHandler := handler.NewReplayHandler(replayService)
 	analyticsHandler := handler.NewAnalyticsHandler(analyticsService)
 	proxyHandler := handler.NewProxyHandler()
-	salePageHandler := handler.NewSalePageHandler(salePageService, logger)
+	salePageHandler := handler.NewSalePageHandler(salePageService, cfg.BaseURL, logger)
 	customDomainHandler := handler.NewCustomDomainHandler(customDomainService, cfg.CFCNAMETarget, logger)
 	uploadHandler := handler.NewUploadHandler(storageService)
 

--- a/backend/internal/service/sale_page_service.go
+++ b/backend/internal/service/sale_page_service.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/url"
 	"regexp"
 	"strings"
@@ -51,7 +53,7 @@ func NewSalePageService(salePageRepo repository.SalePageRepository, customerRepo
 
 type CreateSalePageInput struct {
 	Name         string          `json:"name" validate:"required"`
-	Slug         string          `json:"slug" validate:"required,min=2,max=100"`
+	Slug         string          `json:"slug" validate:"omitempty,min=2,max=100"`
 	PixelID      *string         `json:"pixel_id,omitempty"`
 	TemplateName string          `json:"template_name" validate:"required"`
 	Content      json.RawMessage `json:"content" validate:"required"`
@@ -73,6 +75,20 @@ type SalePagePublishData struct {
 	FBPixelID string
 }
 
+func generateRandomSlug() (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 8)
+	max := big.NewInt(int64(len(charset)))
+	for i := range b {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = charset[n.Int64()]
+	}
+	return "p-" + string(b), nil
+}
+
 func validateSlug(slug string) error {
 	if !slugRegex.MatchString(slug) {
 		return ErrInvalidSlug
@@ -84,20 +100,40 @@ func validateSlug(slug string) error {
 }
 
 func (s *SalePageService) Create(ctx context.Context, customerID string, input CreateSalePageInput) (*domain.SalePage, error) {
-	if err := validateSlug(input.Slug); err != nil {
-		return nil, err
-	}
-
 	if err := validateContent(input.Content); err != nil {
 		return nil, err
 	}
 
-	exists, err := s.salePageRepo.SlugExists(ctx, input.Slug)
-	if err != nil {
-		return nil, fmt.Errorf("check slug: %w", err)
-	}
-	if exists {
-		return nil, ErrSlugTaken
+	if input.Slug == "" {
+		// Auto-generate random slug
+		for i := 0; i < 5; i++ {
+			generated, err := generateRandomSlug()
+			if err != nil {
+				return nil, fmt.Errorf("generate slug: %w", err)
+			}
+			exists, err := s.salePageRepo.SlugExists(ctx, generated)
+			if err != nil {
+				return nil, fmt.Errorf("check slug: %w", err)
+			}
+			if !exists {
+				input.Slug = generated
+				break
+			}
+		}
+		if input.Slug == "" {
+			return nil, fmt.Errorf("failed to generate unique slug")
+		}
+	} else {
+		if err := validateSlug(input.Slug); err != nil {
+			return nil, err
+		}
+		exists, err := s.salePageRepo.SlugExists(ctx, input.Slug)
+		if err != nil {
+			return nil, fmt.Errorf("check slug: %w", err)
+		}
+		if exists {
+			return nil, ErrSlugTaken
+		}
 	}
 
 	var pixelID *string

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Page.Name}}</title>
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{.Page.Name}}">
+    {{with firstImageURL .BlocksContent.Blocks}}<meta property="og:image" content="{{.}}">{{end}}
+    <meta property="og:url" content="{{.BaseURL}}/p/{{.Page.Slug}}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;600;700&display=swap" rel="stylesheet">

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Content.Hero.Title}}</title>
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{.Content.Hero.Title}}">
+    {{if .Content.Hero.Subtitle}}<meta property="og:description" content="{{.Content.Hero.Subtitle}}">{{end}}
+    {{if .Content.Hero.ImageURL}}<meta property="og:image" content="{{.Content.Hero.ImageURL}}">{{end}}
+    <meta property="og:url" content="{{.BaseURL}}/p/{{.Page.Slug}}">
     <style>
         :root {
             --bg-color: {{if .Style.BgColor}}{{.Style.BgColor}}{{else}}#f8f9fa{{end}};

--- a/frontend/src/hooks/use-sale-pages.ts
+++ b/frontend/src/hooks/use-sale-pages.ts
@@ -17,7 +17,7 @@ export function useCreateSalePage() {
   return useMutation({
     mutationFn: async (input: {
       name: string
-      slug: string
+      slug?: string
       pixel_id?: string
       template_name: string
       content: SalePageContent | SalePageContentV2

--- a/frontend/src/pages/BlockEditorPage.tsx
+++ b/frontend/src/pages/BlockEditorPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router'
-import { ArrowLeft, Copy, Check, ExternalLink, Info, Eye, Pencil } from 'lucide-react'
+import { ArrowLeft, Copy, Check, ExternalLink, Info, Eye, Pencil, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -23,14 +23,6 @@ const CTA_EVENT_OPTIONS = [
   { value: 'SubmitApplication', label: 'SubmitApplication — ลูกค้าส่งใบสมัคร' },
 ] as const
 
-function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-}
 
 // Wrapper: handles data loading and v1→v2 redirect
 export function BlockEditorPage() {
@@ -74,7 +66,7 @@ function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
   // Page settings
   const [name, setName] = useState(existingPage?.name ?? '')
   const [slug, setSlug] = useState(existingPage?.slug ?? '')
-  const [slugTouched, setSlugTouched] = useState(isEditing)
+  const [showCustomSlug, setShowCustomSlug] = useState(isEditing)
   const [pixelId, setPixelId] = useState(existingPage?.pixel_id ?? '')
 
   // Page style
@@ -97,9 +89,6 @@ function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
 
   const handleNameChange = (value: string) => {
     setName(value)
-    if (!slugTouched) {
-      setSlug(generateSlug(value))
-    }
   }
 
   const buildContent = (): SalePageContentV2 => ({
@@ -118,8 +107,8 @@ function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
 
   const onSubmit = async (isPublished: boolean) => {
     setSubmitError(null)
-    if (!name.trim() || !slug.trim()) {
-      setSubmitError('กรุณากรอกชื่อหน้าเพจและ URL')
+    if (!name.trim()) {
+      setSubmitError('กรุณากรอกชื่อหน้าเพจ')
       return
     }
     if (blocks.length === 0) {
@@ -130,21 +119,24 @@ function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
       const content = buildContent()
       const payload = {
         name,
-        slug,
+        slug: slug || undefined,
         pixel_id: pixelId || undefined,
         template_name: 'blocks',
         content,
         is_published: isPublished,
       }
 
+      let resultSlug = slug
       if (isEditing && existingPage) {
-        await updateSalePage.mutateAsync({ id: existingPage.id, ...payload })
+        const result = await updateSalePage.mutateAsync({ id: existingPage.id, ...payload })
+        resultSlug = result.slug
       } else {
-        await createSalePage.mutateAsync(payload)
+        const result = await createSalePage.mutateAsync(payload)
+        resultSlug = result.slug
       }
 
       if (isPublished) {
-        setPublishedDialog({ slug })
+        setPublishedDialog({ slug: resultSlug })
       } else {
         navigate('/sale-pages')
       }
@@ -230,19 +222,31 @@ function BlockEditorInner({ existingPage }: { existingPage?: SalePage }) {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="page-slug">URL</Label>
-                <div className="flex">
-                  <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-neutral-200 bg-neutral-50 text-sm text-neutral-500">
-                    /p/
-                  </span>
-                  <Input
-                    id="page-slug"
-                    className="rounded-l-none"
-                    placeholder="my-page"
-                    value={slug}
-                    onChange={(e) => { setSlug(e.target.value); setSlugTouched(true) }}
-                  />
-                </div>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-700 transition-colors"
+                  onClick={() => setShowCustomSlug(!showCustomSlug)}
+                >
+                  <ChevronDown className={`h-3.5 w-3.5 transition-transform ${showCustomSlug ? 'rotate-0' : '-rotate-90'}`} />
+                  ตั้ง URL เอง (ไม่บังคับ)
+                </button>
+                {showCustomSlug && (
+                  <div className="flex">
+                    <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-neutral-200 bg-neutral-50 text-sm text-neutral-500">
+                      /p/
+                    </span>
+                    <Input
+                      id="page-slug"
+                      className="rounded-l-none"
+                      placeholder="my-page"
+                      value={slug}
+                      onChange={(e) => setSlug(e.target.value)}
+                    />
+                  </div>
+                )}
+                {!showCustomSlug && (
+                  <p className="text-xs text-neutral-400">ระบบจะสร้าง URL ให้อัตโนมัติ</p>
+                )}
               </div>
               <div className="space-y-2">
                 <Label htmlFor="pixel-select">Pixel (ไม่บังคับ)</Label>

--- a/frontend/src/pages/SalePageEditorPage.tsx
+++ b/frontend/src/pages/SalePageEditorPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { ArrowLeft, Plus, X, Copy, Check, ExternalLink, Info, Upload, Loader2 } from 'lucide-react'
+import { ArrowLeft, Plus, X, Copy, Check, ExternalLink, Info, Upload, Loader2, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -29,7 +29,10 @@ const CTA_EVENT_OPTIONS = [
 
 const salePageSchema = z.object({
   name: z.string().min(1, 'Page name is required'),
-  slug: z.string().min(1, 'URL slug is required').regex(/^[a-z0-9-]+$/, 'Only lowercase letters, numbers, and hyphens'),
+  slug: z.string().refine(
+    (val) => val === '' || /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(val),
+    'ใช้ได้เฉพาะตัวอักษรภาษาอังกฤษพิมพ์เล็ก ตัวเลข และเครื่องหมาย -'
+  ),
   pixel_id: z.string().optional(),
   hero_title: z.string(),
   hero_subtitle: z.string(),
@@ -49,15 +52,6 @@ const salePageSchema = z.object({
 
 type SalePageForm = z.infer<typeof salePageSchema>
 
-function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-}
-
 export function SalePageEditorPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -71,7 +65,7 @@ export function SalePageEditorPage() {
   const [features, setFeatures] = useState<string[]>([''])
   const [bodyImages, setBodyImages] = useState<string[]>([])
   const [pageStyle, setPageStyle] = useState<PageStyle>({})
-  const [slugTouched, setSlugTouched] = useState(false)
+  const [showCustomSlug, setShowCustomSlug] = useState(false)
   const [publishedDialog, setPublishedDialog] = useState<{ slug: string } | null>(null)
   const [copiedUrl, setCopiedUrl] = useState(false)
   const uploadImage = useUploadImage()
@@ -142,18 +136,9 @@ export function SalePageEditorPage() {
       setFeatures(featuresList)
       setBodyImages(c.body.images ?? [])
       setPageStyle(c.style ?? {})
-      setSlugTouched(true)
+      setShowCustomSlug(true)
     }
   }, [existingPage, reset, id, navigate])
-
-  // Auto-generate slug from name
-  const watchName = watch('name')
-  useEffect(() => {
-    if (!slugTouched && watchName) {
-      const slug = generateSlug(watchName)
-      setValue('slug', slug)
-    }
-  }, [watchName, slugTouched, setValue])
 
   // Sync features state to form
   useEffect(() => {
@@ -231,7 +216,7 @@ export function SalePageEditorPage() {
     const content = buildContent(data)
     const payload = {
       name: data.name,
-      slug: data.slug,
+      slug: data.slug || undefined,
       pixel_id: data.pixel_id ?? '',
       template_name: 'simple',
       content,
@@ -239,16 +224,16 @@ export function SalePageEditorPage() {
     }
 
     if (isEditing) {
-      await updateSalePage.mutateAsync({ id, ...payload })
+      const result = await updateSalePage.mutateAsync({ id, ...payload })
       if (isPublished) {
-        setPublishedDialog({ slug: data.slug })
+        setPublishedDialog({ slug: result.slug })
       } else {
         navigate('/sale-pages')
       }
     } else {
-      await createSalePage.mutateAsync(payload)
+      const result = await createSalePage.mutateAsync(payload)
       if (isPublished) {
-        setPublishedDialog({ slug: data.slug })
+        setPublishedDialog({ slug: result.slug })
       } else {
         navigate('/sale-pages')
       }
@@ -305,20 +290,30 @@ export function SalePageEditorPage() {
                 {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
               </div>
               <div className="space-y-2">
-                <Label htmlFor="slug">URL Slug</Label>
-                <div className="flex">
-                  <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-neutral-200 bg-neutral-50 text-sm text-neutral-500">
-                    /p/
-                  </span>
-                  <Input
-                    id="slug"
-                    className="rounded-l-none"
-                    placeholder="my-sale-page"
-                    {...register('slug', {
-                      onChange: () => setSlugTouched(true),
-                    })}
-                  />
-                </div>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-700 transition-colors"
+                  onClick={() => setShowCustomSlug(!showCustomSlug)}
+                >
+                  <ChevronDown className={`h-3.5 w-3.5 transition-transform ${showCustomSlug ? 'rotate-0' : '-rotate-90'}`} />
+                  ตั้ง URL เอง (ไม่บังคับ)
+                </button>
+                {showCustomSlug && (
+                  <div className="flex">
+                    <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-neutral-200 bg-neutral-50 text-sm text-neutral-500">
+                      /p/
+                    </span>
+                    <Input
+                      id="slug"
+                      className="rounded-l-none"
+                      placeholder="my-sale-page"
+                      {...register('slug')}
+                    />
+                  </div>
+                )}
+                {!showCustomSlug && (
+                  <p className="text-xs text-neutral-400">ระบบจะสร้าง URL ให้อัตโนมัติ</p>
+                )}
                 {errors.slug && <p className="text-sm text-red-500">{errors.slug.message}</p>}
               </div>
               <div className="space-y-2">

--- a/frontend/src/pages/SalePagesPage.tsx
+++ b/frontend/src/pages/SalePagesPage.tsx
@@ -67,7 +67,14 @@ export function SalePagesPage() {
                 <tr key={page.id} className="border-b border-neutral-200 last:border-0">
                   <td className="px-4 py-3 text-sm font-medium text-neutral-900">{page.name}</td>
                   <td className="px-4 py-3 text-sm text-neutral-600">
-                    <span className="font-mono truncate max-w-[200px] inline-block">/p/{page.slug}</span>
+                    <a
+                      href={`/p/${page.slug}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-mono truncate max-w-[200px] inline-block text-indigo-600 hover:text-indigo-800 hover:underline"
+                    >
+                      /p/{page.slug}
+                    </a>
                   </td>
                   <td className="px-4 py-3 text-sm text-neutral-600">{getPixelName(page.pixel_id)}</td>
                   <td className="px-4 py-3">


### PR DESCRIPTION
## Summary
- เพิ่ม Open Graph meta tags (`og:type`, `og:title`, `og:description`, `og:image`, `og:url`) ให้ทั้ง simple.html และ blocks.html templates เพื่อให้ Facebook crawler อ่าน content ได้และแสดง link preview ถูกต้อง
- เพิ่มระบบ auto-generate random slug (format: `p-{8chars}`, e.g. `p-a7x2k9m1`) เมื่อ user ไม่ระบุ slug เอง — ลด friction ในการสร้าง sale page
- Frontend: slug field เปลี่ยนเป็น collapsible "ตั้ง URL เอง (ไม่บังคับ)" ทั้ง Classic และ Block editor
- URL column ในหน้า Sale Pages เป็น clickable link

## Test plan
- [ ] สร้าง sale page **ไม่ใส่ slug** → response ได้ slug auto-generated เช่น `p-a7x2k9m1`
- [ ] สร้าง sale page **ใส่ slug เอง** (กด expand advanced) → ยังทำงานเหมือนเดิม
- [ ] เปิด `/p/{slug}` → View Page Source → เห็น OG meta tags ครบ
- [ ] ใช้ [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) ทดสอบ → เห็น title, description, image preview
- [ ] ทดสอบ slug validation: ใส่ตัวอักษรไม่ถูก format → แสดง error message ภาษาไทย
- [ ] Edit page ที่มีอยู่แล้ว → slug ยังแสดงถูกต้อง (collapsible เปิดอยู่)

🤖 Generated with [Claude Code](https://claude.com/claude-code)