### PR TITLE
fix: add user_data to test pixel connection for Meta CAPI compliance

### DIFF
--- a/backend/internal/handler/pixel_handler.go
+++ b/backend/internal/handler/pixel_handler.go
@@ -108,7 +108,13 @@ func (h *PixelHandler) Test(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pixelID := chi.URLParam(r, "id")
 
-	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID)
+	clientIP := r.Header.Get("X-Forwarded-For")
+	if clientIP == "" {
+		clientIP = r.RemoteAddr
+	}
+	userAgent := r.UserAgent()
+
+	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID, clientIP, userAgent)
 	if err != nil {
 		if errors.Is(err, service.ErrPixelNotFound) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")
@@ -128,6 +134,7 @@ func (h *PixelHandler) Test(w http.ResponseWriter, r *http.Request) {
 			slog.Error("pixel test connection CAPI error",
 				"pixel_id", pixelID,
 				"fb_status", capiErr.StatusCode,
+				"fb_response", capiErr.Message,
 			)
 			ErrorJSON(w, http.StatusBadGateway, sanitizeCAPIError(capiErr.StatusCode))
 			return

--- a/backend/internal/service/pixel_service.go
+++ b/backend/internal/service/pixel_service.go
@@ -140,7 +140,7 @@ func (s *PixelService) Delete(ctx context.Context, customerID, pixelID string) e
 	return s.pixelRepo.Delete(ctx, pixelID)
 }
 
-func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID string) (*facebook.CAPIResponse, error) {
+func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, clientIP, userAgent string) (*facebook.CAPIResponse, error) {
 	pixel, err := s.GetByID(ctx, customerID, pixelID)
 	if err != nil {
 		return nil, err
@@ -156,6 +156,10 @@ func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID s
 		ActionSource:          "website",
 		EventID:               uuid.NewString(),
 		DataProcessingOptions: []string{},
+		UserData: map[string]interface{}{
+			"client_ip_address": clientIP,
+			"client_user_agent": userAgent,
+		},
 	}
 
 	resp, err := s.capiClient.SendEvent(ctx, pixel.FBPixelID, pixel.FBAccessToken, event)

--- a/backend/internal/service/pixel_service_test.go
+++ b/backend/internal/service/pixel_service_test.go
@@ -353,7 +353,7 @@ func TestPixelService_TestConnection(t *testing.T) {
 
 			svc := NewPixelService(pixelRepo, capiClient, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID)
+			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID, "127.0.0.1", "TestAgent/1.0")
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)


### PR DESCRIPTION
## Summary
- เพิ่ม `user_data` (client_ip_address, client_user_agent) ใน test event ที่ส่งไป Facebook CAPI เพื่อแก้ HTTP 400 error
- ดึง client IP จาก `X-Forwarded-For` header (fallback `RemoteAddr`) และ User-Agent จาก HTTP request
- เพิ่ม `fb_response` ใน error log เพื่อให้ debug Facebook errors ได้ง่ายขึ้น

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/service/... ./internal/handler/...` passes
- [ ] กดปุ่มทดสอบเชื่อมต่อ Pixel ใน UI — ต้องขึ้น success ถ้า Pixel ID + Access Token ถูกต้อง
- [ ] ถ้ายัง error → ดู backend log จะเห็น `fb_response` บอกสาเหตุจริงจาก Facebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)