### PR TITLE
feat: add realtime events dashboard with hybrid polling

### DIFF
--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -5,6 +5,17 @@ import (
 	"time"
 )
 
+type RealtimeEvent struct {
+	ID              string    `json:"id"`
+	PixelID         string    `json:"pixel_id"`
+	PixelName       string    `json:"pixel_name"`
+	EventName       string    `json:"event_name"`
+	SourceURL       string    `json:"source_url,omitempty"`
+	ForwardedToCAPI bool      `json:"forwarded_to_capi"`
+	EventTime       time.Time `json:"event_time"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
 type PixelEvent struct {
 	ID               string          `json:"id"`
 	PixelID          string          `json:"pixel_id"`

--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -5,9 +5,11 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 
 	"github.com/jaochai/pixlinks/backend/internal/middleware"
 	"github.com/jaochai/pixlinks/backend/internal/service"
@@ -77,6 +79,43 @@ func (h *EventHandler) List(w http.ResponseWriter, r *http.Request) {
 		PerPage:    perPage,
 		TotalPages: int(math.Ceil(float64(total) / float64(perPage))),
 	})
+}
+
+func (h *EventHandler) ListRecent(w http.ResponseWriter, r *http.Request) {
+	customerID := middleware.GetCustomerID(r.Context())
+
+	sinceStr := r.URL.Query().Get("since")
+	if sinceStr == "" {
+		ErrorJSON(w, http.StatusBadRequest, "since parameter is required (RFC3339 format)")
+		return
+	}
+	since, err := time.Parse(time.RFC3339, sinceStr)
+	if err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "since parameter must be in RFC3339 format")
+		return
+	}
+
+	// Clamp since to max 5 minutes ago to prevent expensive historical scans
+	maxLookback := time.Now().Add(-5 * time.Minute)
+	if since.Before(maxLookback) {
+		since = maxLookback
+	}
+
+	pixelID := r.URL.Query().Get("pixel_id")
+	if pixelID != "" {
+		if _, err := uuid.Parse(pixelID); err != nil {
+			ErrorJSON(w, http.StatusBadRequest, "pixel_id must be a valid UUID")
+			return
+		}
+	}
+
+	events, err := h.eventService.ListRecent(r.Context(), customerID, since, pixelID)
+	if err != nil {
+		ErrorJSON(w, http.StatusInternalServerError, "failed to fetch recent events")
+		return
+	}
+
+	JSON(w, http.StatusOK, APIResponse{Data: events})
 }
 
 func (h *EventHandler) GetByID(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -30,6 +30,7 @@ type EventRepository interface {
 	ListByCustomerID(ctx context.Context, customerID string, limit, offset int) ([]*domain.PixelEvent, int, error)
 	MarkForwarded(ctx context.Context, id string, responseCode int) error
 	GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) ([]*domain.PixelEvent, error)
+	ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error)
 }
 
 type EventRuleRepository interface {

--- a/backend/internal/repository/postgres/event_repo.go
+++ b/backend/internal/repository/postgres/event_repo.go
@@ -176,3 +176,36 @@ func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, even
 	}
 	return events, rows.Err()
 }
+
+func (r *EventRepo) ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT pe.id, pe.pixel_id, p.name AS pixel_name, pe.event_name,
+		        pe.source_url, pe.forwarded_to_capi, pe.event_time, pe.created_at
+		 FROM pixel_events pe
+		 JOIN pixels p ON p.id = pe.pixel_id
+		 WHERE p.customer_id = $1
+		   AND pe.created_at > $2
+		   AND ($3::text = '' OR pe.pixel_id = $3::uuid)
+		 ORDER BY pe.created_at ASC
+		 LIMIT $4`,
+		customerID, since, pixelID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []*domain.RealtimeEvent
+	for rows.Next() {
+		e := &domain.RealtimeEvent{}
+		var sourceURL *string
+		if err := rows.Scan(&e.ID, &e.PixelID, &e.PixelName, &e.EventName, &sourceURL, &e.ForwardedToCAPI, &e.EventTime, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		if sourceURL != nil {
+			e.SourceURL = *sourceURL
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -122,6 +122,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool) http.Handl
 
 			// Event log routes - Phase 4
 			r.Get("/events", eventHandler.List)
+			r.Get("/events/recent", eventHandler.ListRecent)
 			r.Get("/events/{id}", eventHandler.GetByID)
 
 			// Event rules - Phase 5

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -180,6 +180,19 @@ func (s *EventService) ListByCustomerID(ctx context.Context, customerID string, 
 	return events, total, nil
 }
 
+const realtimeEventLimit = 50
+
+func (s *EventService) ListRecent(ctx context.Context, customerID string, since time.Time, pixelID string) ([]*domain.RealtimeEvent, error) {
+	events, err := s.eventRepo.ListRecentByCustomerID(ctx, customerID, since, pixelID, realtimeEventLimit)
+	if err != nil {
+		return nil, fmt.Errorf("list recent events: %w", err)
+	}
+	if events == nil {
+		return []*domain.RealtimeEvent{}, nil
+	}
+	return events, nil
+}
+
 func (s *EventService) GetByID(ctx context.Context, id string) (*domain.PixelEvent, error) {
 	event, err := s.eventRepo.GetByID(ctx, id)
 	if err != nil {

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -221,4 +222,52 @@ func TestEventService_ListByCustomerID(t *testing.T) {
 			eventRepo.AssertExpectations(t)
 		})
 	}
+}
+
+func TestEventService_ListRecent_Success(t *testing.T) {
+	svc, eventRepo, _ := newTestEventService()
+	since := time.Now().Add(-5 * time.Minute)
+
+	eventRepo.On("ListRecentByCustomerID", mock.Anything, "cust-1", since, "", 50).Return([]*domain.RealtimeEvent{
+		{ID: "evt-1", PixelID: "px-1", PixelName: "My Pixel", EventName: "PageView", CreatedAt: since.Add(time.Second)},
+		{ID: "evt-2", PixelID: "px-1", PixelName: "My Pixel", EventName: "Purchase", CreatedAt: since.Add(2 * time.Second)},
+	}, nil)
+
+	events, err := svc.ListRecent(context.Background(), "cust-1", since, "")
+
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+	assert.Equal(t, "evt-1", events[0].ID)
+	assert.Equal(t, "evt-2", events[1].ID)
+	eventRepo.AssertExpectations(t)
+}
+
+func TestEventService_ListRecent_EmptyResult(t *testing.T) {
+	svc, eventRepo, _ := newTestEventService()
+	since := time.Now()
+
+	eventRepo.On("ListRecentByCustomerID", mock.Anything, "cust-1", since, "", 50).Return(nil, nil)
+
+	events, err := svc.ListRecent(context.Background(), "cust-1", since, "")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, events)
+	assert.Len(t, events, 0)
+	eventRepo.AssertExpectations(t)
+}
+
+func TestEventService_ListRecent_WithPixelIDFilter(t *testing.T) {
+	svc, eventRepo, _ := newTestEventService()
+	since := time.Now().Add(-10 * time.Minute)
+
+	eventRepo.On("ListRecentByCustomerID", mock.Anything, "cust-1", since, "px-2", 50).Return([]*domain.RealtimeEvent{
+		{ID: "evt-3", PixelID: "px-2", PixelName: "Other Pixel", EventName: "AddToCart", CreatedAt: since.Add(time.Second)},
+	}, nil)
+
+	events, err := svc.ListRecent(context.Background(), "cust-1", since, "px-2")
+
+	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+	assert.Equal(t, "px-2", events[0].PixelID)
+	eventRepo.AssertExpectations(t)
 }

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -131,6 +131,13 @@ func (m *MockEventRepo) GetEventsForReplay(ctx context.Context, pixelID string, 
 	}
 	return args.Get(0).([]*domain.PixelEvent), args.Error(1)
 }
+func (m *MockEventRepo) ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error) {
+	args := m.Called(ctx, customerID, since, pixelID, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.RealtimeEvent), args.Error(1)
+}
 
 // MockEventRuleRepo
 type MockEventRuleRepo struct{ mock.Mock }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink, useNavigate } from 'react-router'
 import {
   LayoutDashboard,
   Radio,
+  Activity,
   FileText,
   Globe,
   ScrollText,
@@ -18,6 +19,7 @@ const navItems = [
   { to: '/sale-pages', icon: FileText, label: 'Sale Pages' },
   { to: '/domains', icon: Globe, label: 'Custom Domains' },
   { to: '/events/log', icon: ScrollText, label: 'Event Log' },
+  { to: '/events/realtime', icon: Activity, label: 'Realtime' },
   { to: '/replay', icon: RotateCcw, label: 'Replay Center' },
   { to: '/settings', icon: Settings, label: 'Settings' },
 ]

--- a/frontend/src/hooks/use-realtime-events.ts
+++ b/frontend/src/hooks/use-realtime-events.ts
@@ -1,0 +1,85 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import api from '@/lib/api'
+import type { APIResponse, RealtimeEvent } from '@/types'
+
+const MAX_BUFFER = 200
+
+function thirtySecondsAgo() {
+  return new Date(Date.now() - 30_000).toISOString()
+}
+
+export function useRealtimeEvents() {
+  const [events, setEvents] = useState<RealtimeEvent[]>([])
+  const [isPaused, setIsPaused] = useState(false)
+  const [pixelId, setPixelIdState] = useState<string | null>(null)
+  const sinceRef = useRef<string>(thirtySecondsAgo())
+  const processedIdsRef = useRef<Set<string>>(new Set())
+
+  const query = useQuery({
+    queryKey: ['realtime-events', pixelId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ since: sinceRef.current })
+      if (pixelId) params.set('pixel_id', pixelId)
+      const { data } = await api.get<APIResponse<RealtimeEvent[]>>(
+        `/events/recent?${params.toString()}`
+      )
+      return data.data ?? []
+    },
+    refetchInterval: isPaused ? false : 5000,
+  })
+
+  useEffect(() => {
+    const data = query.data
+    if (!data || data.length === 0) return
+
+    // Deduplicate using a Set of processed IDs
+    const newEvents = data.filter((e) => !processedIdsRef.current.has(e.id))
+    if (newEvents.length === 0) return
+
+    // Track new event IDs
+    for (const e of newEvents) {
+      processedIdsRef.current.add(e.id)
+    }
+
+    // Update since cursor to the NEWEST event (last in ASC-ordered array)
+    const lastEvent = data[data.length - 1]
+    if (lastEvent) {
+      sinceRef.current = lastEvent.created_at
+    }
+
+    // Prepend new events (reversed so newest first) and cap buffer
+    setEvents((prev) => [...newEvents.reverse(), ...prev].slice(0, MAX_BUFFER))
+
+    // Cap the processedIds set to prevent memory leak
+    if (processedIdsRef.current.size > MAX_BUFFER * 2) {
+      const entries = [...processedIdsRef.current]
+      processedIdsRef.current = new Set(entries.slice(-MAX_BUFFER))
+    }
+  }, [query.data])
+
+  const setPixelId = useCallback((id: string | null) => {
+    setPixelIdState(id)
+    setEvents([])
+    sinceRef.current = thirtySecondsAgo()
+    processedIdsRef.current = new Set()
+  }, [])
+
+  const togglePause = useCallback(() => setIsPaused((p) => !p), [])
+
+  const clear = useCallback(() => {
+    setEvents([])
+    sinceRef.current = new Date().toISOString()
+    processedIdsRef.current = new Set()
+  }, [])
+
+  return {
+    events,
+    isLive: !isPaused && !query.isError,
+    isPaused,
+    togglePause,
+    clear,
+    pixelId,
+    setPixelId,
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,12 @@
 @import "tailwindcss";
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/pages/RealtimeEventsPage.tsx
+++ b/frontend/src/pages/RealtimeEventsPage.tsx
@@ -1,0 +1,127 @@
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Pause, Play, Trash2, Check, X } from 'lucide-react'
+import { useRealtimeEvents } from '@/hooks/use-realtime-events'
+import { usePixels } from '@/hooks/use-pixels'
+import { formatDistanceToNow } from 'date-fns'
+
+const eventBadgeVariant = (name: string) => {
+  switch (name) {
+    case 'PageView':
+      return 'secondary'
+    case 'Purchase':
+      return 'success'
+    case 'Lead':
+    case 'CompleteRegistration':
+      return 'default'
+    case 'AddToCart':
+    case 'InitiateCheckout':
+      return 'warning'
+    default:
+      return 'outline'
+  }
+}
+
+export function RealtimeEventsPage() {
+  const { events, isLive, isPaused, togglePause, clear, pixelId, setPixelId } =
+    useRealtimeEvents()
+  const { data: pixels } = usePixels()
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-2xl font-bold text-neutral-900">Realtime Events</h1>
+            <p className="text-sm text-neutral-500 mt-1">{events.length} events</p>
+          </div>
+          <Badge variant={isLive ? 'success' : 'warning'}>{isLive ? 'Live' : 'Paused'}</Badge>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={togglePause}>
+            {isPaused ? <Play className="h-4 w-4 mr-1" /> : <Pause className="h-4 w-4 mr-1" />}
+            {isPaused ? 'Resume' : 'Pause'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={clear}>
+            <Trash2 className="h-4 w-4 mr-1" />
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <select
+          className="border border-neutral-200 rounded-lg px-3 py-2 text-sm bg-white text-neutral-900"
+          value={pixelId ?? ''}
+          onChange={(e) => setPixelId(e.target.value || null)}
+        >
+          <option value="">All Pixels</option>
+          {pixels?.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="text-center py-16 border border-dashed border-neutral-300 rounded-lg">
+          <div className="animate-pulse mb-3">
+            <div className="inline-block h-3 w-3 rounded-full bg-emerald-400" />
+          </div>
+          <p className="text-neutral-500">Waiting for events...</p>
+          <p className="text-sm text-neutral-400 mt-1">
+            New events will appear here in realtime
+          </p>
+        </div>
+      ) : (
+        <div className="border border-neutral-200 rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-neutral-200 bg-neutral-50">
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Event</th>
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Pixel</th>
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">
+                  Source URL
+                </th>
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">CAPI</th>
+                <th className="text-left text-sm font-medium text-neutral-500 px-4 py-3">Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((event) => (
+                <tr
+                  key={event.id}
+                  className="border-b border-neutral-200 last:border-0 animate-[fadeIn_0.3s_ease-in]"
+                >
+                  <td className="px-4 py-3">
+                    <Badge variant={eventBadgeVariant(event.event_name)}>
+                      {event.event_name}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-neutral-700">{event.pixel_name}</td>
+                  <td
+                    className="px-4 py-3 text-sm text-neutral-500 max-w-xs truncate"
+                    title={event.source_url}
+                  >
+                    {event.source_url || '-'}
+                  </td>
+                  <td className="px-4 py-3">
+                    {event.forwarded_to_capi ? (
+                      <Check className="h-4 w-4 text-emerald-600" />
+                    ) : (
+                      <X className="h-4 w-4 text-red-400" />
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-neutral-500">
+                    {formatDistanceToNow(new Date(event.event_time), { addSuffix: true })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,7 @@ import { SalePagesPage } from '@/pages/SalePagesPage'
 import { SalePageEditorPage } from '@/pages/SalePageEditorPage'
 import { BlockEditorPage } from '@/pages/BlockEditorPage'
 import { CustomDomainsPage } from '@/pages/CustomDomainsPage'
+import { RealtimeEventsPage } from '@/pages/RealtimeEventsPage'
 
 export const router = createBrowserRouter([
   {
@@ -40,6 +41,7 @@ export const router = createBrowserRouter([
       { path: 'sale-pages/:id/edit-blocks', element: <BlockEditorPage /> },
       { path: 'domains', element: <CustomDomainsPage /> },
       { path: 'events/log', element: <EventLogPage /> },
+      { path: 'events/realtime', element: <RealtimeEventsPage /> },
       { path: 'replay', element: <ReplayPage /> },
       { path: 'settings', element: <SettingsPage /> },
     ],

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -161,6 +161,17 @@ export interface CustomDomain {
   updated_at: string
 }
 
+export interface RealtimeEvent {
+  id: string
+  pixel_id: string
+  pixel_name: string
+  event_name: string
+  source_url?: string
+  forwarded_to_capi: boolean
+  event_time: string
+  created_at: string
+}
+
 export interface AuthTokens {
   access_token: string
   refresh_token: string


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/events/recent` backend endpoint with cursor-based polling via `since` timestamp, UUID validation on `pixel_id`, and 5-minute max lookback window
- Add Realtime Events dashboard page with 5-second polling, pause/resume, pixel filter dropdown, Set-based deduplication, 200-event buffer, and fade-in animations
- Add sidebar navigation entry with Activity icon

## Test plan
- [ ] Backend: `cd backend && go vet ./... && go test -race ./...` passes
- [ ] Frontend: `cd frontend && npm run lint && npm run build` passes
- [ ] Open Realtime page → Live badge shows green
- [ ] Fire SDK events → events appear within 5 seconds with fade-in
- [ ] Select pixel filter → only that pixel's events shown
- [ ] Click Pause → badge turns yellow, no new events
- [ ] Click Resume → missed events load in batch
- [ ] Click Clear → feed empties, counter resets
- [ ] Invalid `pixel_id` param → returns 400 (not 500)
- [ ] `since` older than 5 minutes → clamped to 5 minutes ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)