### PR TITLE
feat: add clickable image blocks and simplify CTA event options

### DIFF
--- a/backend/internal/domain/sale_page.go
+++ b/backend/internal/domain/sale_page.go
@@ -78,6 +78,7 @@ type Block struct {
 	ID          string    `json:"id"`
 	Type        BlockType `json:"type"`
 	ImageURL    string    `json:"image_url,omitempty"`
+	LinkURL     string    `json:"link_url,omitempty"`
 	Text        string    `json:"text,omitempty"`
 	ButtonStyle string    `json:"button_style,omitempty"`
 	ButtonText  string    `json:"button_text,omitempty"`

--- a/backend/internal/service/sale_page_service.go
+++ b/backend/internal/service/sale_page_service.go
@@ -362,6 +362,9 @@ func validateContent(raw json.RawMessage) error {
 				if err := validateSafeURL(b.ImageURL); err != nil {
 					return err
 				}
+				if err := validateSafeURL(b.LinkURL); err != nil {
+					return err
+				}
 			case domain.BlockTypeText:
 				// text can be empty (draft)
 			case domain.BlockTypeButton:

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -111,7 +111,13 @@
     <div class="page-wrapper">
         {{range .BlocksContent.Blocks}}
             {{if eq .Type "image"}}
-            <img src="{{.ImageURL}}" alt="" class="block-image">
+                {{if .LinkURL}}
+                <a href="{{.LinkURL}}" target="_blank" rel="noopener" data-track-cta>
+                    <img src="{{.ImageURL}}" alt="" class="block-image">
+                </a>
+                {{else}}
+                <img src="{{.ImageURL}}" alt="" class="block-image">
+                {{end}}
             {{end}}
 
             {{if eq .Type "text"}}

--- a/frontend/src/components/sale-pages/BlockEditor.tsx
+++ b/frontend/src/components/sale-pages/BlockEditor.tsx
@@ -133,6 +133,12 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
                 onChange={(e) => updateBlock(index, { image_url: e.target.value })}
                 className="text-xs"
               />
+              <Input
+                placeholder="ลิงก์เมื่อกดรูป (ไม่บังคับ) เช่น https://line.me/ti/p/~@shop"
+                value={block.link_url || ''}
+                onChange={(e) => updateBlock(index, { link_url: e.target.value })}
+                className="text-xs"
+              />
             </div>
           )}
 

--- a/frontend/src/components/sale-pages/BlockPreview.tsx
+++ b/frontend/src/components/sale-pages/BlockPreview.tsx
@@ -30,19 +30,22 @@ export function BlockPreview({ blocks, ctaEventName, style }: BlockPreviewProps)
         )}
         {blocks.map((block) => {
           if (block.type === 'image') {
-            return block.image_url ? (
+            const img = block.image_url ? (
               <img
-                key={block.id}
                 src={block.image_url}
                 alt=""
                 className="w-full block object-cover"
                 style={{ aspectRatio: '1/1' }}
               />
             ) : (
-              <div key={block.id} className="w-full bg-neutral-100 flex items-center justify-center text-neutral-400 text-xs" style={{ aspectRatio: '1/1' }}>
+              <div className="w-full bg-neutral-100 flex items-center justify-center text-neutral-400 text-xs" style={{ aspectRatio: '1/1' }}>
                 รูปภาพ
               </div>
             )
+            if (block.link_url) {
+              return <a key={block.id} href={block.link_url} target="_blank" rel="noopener noreferrer">{img}</a>
+            }
+            return <div key={block.id}>{img}</div>
           }
 
           if (block.type === 'text') {

--- a/frontend/src/pages/BlockEditorPage.tsx
+++ b/frontend/src/pages/BlockEditorPage.tsx
@@ -14,13 +14,10 @@ import { usePixels } from '@/hooks/use-pixels'
 import type { Block, SalePage, SalePageContentV2, PageStyle } from '@/types'
 
 const CTA_EVENT_OPTIONS = [
-  { value: 'Lead', label: 'Lead — ลูกค้าสนใจ ต้องการข้อมูลเพิ่ม' },
-  { value: 'Purchase', label: 'Purchase — ลูกค้าซื้อสินค้า/บริการ' },
-  { value: 'InitiateCheckout', label: 'InitiateCheckout — ลูกค้าเริ่มชำระเงิน' },
-  { value: 'AddToCart', label: 'AddToCart — ลูกค้าเพิ่มสินค้าลงตะกร้า' },
-  { value: 'CompleteRegistration', label: 'CompleteRegistration — ลูกค้าสมัครสมาชิกสำเร็จ' },
-  { value: 'Schedule', label: 'Schedule — ลูกค้าจองนัดหมาย' },
-  { value: 'SubmitApplication', label: 'SubmitApplication — ลูกค้าส่งใบสมัคร' },
+  { value: 'Lead', label: 'ลูกค้าสนใจ — แอด LINE / ทักแชท (Lead)' },
+  { value: 'Purchase', label: 'ลูกค้าสั่งซื้อ — โอนเงิน / จ่ายเงิน (Purchase)' },
+  { value: 'Contact', label: 'ลูกค้าติดต่อ — กดโทร / กดแชท (Contact)' },
+  { value: 'CompleteRegistration', label: 'ลูกค้าสมัคร — ลงทะเบียน / สมัครสมาชิก (CompleteRegistration)' },
 ] as const
 
 

--- a/frontend/src/pages/SalePageEditorPage.tsx
+++ b/frontend/src/pages/SalePageEditorPage.tsx
@@ -18,13 +18,10 @@ import { useUploadImage, useUploadImages } from '@/hooks/use-upload'
 import type { SalePageContent, SalePageContentV2, PageStyle } from '@/types'
 
 const CTA_EVENT_OPTIONS = [
-  { value: 'Lead', label: 'Lead — ลูกค้าสนใจ ต้องการข้อมูลเพิ่ม' },
-  { value: 'Purchase', label: 'Purchase — ลูกค้าซื้อสินค้า/บริการ' },
-  { value: 'InitiateCheckout', label: 'InitiateCheckout — ลูกค้าเริ่มชำระเงิน' },
-  { value: 'AddToCart', label: 'AddToCart — ลูกค้าเพิ่มสินค้าลงตะกร้า' },
-  { value: 'CompleteRegistration', label: 'CompleteRegistration — ลูกค้าสมัครสมาชิกสำเร็จ' },
-  { value: 'Schedule', label: 'Schedule — ลูกค้าจองนัดหมาย' },
-  { value: 'SubmitApplication', label: 'SubmitApplication — ลูกค้าส่งใบสมัคร' },
+  { value: 'Lead', label: 'ลูกค้าสนใจ — แอด LINE / ทักแชท (Lead)' },
+  { value: 'Purchase', label: 'ลูกค้าสั่งซื้อ — โอนเงิน / จ่ายเงิน (Purchase)' },
+  { value: 'Contact', label: 'ลูกค้าติดต่อ — กดโทร / กดแชท (Contact)' },
+  { value: 'CompleteRegistration', label: 'ลูกค้าสมัคร — ลงทะเบียน / สมัครสมาชิก (CompleteRegistration)' },
 ] as const
 
 const salePageSchema = z.object({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -98,6 +98,7 @@ export interface Block {
   id: string
   type: BlockType
   image_url?: string
+  link_url?: string
   text?: string
   button_style?: ButtonStyle
   button_text?: string


### PR DESCRIPTION
## Summary
- Image blocks now support an optional `link_url` field — when set, the image is wrapped in a clickable `<a>` tag with `data-track-cta` for CTA event tracking
- Backend validates `link_url` with `validateSafeURL()` to prevent `javascript:` injection
- CTA event options reduced from 7 to 4 Thai-labeled choices matching real user workflows: Lead, Purchase, Contact, CompleteRegistration

## Test plan
- [ ] Create a Block page → add image block → set link URL → preview shows clickable image
- [ ] Create image block without link → works as before (plain image)
- [ ] Open published page → click linked image → opens URL in new tab + fires CTA event
- [ ] Test validation: submit `javascript:alert(1)` as link_url → backend rejects
- [ ] Verify CTA dropdown shows 4 Thai-labeled options in both SalePageEditor and BlockEditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)