### PR TITLE
fix: add /api/ proxy to Nginx for SDK event ingestion

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,6 +20,15 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Proxy API requests to backend
+    location /api/ {
+        proxy_pass ${BACKEND_URL};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Proxy SDK file to backend
     location /sdk/ {
         proxy_pass ${BACKEND_URL};


### PR DESCRIPTION
## Summary
- Nginx was missing `/api/` location block, causing SDK `POST /api/v1/events/ingest` requests from sale pages to be served `index.html` instead of being proxied to the Go backend
- Dashboard API calls worked because `VITE_API_URL` points directly to the backend service, bypassing Nginx
- Added `location /api/` proxy block to `nginx.conf`

## Root cause
SDK on sale pages sends events to `https://pixlinks.xyz/api/v1/events/ingest`. Nginx only had proxy rules for `/p/` and `/sdk/`, so `/api/` fell through to `location /` which serves `index.html`.

## Test plan
- [x] Frontend lint + test + build pass
- [ ] After deploy: visit sale page, check Railway logs for `POST /api/v1/events/ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)