### PR TITLE
feat: add Meta CAPI compliance and clickable image blocks

### DIFF
--- a/backend/db/migrations/000004_capi_compliance.down.sql
+++ b/backend/db/migrations/000004_capi_compliance.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_pixel_events_event_id;
+ALTER TABLE pixel_events
+  DROP COLUMN IF EXISTS event_id,
+  DROP COLUMN IF EXISTS client_ip,
+  DROP COLUMN IF EXISTS client_user_agent;

--- a/backend/db/migrations/000004_capi_compliance.up.sql
+++ b/backend/db/migrations/000004_capi_compliance.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE pixel_events
+  ADD COLUMN event_id VARCHAR(36),
+  ADD COLUMN client_ip TEXT,
+  ADD COLUMN client_user_agent TEXT;
+
+CREATE INDEX idx_pixel_events_event_id ON pixel_events(event_id);

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -12,6 +12,9 @@ type PixelEvent struct {
 	EventData        json.RawMessage `json:"event_data"`
 	UserData         json.RawMessage `json:"user_data,omitempty"`
 	SourceURL        string          `json:"source_url,omitempty"`
+	EventID          string          `json:"event_id,omitempty"`
+	ClientIP         string          `json:"client_ip,omitempty"`
+	ClientUserAgent  string          `json:"client_user_agent,omitempty"`
 	EventTime        time.Time       `json:"event_time"`
 	ForwardedToCAPI  bool            `json:"forwarded_to_capi"`
 	CAPIResponseCode *int            `json:"capi_response_code,omitempty"`

--- a/backend/internal/facebook/capi.go
+++ b/backend/internal/facebook/capi.go
@@ -25,16 +25,19 @@ func NewCAPIClient(baseURL string) *CAPIClient {
 }
 
 type CAPIEvent struct {
-	EventName      string                 `json:"event_name"`
-	EventTime      int64                  `json:"event_time"`
-	UserData       map[string]interface{} `json:"user_data,omitempty"`
-	CustomData     map[string]interface{} `json:"custom_data,omitempty"`
-	EventSourceURL string                 `json:"event_source_url,omitempty"`
-	ActionSource   string                 `json:"action_source"`
+	EventName             string                 `json:"event_name"`
+	EventTime             int64                  `json:"event_time"`
+	UserData              map[string]interface{} `json:"user_data,omitempty"`
+	CustomData            map[string]interface{} `json:"custom_data,omitempty"`
+	EventSourceURL        string                 `json:"event_source_url,omitempty"`
+	ActionSource          string                 `json:"action_source"`
+	EventID               string                 `json:"event_id,omitempty"`
+	DataProcessingOptions []string               `json:"data_processing_options"`
 }
 
 type CAPIRequest struct {
-	Data []CAPIEvent `json:"data"`
+	Data        []CAPIEvent `json:"data"`
+	AccessToken string      `json:"access_token,omitempty"`
 }
 
 type CAPIResponse struct {
@@ -53,9 +56,12 @@ func (e *CAPIError) Error() string {
 }
 
 func (c *CAPIClient) SendEvents(ctx context.Context, pixelID, accessToken string, events []CAPIEvent) (*CAPIResponse, error) {
-	url := fmt.Sprintf("%s/%s/events?access_token=%s", c.baseURL, pixelID, accessToken)
+	url := fmt.Sprintf("%s/%s/events", c.baseURL, pixelID)
 
-	reqBody := CAPIRequest{Data: events}
+	reqBody := CAPIRequest{
+		Data:        events,
+		AccessToken: accessToken,
+	}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -95,4 +101,24 @@ func (c *CAPIClient) SendEvents(ctx context.Context, pixelID, accessToken string
 
 func (c *CAPIClient) SendEvent(ctx context.Context, pixelID, accessToken string, event CAPIEvent) (*CAPIResponse, error) {
 	return c.SendEvents(ctx, pixelID, accessToken, []CAPIEvent{event})
+}
+
+func (c *CAPIClient) SendEventsBatch(ctx context.Context, pixelID, accessToken string, events []CAPIEvent) ([]*CAPIResponse, error) {
+	const maxBatchSize = 1000
+	var responses []*CAPIResponse
+
+	for i := 0; i < len(events); i += maxBatchSize {
+		end := i + maxBatchSize
+		if end > len(events) {
+			end = len(events)
+		}
+		batch := events[i:end]
+
+		resp, err := c.SendEvents(ctx, pixelID, accessToken, batch)
+		if err != nil {
+			return responses, fmt.Errorf("batch %d-%d: %w", i, end, err)
+		}
+		responses = append(responses, resp)
+	}
+	return responses, nil
 }

--- a/backend/internal/facebook/hash.go
+++ b/backend/internal/facebook/hash.go
@@ -1,0 +1,38 @@
+package facebook
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// piiFields are fields that must be SHA-256 hashed per Meta CAPI requirements.
+var piiFields = map[string]bool{
+	"em": true, "ph": true, "fn": true, "ln": true,
+	"ge": true, "db": true, "ct": true, "st": true,
+	"zp": true, "country": true, "external_id": true,
+}
+
+// HashUserData hashes PII fields in user_data per Meta CAPI requirements.
+// Non-PII fields (client_ip_address, client_user_agent, fbc, fbp) are passed through unchanged.
+func HashUserData(userData map[string]interface{}) map[string]interface{} {
+	if userData == nil {
+		return userData
+	}
+
+	result := make(map[string]interface{}, len(userData))
+	for k, v := range userData {
+		if piiFields[k] {
+			if s, ok := v.(string); ok && s != "" {
+				normalized := strings.ToLower(strings.TrimSpace(s))
+				hash := sha256.Sum256([]byte(normalized))
+				result[k] = fmt.Sprintf("%x", hash)
+			} else {
+				result[k] = v
+			}
+		} else {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/backend/internal/facebook/hash_test.go
+++ b/backend/internal/facebook/hash_test.go
@@ -1,0 +1,98 @@
+package facebook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashUserData(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		checkKey string
+		wantHash bool
+		wantVal  string
+	}{
+		{
+			name:     "hashes email",
+			input:    map[string]interface{}{"em": "Test@Example.com"},
+			checkKey: "em",
+			wantHash: true,
+		},
+		{
+			name:     "hashes phone",
+			input:    map[string]interface{}{"ph": " 1234567890 "},
+			checkKey: "ph",
+			wantHash: true,
+		},
+		{
+			name:     "passes through client_ip_address",
+			input:    map[string]interface{}{"client_ip_address": "1.2.3.4"},
+			checkKey: "client_ip_address",
+			wantHash: false,
+			wantVal:  "1.2.3.4",
+		},
+		{
+			name:     "passes through client_user_agent",
+			input:    map[string]interface{}{"client_user_agent": "Mozilla/5.0"},
+			checkKey: "client_user_agent",
+			wantHash: false,
+			wantVal:  "Mozilla/5.0",
+		},
+		{
+			name:     "passes through fbc",
+			input:    map[string]interface{}{"fbc": "fb.1.123.abc"},
+			checkKey: "fbc",
+			wantHash: false,
+			wantVal:  "fb.1.123.abc",
+		},
+		{
+			name:     "passes through fbp",
+			input:    map[string]interface{}{"fbp": "fb.1.456.def"},
+			checkKey: "fbp",
+			wantHash: false,
+			wantVal:  "fb.1.456.def",
+		},
+		{
+			name:     "nil input returns nil",
+			input:    nil,
+			checkKey: "",
+			wantHash: false,
+		},
+		{
+			name:     "empty string PII not hashed",
+			input:    map[string]interface{}{"em": ""},
+			checkKey: "em",
+			wantHash: false,
+			wantVal:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HashUserData(tt.input)
+			if tt.input == nil {
+				assert.Nil(t, result)
+				return
+			}
+			val := result[tt.checkKey]
+			if tt.wantHash {
+				s, ok := val.(string)
+				assert.True(t, ok)
+				assert.Len(t, s, 64) // SHA-256 hex = 64 chars
+				assert.NotEqual(t, tt.input[tt.checkKey], s)
+			} else if tt.wantVal != "" {
+				assert.Equal(t, tt.wantVal, val)
+			}
+		})
+	}
+}
+
+func TestHashUserData_Normalization(t *testing.T) {
+	r1 := HashUserData(map[string]interface{}{"em": "Test@Example.com"})
+	r2 := HashUserData(map[string]interface{}{"em": "test@example.com"})
+	r3 := HashUserData(map[string]interface{}{"em": " Test@Example.com "})
+	assert.Equal(t, r1["em"], r2["em"])
+	assert.Equal(t, r1["em"], r3["em"])
+}

--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -38,7 +38,10 @@ func (h *EventHandler) Ingest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	created, err := h.eventService.Ingest(r.Context(), customerID, input)
+	clientIP := r.RemoteAddr
+	clientUA := r.Header.Get("User-Agent")
+
+	created, err := h.eventService.Ingest(r.Context(), customerID, input, clientIP, clientUA)
 	if err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "ingestion failed")
 		return

--- a/backend/internal/repository/postgres/event_repo.go
+++ b/backend/internal/repository/postgres/event_repo.go
@@ -19,23 +19,36 @@ func NewEventRepo(pool *pgxpool.Pool) *EventRepo {
 
 func (r *EventRepo) Create(ctx context.Context, e *domain.PixelEvent) error {
 	return r.pool.QueryRow(ctx,
-		`INSERT INTO pixel_events (pixel_id, event_name, event_data, user_data, source_url, event_time)
-		 VALUES ($1, $2, $3, $4, $5, $6)
+		`INSERT INTO pixel_events (pixel_id, event_name, event_data, user_data, source_url, event_time, event_id, client_ip, client_user_agent)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING id, forwarded_to_capi, created_at`,
-		e.PixelID, e.EventName, e.EventData, e.UserData, e.SourceURL, e.EventTime,
+		e.PixelID, e.EventName, e.EventData, e.UserData, e.SourceURL, e.EventTime, e.EventID, e.ClientIP, e.ClientUserAgent,
 	).Scan(&e.ID, &e.ForwardedToCAPI, &e.CreatedAt)
 }
 
 func (r *EventRepo) GetByID(ctx context.Context, id string) (*domain.PixelEvent, error) {
 	e := &domain.PixelEvent{}
+	var eventID, clientIP, clientUA *string
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at
+		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at, event_id, client_ip, client_user_agent
 		 FROM pixel_events WHERE id = $1`, id,
-	).Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt)
+	).Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt, &eventID, &clientIP, &clientUA)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
-	return e, err
+	if err != nil {
+		return nil, err
+	}
+	if eventID != nil {
+		e.EventID = *eventID
+	}
+	if clientIP != nil {
+		e.ClientIP = *clientIP
+	}
+	if clientUA != nil {
+		e.ClientUserAgent = *clientUA
+	}
+	return e, nil
 }
 
 func (r *EventRepo) ListByPixelID(ctx context.Context, pixelID string, limit, offset int) ([]*domain.PixelEvent, int, error) {
@@ -48,7 +61,7 @@ func (r *EventRepo) ListByPixelID(ctx context.Context, pixelID string, limit, of
 	}
 
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at
+		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at, event_id, client_ip, client_user_agent
 		 FROM pixel_events WHERE pixel_id = $1
 		 ORDER BY event_time DESC LIMIT $2 OFFSET $3`, pixelID, limit, offset,
 	)
@@ -60,8 +73,18 @@ func (r *EventRepo) ListByPixelID(ctx context.Context, pixelID string, limit, of
 	var events []*domain.PixelEvent
 	for rows.Next() {
 		e := &domain.PixelEvent{}
-		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt); err != nil {
+		var eventID, clientIP, clientUA *string
+		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt, &eventID, &clientIP, &clientUA); err != nil {
 			return nil, 0, err
+		}
+		if eventID != nil {
+			e.EventID = *eventID
+		}
+		if clientIP != nil {
+			e.ClientIP = *clientIP
+		}
+		if clientUA != nil {
+			e.ClientUserAgent = *clientUA
 		}
 		events = append(events, e)
 	}
@@ -78,7 +101,7 @@ func (r *EventRepo) ListByCustomerID(ctx context.Context, customerID string, lim
 	}
 
 	rows, err := r.pool.Query(ctx,
-		`SELECT pe.id, pe.pixel_id, pe.event_name, pe.event_data, pe.user_data, pe.source_url, pe.event_time, pe.forwarded_to_capi, pe.capi_response_code, pe.created_at
+		`SELECT pe.id, pe.pixel_id, pe.event_name, pe.event_data, pe.user_data, pe.source_url, pe.event_time, pe.forwarded_to_capi, pe.capi_response_code, pe.created_at, pe.event_id, pe.client_ip, pe.client_user_agent
 		 FROM pixel_events pe JOIN pixels p ON p.id = pe.pixel_id
 		 WHERE p.customer_id = $1
 		 ORDER BY pe.event_time DESC LIMIT $2 OFFSET $3`, customerID, limit, offset,
@@ -91,8 +114,18 @@ func (r *EventRepo) ListByCustomerID(ctx context.Context, customerID string, lim
 	var events []*domain.PixelEvent
 	for rows.Next() {
 		e := &domain.PixelEvent{}
-		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt); err != nil {
+		var eventID, clientIP, clientUA *string
+		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt, &eventID, &clientIP, &clientUA); err != nil {
 			return nil, 0, err
+		}
+		if eventID != nil {
+			e.EventID = *eventID
+		}
+		if clientIP != nil {
+			e.ClientIP = *clientIP
+		}
+		if clientUA != nil {
+			e.ClientUserAgent = *clientUA
 		}
 		events = append(events, e)
 	}
@@ -109,7 +142,7 @@ func (r *EventRepo) MarkForwarded(ctx context.Context, id string, responseCode i
 
 func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) ([]*domain.PixelEvent, error) {
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at
+		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, created_at, event_id, client_ip, client_user_agent
 		 FROM pixel_events
 		 WHERE pixel_id = $1
 		   AND ($2::text[] IS NULL OR event_name = ANY($2::text[]))
@@ -126,8 +159,18 @@ func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, even
 	var events []*domain.PixelEvent
 	for rows.Next() {
 		e := &domain.PixelEvent{}
-		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt); err != nil {
+		var eventID, clientIP, clientUA *string
+		if err := rows.Scan(&e.ID, &e.PixelID, &e.EventName, &e.EventData, &e.UserData, &e.SourceURL, &e.EventTime, &e.ForwardedToCAPI, &e.CAPIResponseCode, &e.CreatedAt, &eventID, &clientIP, &clientUA); err != nil {
 			return nil, err
+		}
+		if eventID != nil {
+			e.EventID = *eventID
+		}
+		if clientIP != nil {
+			e.ClientIP = *clientIP
+		}
+		if clientUA != nil {
+			e.ClientUserAgent = *clientUA
 		}
 		events = append(events, e)
 	}

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/facebook"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
@@ -40,13 +42,14 @@ type IngestEventInput struct {
 	UserData  json.RawMessage `json:"user_data,omitempty"`
 	SourceURL string          `json:"source_url,omitempty"`
 	EventTime string          `json:"event_time,omitempty"`
+	EventID   string          `json:"event_id,omitempty"`
 }
 
 type IngestBatchInput struct {
 	Events []IngestEventInput `json:"events" validate:"required,min=1,max=100"`
 }
 
-func (s *EventService) Ingest(ctx context.Context, customerID string, input IngestBatchInput) (int, error) {
+func (s *EventService) Ingest(ctx context.Context, customerID string, input IngestBatchInput, clientIP, clientUA string) (int, error) {
 	created := 0
 	for _, eventInput := range input.Events {
 		// Verify pixel belongs to customer
@@ -72,13 +75,28 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 			eventData = json.RawMessage(`{}`)
 		}
 
+		// Strip port from clientIP
+		ip := clientIP
+		if host, _, err := net.SplitHostPort(clientIP); err == nil {
+			ip = host
+		}
+
+		// Generate event_id if not provided
+		eventID := eventInput.EventID
+		if eventID == "" {
+			eventID = uuid.New().String()
+		}
+
 		event := &domain.PixelEvent{
-			PixelID:   eventInput.PixelID,
-			EventName: eventInput.EventName,
-			EventData: eventData,
-			UserData:  eventInput.UserData,
-			SourceURL: eventInput.SourceURL,
-			EventTime: eventTime,
+			PixelID:         eventInput.PixelID,
+			EventName:       eventInput.EventName,
+			EventData:       eventData,
+			UserData:        eventInput.UserData,
+			SourceURL:       eventInput.SourceURL,
+			EventTime:       eventTime,
+			EventID:         eventID,
+			ClientIP:        ip,
+			ClientUserAgent: clientUA,
 		}
 
 		if err := s.eventRepo.Create(ctx, event); err != nil {
@@ -104,14 +122,30 @@ func (s *EventService) forwardToCAPI(ctx context.Context, event *domain.PixelEve
 	if event.UserData != nil {
 		_ = json.Unmarshal(event.UserData, &userData)
 	}
+	if userData == nil {
+		userData = make(map[string]interface{})
+	}
+
+	// Add client context for EMQ score
+	if event.ClientIP != "" {
+		userData["client_ip_address"] = event.ClientIP
+	}
+	if event.ClientUserAgent != "" {
+		userData["client_user_agent"] = event.ClientUserAgent
+	}
+
+	// Hash PII fields
+	userData = facebook.HashUserData(userData)
 
 	capiEvent := facebook.CAPIEvent{
-		EventName:      event.EventName,
-		EventTime:      event.EventTime.Unix(),
-		UserData:       userData,
-		CustomData:     customData,
-		EventSourceURL: event.SourceURL,
-		ActionSource:   "website",
+		EventName:             event.EventName,
+		EventTime:             event.EventTime.Unix(),
+		UserData:              userData,
+		CustomData:            customData,
+		EventSourceURL:        event.SourceURL,
+		ActionSource:          "website",
+		EventID:               event.EventID,
+		DataProcessingOptions: []string{},
 	}
 
 	resp, err := s.capiClient.SendEvent(ctx, pixel.FBPixelID, pixel.FBAccessToken, capiEvent)

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -108,6 +108,55 @@ func TestEventService_Ingest(t *testing.T) {
 			},
 			wantCreated: 0,
 		},
+		{
+			name:       "event_id from input preserved",
+			customerID: "cust-1",
+			input: IngestBatchInput{
+				Events: []IngestEventInput{
+					{
+						PixelID:   "pixel-1",
+						EventName: "Purchase",
+						EventData: json.RawMessage(`{}`),
+						EventID:   "custom-event-id-123",
+					},
+				},
+			},
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID:         "pixel-1",
+					CustomerID: "cust-1",
+					IsActive:   true,
+				}, nil)
+				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
+					return e.EventID == "custom-event-id-123"
+				})).Return(nil)
+			},
+			wantCreated: 1,
+		},
+		{
+			name:       "event_id generated when empty",
+			customerID: "cust-1",
+			input: IngestBatchInput{
+				Events: []IngestEventInput{
+					{
+						PixelID:   "pixel-1",
+						EventName: "PageView",
+						EventData: json.RawMessage(`{}`),
+					},
+				},
+			},
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID:         "pixel-1",
+					CustomerID: "cust-1",
+					IsActive:   true,
+				}, nil)
+				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
+					return e.EventID != "" && len(e.EventID) == 36
+				})).Return(nil)
+			},
+			wantCreated: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -115,7 +164,7 @@ func TestEventService_Ingest(t *testing.T) {
 			svc, eventRepo, pixelRepo := newTestEventService()
 			tt.setup(eventRepo, pixelRepo)
 
-			created, err := svc.Ingest(context.Background(), tt.customerID, tt.input)
+			created, err := svc.Ingest(context.Background(), tt.customerID, tt.input, "192.168.1.1:12345", "TestAgent/1.0")
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCreated, created)

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -6,10 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/facebook"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
@@ -108,26 +107,24 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 	_ = s.replayRepo.UpdateStatus(ctx, session.ID, "running")
 
 	var replayed, failed int64
-	var mu sync.Mutex
-	sem := make(chan struct{}, 5) // limit concurrency to 5
+	const batchSize = 1000
 
-	var wg sync.WaitGroup
-	for i, event := range events {
-		wg.Add(1)
-		sem <- struct{}{}
+	for i := 0; i < len(events); i += batchSize {
+		end := i + batchSize
+		if end > len(events) {
+			end = len(events)
+		}
+		batch := events[i:end]
 
-		go func(idx int, evt *domain.PixelEvent) {
-			defer wg.Done()
-			defer func() { <-sem }()
-
-			// Rate limit: ~50 events per second
-			time.Sleep(20 * time.Millisecond)
-
+		capiEvents := make([]facebook.CAPIEvent, 0, len(batch))
+		for _, evt := range batch {
 			capiEvt := facebook.CAPIEvent{
-				EventName:      evt.EventName,
-				EventTime:      evt.EventTime.Unix(),
-				EventSourceURL: evt.SourceURL,
-				ActionSource:   "website",
+				EventName:             evt.EventName,
+				EventTime:             evt.EventTime.Unix(),
+				EventSourceURL:        evt.SourceURL,
+				ActionSource:          "website",
+				EventID:               uuid.New().String(),
+				DataProcessingOptions: []string{},
 			}
 
 			if evt.EventData != nil {
@@ -135,32 +132,32 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 				_ = json.Unmarshal(evt.EventData, &cd)
 				capiEvt.CustomData = cd
 			}
+
+			userData := make(map[string]interface{})
 			if evt.UserData != nil {
-				var ud map[string]interface{}
-				_ = json.Unmarshal(evt.UserData, &ud)
-				capiEvt.UserData = ud
+				_ = json.Unmarshal(evt.UserData, &userData)
 			}
+			if evt.ClientIP != "" {
+				userData["client_ip_address"] = evt.ClientIP
+			}
+			if evt.ClientUserAgent != "" {
+				userData["client_user_agent"] = evt.ClientUserAgent
+			}
+			capiEvt.UserData = facebook.HashUserData(userData)
 
-			_, err := s.capiClient.SendEvent(ctx, targetPixel.FBPixelID, targetPixel.FBAccessToken, capiEvt)
-			if err != nil {
-				atomic.AddInt64(&failed, 1)
-				s.logger.Error("replay event failed", "error", err, "event_id", evt.ID)
-			} else {
-				atomic.AddInt64(&replayed, 1)
-			}
+			capiEvents = append(capiEvents, capiEvt)
+		}
 
-			// Update progress every 10 events
-			if (idx+1)%10 == 0 || idx == len(events)-1 {
-				mu.Lock()
-				_ = s.replayRepo.UpdateProgress(ctx, session.ID, int(atomic.LoadInt64(&replayed)), int(atomic.LoadInt64(&failed)))
-				mu.Unlock()
-			}
-		}(i, event)
+		_, err := s.capiClient.SendEvents(ctx, targetPixel.FBPixelID, targetPixel.FBAccessToken, capiEvents)
+		if err != nil {
+			failed += int64(len(batch))
+			s.logger.Error("replay batch failed", "error", err, "batch_start", i, "batch_end", end)
+		} else {
+			replayed += int64(len(batch))
+		}
+
+		_ = s.replayRepo.UpdateProgress(ctx, session.ID, int(replayed), int(failed))
 	}
-
-	wg.Wait()
-
-	_ = s.replayRepo.UpdateProgress(ctx, session.ID, int(replayed), int(failed))
 
 	if failed > 0 && replayed == 0 {
 		_ = s.replayRepo.UpdateStatus(ctx, session.ID, "failed")

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -187,12 +187,21 @@
         var contentValue = {{.BlocksContent.Tracking.ContentValue}};
         var currency = '{{.BlocksContent.Tracking.Currency}}' || 'THB';
 
+        function genId() {
+            if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+                var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+                return v.toString(16);
+            });
+        }
+
         function dualTrack(eventName, params) {
+            var eid = genId();
             if (typeof fbq === 'function') {
-                fbq('track', eventName, params);
+                fbq('track', eventName, params, {eventID: eid});
             }
             if (window.pixlinks) {
-                window.pixlinks.track(eventName, params);
+                window.pixlinks.track(eventName, params, undefined, eid);
             }
         }
 

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -288,12 +288,21 @@
         var contentValue = {{.Content.Tracking.ContentValue}};
         var currency = '{{.Content.Tracking.Currency}}' || 'THB';
 
+        function genId() {
+            if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+                var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+                return v.toString(16);
+            });
+        }
+
         function dualTrack(eventName, params) {
+            var eid = genId();
             if (typeof fbq === 'function') {
-                fbq('track', eventName, params);
+                fbq('track', eventName, params, {eventID: eid});
             }
             if (window.pixlinks) {
-                window.pixlinks.track(eventName, params);
+                window.pixlinks.track(eventName, params, undefined, eid);
             }
         }
 

--- a/sdk/src/__tests__/tracker.test.ts
+++ b/sdk/src/__tests__/tracker.test.ts
@@ -83,4 +83,32 @@ describe('PixlinksTracker', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2)
     tracker.destroy()
   })
+
+  it('includes event_id in payload', () => {
+    const tracker = new PixlinksTracker({ apiKey: 'key123', pixelId: 'px123' })
+    tracker.track('Purchase', { value: 100 })
+    tracker.flush()
+
+    const [, options] = mockFetch.mock.calls[0]
+    const body = JSON.parse(options.body)
+    expect(body.events[0].event_id).toBeDefined()
+    expect(body.events[0].event_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+
+    tracker.destroy()
+  })
+
+  it('preserves explicit eventId', () => {
+    const tracker = new PixlinksTracker({ apiKey: 'key123', pixelId: 'px123' })
+    const customId = '11111111-2222-3333-4444-555555555555'
+    tracker.track('Purchase', { value: 100 }, undefined, customId)
+    tracker.flush()
+
+    const [, options] = mockFetch.mock.calls[0]
+    const body = JSON.parse(options.body)
+    expect(body.events[0].event_id).toBe(customId)
+
+    tracker.destroy()
+  })
 })

--- a/sdk/src/tracker.ts
+++ b/sdk/src/tracker.ts
@@ -12,11 +12,24 @@ interface EventPayload {
   user_data?: Record<string, unknown>
   source_url?: string
   event_time?: string
+  event_id?: string
 }
 
 interface QueuedEvent {
   payload: EventPayload
   retries: number
+}
+
+function generateEventId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  // Fallback for older browsers
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
 }
 
 const DEFAULT_ENDPOINT = 'https://api.pixlinks.io'
@@ -51,7 +64,7 @@ export class PixlinksTracker {
     this.log('Initialized')
   }
 
-  track(eventName: string, eventData?: Record<string, unknown>, userData?: Record<string, unknown>): void {
+  track(eventName: string, eventData?: Record<string, unknown>, userData?: Record<string, unknown>, eventId?: string): void {
     if (!this.initialized) {
       console.warn('[Pixlinks] Not initialized')
       return
@@ -64,6 +77,7 @@ export class PixlinksTracker {
       user_data: userData,
       source_url: window.location.href,
       event_time: new Date().toISOString(),
+      event_id: eventId || generateEventId(),
     }
 
     this.queue.push({ payload, retries: 0 })


### PR DESCRIPTION
## Summary

- **Meta CAPI Compliance**: Add event_id deduplication between browser pixel and server-side CAPI, SHA-256 hashing for PII fields (em, ph, fn, ln, etc.), move access_token from URL to POST body, capture client IP/user-agent for EMQ score, refactor replay service to batch sending (1000 events/request), and add data_processing_options
- **Clickable Image Blocks**: Add link_url support on image blocks in sale page editor, allowing images to be clickable with CTA tracking
- **CTA Event Simplification**: Streamline CTA event options in sale page editor

## Test plan

- [ ] Run `cd backend && go vet ./... && go test -race ./...` — all pass
- [ ] Run `cd sdk && npm run test && npm run build` — 8/8 tests pass, build OK
- [ ] Run migration `000004_capi_compliance.up.sql` against Neon DB
- [ ] Open Sale Page with Facebook Pixel Helper — verify event_id matches between browser pixel and server CAPI
- [ ] Check Events Manager for dedup (events not double-counted)
- [ ] Verify access_token is NOT in CAPI request URL (moved to POST body)
- [ ] Verify PII fields (em, ph) are SHA-256 hashed in CAPI requests
- [ ] Test replay — verify batch sending and new event_ids per replayed event
- [ ] Test clickable image blocks in sale page editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)