### PR TITLE
fix: exclude auth endpoints from 401 response interceptor

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,7 +39,10 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    const authPaths = ['/auth/login', '/auth/register', '/auth/refresh']
+    const isAuthRequest = authPaths.some((path) => originalRequest.url?.includes(path))
+
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthRequest) {
       originalRequest._retry = true
 
       if (isRefreshing) {
@@ -85,7 +88,6 @@ api.interceptors.response.use(
         localStorage.removeItem('access_token')
         localStorage.removeItem('refresh_token')
         useAuthStore.getState().logout()
-        window.location.href = '/login'
       } finally {
         isRefreshing = false
       }


### PR DESCRIPTION
## Summary
- Auth endpoints (`/auth/login`, `/auth/register`, `/auth/refresh`) now bypass the automatic token refresh interceptor, allowing 401 errors to reach callers directly for proper error message display
- Removed `window.location.href = '/login'` redirect — `ProtectedRoute` handles navigation via Zustand `isAuthenticated` state, preventing full page reloads and preserving React state (toasts, error messages)

## Test plan
- [ ] Login with wrong password → error message "อีเมลหรือรหัสผ่านไม่ถูกต้อง" displays without page reload
- [ ] Login with correct credentials → navigates to dashboard normally
- [ ] Token expired during session → ProtectedRoute redirects to /login
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)