### PR TITLE
fix: add event_source_url and external_id to test pixel connection event

### DIFF
--- a/backend/internal/facebook/hash.go
+++ b/backend/internal/facebook/hash.go
@@ -13,6 +13,13 @@ var piiFields = map[string]bool{
 	"zp": true, "country": true, "external_id": true,
 }
 
+// HashValue normalizes and SHA-256 hashes a single value per Meta CAPI requirements.
+func HashValue(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	hash := sha256.Sum256([]byte(normalized))
+	return fmt.Sprintf("%x", hash)
+}
+
 // HashUserData hashes PII fields in user_data per Meta CAPI requirements.
 // Non-PII fields (client_ip_address, client_user_agent, fbc, fbp) are passed through unchanged.
 func HashUserData(userData map[string]interface{}) map[string]interface{} {

--- a/backend/internal/handler/pixel_handler.go
+++ b/backend/internal/handler/pixel_handler.go
@@ -108,7 +108,7 @@ func (h *PixelHandler) Test(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pixelID := chi.URLParam(r, "id")
 
-	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID, r.UserAgent())
+	resp, err := h.pixelService.TestConnection(r.Context(), customerID, pixelID)
 	if err != nil {
 		if errors.Is(err, service.ErrPixelNotFound) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")

--- a/backend/internal/service/pixel_service.go
+++ b/backend/internal/service/pixel_service.go
@@ -140,7 +140,7 @@ func (s *PixelService) Delete(ctx context.Context, customerID, pixelID string) e
 	return s.pixelRepo.Delete(ctx, pixelID)
 }
 
-func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, userAgent string) (*facebook.CAPIResponse, error) {
+func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID string) (*facebook.CAPIResponse, error) {
 	pixel, err := s.GetByID(ctx, customerID, pixelID)
 	if err != nil {
 		return nil, err
@@ -155,9 +155,11 @@ func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID, 
 		EventTime:             time.Now().Unix(),
 		ActionSource:          "website",
 		EventID:               uuid.NewString(),
+		EventSourceURL:        "https://keepx.io/test",
 		DataProcessingOptions: []string{},
 		UserData: map[string]interface{}{
-			"client_user_agent": userAgent,
+			"client_user_agent": "KeepPX/1.0 (Connection Test)",
+			"external_id":       facebook.HashValue("keepx-test-" + pixel.FBPixelID),
 		},
 	}
 

--- a/backend/internal/service/pixel_service_test.go
+++ b/backend/internal/service/pixel_service_test.go
@@ -353,7 +353,7 @@ func TestPixelService_TestConnection(t *testing.T) {
 
 			svc := NewPixelService(pixelRepo, capiClient, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID, "TestAgent/1.0")
+			resp, err := svc.TestConnection(context.Background(), tt.customerID, tt.pixelID)
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)


### PR DESCRIPTION
## Summary
- เพิ่ม `event_source_url` (required สำหรับ `action_source: "website"`) ใน test event payload
- เพิ่ม `external_id` (SHA-256 hashed) เป็น identity parameter — แก้ Facebook subcode `2804050` ที่บอกว่าไม่มี identity param ให้จับคู่ได้
- Hardcode `client_user_agent` เป็น `"KeepPX/1.0 (Connection Test)"` แทนการดึงจาก HTTP request — ลดความซับซ้อนของ handler signature
- เพิ่ม `HashValue()` utility function ใน `facebook/hash.go` สำหรับ hash ค่าเดี่ยว

## Context
ปุ่ม "ทดสอบเชื่อมต่อ" Pixel ใน dashboard ได้ error 502 เสมอ เพราะ Facebook CAPI ตอบ HTTP 400:

| ครั้ง | สาเหตุ | Facebook subcode |
|-------|--------|-----------------|
| PR #20 | IP format ผิด (มี port จาก proxy) | `2804007` |
| PR #21 | ไม่มี identity param — Facebook จับคู่ไม่ได้ | `2804050` |

Root cause: Facebook CAPI สำหรับ `action_source: "website"` ต้องการ `event_source_url` + identity param อย่างน้อย 1 ตัว (`em`, `ph`, `external_id`, `fbc`, `fbp`)

## Test plan
- [x] `go vet ./...` — pass
- [x] `go test -race ./internal/service/... ./internal/facebook/...` — pass
- [ ] กดปุ่มทดสอบเชื่อมต่อ Pixel ใน UI → success
- [ ] ใส่ Pixel ID/Token ผิด → error "authentication failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)