### PR TITLE
fix: send only user_agent in test pixel event to fix CAPI 400 error

### DIFF
--- a/backend/internal/handler/pixel_handler.go
+++ b/backend/internal/handler/pixel_handler.go
@@ -108,13 +108,7 @@ func (h *PixelHandler) Test(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pixelID := chi.URLParam(r, "id")
 
-	clientIP := r.Header.Get("X-Forwarded-For")
-	if clientIP == "" {
-		clientIP = r.RemoteAddr
-	}
-	userAgent := r.UserAgent()
-
-	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID, clientIP, userAgent)
+	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID, r.UserAgent())
 	if err != nil {
 		if errors.Is(err, service.ErrPixelNotFound) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")

--- a/backend/internal/service/pixel_service.go
+++ b/backend/internal/service/pixel_service.go
@@ -140,7 +140,7 @@ func (s *PixelService) Delete(ctx context.Context, customerID, pixelID string) e
 	return s.pixelRepo.Delete(ctx, pixelID)
 }
 
-func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, clientIP, userAgent string) (*facebook.CAPIResponse, error) {
+func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, userAgent string) (*facebook.CAPIResponse, error) {
 	pixel, err := s.GetByID(ctx, customerID, pixelID)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,6 @@ func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, 
 		EventID:               uuid.NewString(),
 		DataProcessingOptions: []string{},
 		UserData: map[string]interface{}{
-			"client_ip_address": clientIP,
 			"client_user_agent": userAgent,
 		},
 	}

--- a/backend/internal/service/pixel_service_test.go
+++ b/backend/internal/service/pixel_service_test.go
@@ -353,7 +353,7 @@ func TestPixelService_TestConnection(t *testing.T) {
 
 			svc := NewPixelService(pixelRepo, capiClient, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID, "127.0.0.1", "TestAgent/1.0")
+			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID, "TestAgent/1.0")
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)


### PR DESCRIPTION
## Summary
- แก้ปัญหา test pixel connection ได้ HTTP 400 (subcode 2804007: Invalid IP address) จาก Facebook CAPI
- ส่งแค่ `client_user_agent` ใน `user_data` แทนที่จะส่ง `client_ip_address` ที่มี format ผิด (port/multi-IP จาก proxy)
- Facebook CAPI ต้องการ `user_data` อย่างน้อย 1 field — `client_user_agent` เพียงพอสำหรับ test event

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/service/...` passes
- [ ] กดปุ่มทดสอบเชื่อมต่อ Pixel ใน UI — ต้องขึ้น success ถ้า Pixel ID + Access Token ถูกต้อง

🤖 Generated with [Claude Code](https://claude.com/claude-code)