### PR TITLE
chore: add composite index on pixel_events for realtime polling

### DIFF
--- a/backend/db/migrations/000005_pixel_events_created_at_index.down.sql
+++ b/backend/db/migrations/000005_pixel_events_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_pixel_events_pixel_created;

--- a/backend/db/migrations/000005_pixel_events_created_at_index.up.sql
+++ b/backend/db/migrations/000005_pixel_events_created_at_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pixel_events_pixel_created
+ON pixel_events (pixel_id, created_at ASC);


### PR DESCRIPTION
## Summary
- Add composite index `idx_pixel_events_pixel_created` on `pixel_events(pixel_id, created_at ASC)`
- Supports `GET /events/recent` query performance as `pixel_events` table grows
- Uses `CONCURRENTLY` to avoid table locks during index creation

## Test plan
- [ ] Run migration against Neon: `psql $DATABASE_URL -f backend/db/migrations/000005_pixel_events_created_at_index.up.sql`
- [ ] Verify index exists: `\di idx_pixel_events_pixel_created`
- [ ] Confirm realtime polling still works after index creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)