### PR TITLE
fix: remove Host header override causing proxy loop on /api/ route

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,7 +23,6 @@ server {
     # Proxy API requests to backend
     location /api/ {
         proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- `POST /api/v1/events/ingest` from SDK was returning 502 due to infinite proxy loop
- Root cause: `proxy_set_header Host $host;` in `/api/` location block sent `Host: pixlinks.xyz` to `api.pixlinks.xyz`, causing Railway CDN to route back to pixlinks-web instead of pixlinks-api
- Removed `Host` override to match `/p/` and `/sdk/` blocks that work correctly

## Test plan
- [ ] After deploy: visit sale page, confirm `POST /api/v1/events/ingest → 200` in backend logs (not 502 in Nginx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)