### PR TITLE
feat: add 3 project skills from learned instincts

### DIFF
--- a/.claude/skills/e2e-debug/SKILL.md
+++ b/.claude/skills/e2e-debug/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: e2e-debug
+description: Debug Playwright E2E test failures in CI — root cause analysis, Zod schema alignment, and dialog timing patterns
+---
+
+# E2E Debug
+
+## When to Activate
+
+Activate this skill when the user says:
+- "E2E tests failing" / "CI tests fail" / "Tests pass locally but fail in CI"
+- "Dialog won't close" / "Form not submitting in test"
+- "Playwright timeout" / "Strict mode violation"
+- "Fix flaky test" / "Debug CI failure"
+
+## Step 1: Read the CI Error
+
+Never guess. Read the exact error first:
+
+```bash
+gh run view <run-id> --log-failed | tail -80
+```
+
+From the error, identify:
+1. Which locator failed? What was expected vs received?
+2. Did the previous action complete? (dialog open, form submit, navigation)
+3. Is it a timing issue? (CI is 2-5x slower than local)
+4. Is it a validation issue? (form didn't submit due to Zod schema)
+
+Then read the actual React component code — understand what triggers the state change the test expects.
+
+## Step 2: Check Zod Schema Alignment
+
+If a dialog stays open after clicking submit, the most likely cause is a Zod validation failure.
+
+**Rule**: Fill ALL fields required by the Zod schema — not just what the UI suggests.
+
+```typescript
+// Schema says: fb_access_token: z.string().min(1, 'Required')
+// UI says: "(leave blank to keep current)"
+// Test MUST fill it anyway:
+
+await pixelsPage.nameInput.fill(updatedName)
+await pixelsPage.accessTokenInput.fill('EAAtest123token')  // Required by schema!
+await pixelsPage.saveButton.click()
+```
+
+**Why it silently fails**:
+- Zod validation runs client-side before `handleSubmit`
+- If validation fails, the callback never executes
+- Dialog stays open, test times out — no visible error
+
+**Diagnostic**:
+1. Find the Zod schema for the form (search for `zodResolver` in the component)
+2. List all required fields in the schema
+3. Compare with what the test fills
+4. Missing field = root cause
+
+## Step 3: Add Dialog Timing Waits
+
+CI environments are 2-5x slower. Always add explicit waits around dialog interactions:
+
+```typescript
+// 1. Wait for dialog to OPEN
+await expect(
+  page.getByRole('heading', { name: 'Edit Pixel' })
+).toBeVisible()
+
+// 2. Interact with fields
+await nameInput.fill('new value')
+await saveButton.click()
+
+// 3. Wait for dialog to CLOSE
+await expect(
+  page.getByRole('heading', { name: 'Edit Pixel' })
+).not.toBeVisible()
+
+// 4. NOW assert page content
+await expect(page.getByText('new value')).toBeVisible()
+```
+
+**Rules**:
+- Before interacting with dialog → wait for heading `toBeVisible()`
+- After clicking submit/save → wait for heading `not.toBeVisible()`
+- Between sequential dialogs → wait for previous to fully close first
+- After table update → wait for expected content to appear
+
+## Quick Reference: Common CI Failures
+
+| Symptom | Root Cause | Fix |
+|---------|-----------|-----|
+| Dialog stays open after submit | Zod validation failure | Fill ALL required schema fields |
+| Element not found after action | Animation/render delay | Add `toBeVisible()` / `not.toBeVisible()` wait |
+| Strict mode violation | Multiple matching elements | Scope locator: `.locator('form').getByRole(...)` |
+| Button click has no effect | Element obscured by overlay | Wait for previous dialog/overlay to close first |
+| Test passes locally, fails CI | CI slower than local | Add explicit waits, never rely on implicit timing |
+| Stale data after mutation | TanStack Query cache | Wait for updated content to appear in DOM |
+
+## Decision Tree
+
+```
+E2E test fails in CI
+├── Read CI logs (gh run view --log-failed)
+├── Timeout on dialog?
+│   ├── After clicking submit? → Check Zod schema (Step 2)
+│   └── On open/close? → Add timing waits (Step 3)
+├── Strict mode violation?
+│   └── Scope locator with parent: .locator('form').getByRole(...)
+├── Element not found?
+│   ├── After dialog close? → Wait for not.toBeVisible() first
+│   └── After navigation? → Wait for new page content
+└── Passes locally but fails CI?
+    └── Add explicit waits — CI is always slower
+```
+
+## Verification
+
+After fixing:
+```bash
+cd frontend && npx playwright test              # Run all E2E tests locally
+cd frontend && npx playwright test --grep "test name"  # Run specific test
+```
+
+If tests pass locally, push and verify CI:
+```bash
+git push && gh run watch
+```
+
+## Related
+
+- `frontend-feature` for creating new pages with testable structure
+- `deploy-check` for pre-deployment verification including E2E

--- a/.claude/skills/event-pipeline/SKILL.md
+++ b/.claude/skills/event-pipeline/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: event-pipeline
+description: Checklist and pitfalls for the Keep-PX event tracking pipeline — sale page templates, SDK endpoint sync, and Meta CAPI required fields
+---
+
+# Event Pipeline
+
+## When to Activate
+
+Activate this skill when the user says:
+- "Edit sale page" / "Add field to sale page" / "Change sale page template"
+- "Fix SDK endpoint" / "Events not showing" / "SDK not sending events"
+- "Send event to Meta" / "Fix CAPI" / "Test pixel connection"
+- "Events not appearing in Meta Events Manager"
+- "Change event tracking" / "Update pixel integration"
+
+## Part 1: Sale Page Co-Change Checklist
+
+When modifying the Sale Page feature, a single change typically touches 8-15 files. Update all layers in order:
+
+### Backend (change first)
+1. `backend/internal/domain/sale_page.go` — Domain struct
+2. `backend/db/migrations/` — SQL migration (if schema change)
+3. `backend/internal/repository/postgres/sale_page_repo.go` — Query updates
+4. `backend/internal/service/sale_page_service.go` — Business logic
+5. `backend/internal/handler/sale_page_handler.go` — HTTP handler
+6. `backend/internal/router/router.go` — New routes (if needed)
+7. `backend/internal/templates/sale_pages/blocks.html` — Block template
+8. `backend/internal/templates/sale_pages/simple.html` — Simple template
+
+### Frontend (change after backend)
+9. `frontend/src/types/index.ts` — TypeScript types (must match domain struct)
+10. `frontend/src/hooks/use-sale-pages.ts` — TanStack Query hooks
+11. `frontend/src/pages/SalePageEditorPage.tsx` — Editor page
+12. `frontend/src/pages/BlockEditorPage.tsx` — Block editor
+13. `frontend/src/components/sale-pages/BlockEditor.tsx` — Block editor component
+14. `frontend/src/components/sale-pages/BlockPreview.tsx` — Block preview
+15. `frontend/src/components/sale-pages/SalePagePreview.tsx` — Page preview
+
+**Critical**: `blocks.html` and `simple.html` ALWAYS need the same changes. Forgetting one causes silent rendering failures.
+
+## Part 2: SDK Endpoint Three-Point Sync
+
+When changing the SDK endpoint, you MUST sync all three locations:
+
+```
+sdk/src/tracker.ts (DEFAULT_ENDPOINT)
+        ↕ must match
+backend/internal/templates/sale_pages/*.html (data-endpoint="...")
+        ↕ must match
+frontend/src/pages/PixelsPage.tsx ("Get Code" snippet)
+```
+
+If any one is out of sync, events silently fail — SDK sends to wrong URL, backend never receives POST, no CAPI forwarding.
+
+### Diagnostic: Events Not Appearing
+1. Check browser Network tab → POST `/api/v1/events/ingest`
+2. POST goes to wrong domain → SDK endpoint misconfigured
+3. No POST at all → `data-endpoint` missing from script tag
+4. Check backend logs for incoming event requests
+
+**Trap**: Browser pixel (fbq) works independently. Pixel Helper shows green, but server-side CAPI path may be broken.
+
+## Part 3: Meta CAPI Required Fields
+
+When sending events to Facebook Conversions API, ALL of these fields are required:
+
+```go
+EventData{
+    EventName:      "PageView",           // Required
+    EventTime:      time.Now().Unix(),     // Required, Unix timestamp
+    ActionSource:   "website",            // Required
+    EventSourceURL: "https://...",        // Required, valid URL
+    UserData: UserData{                   // Required, at least one identifier
+        ClientUserAgent: "...",           // From User-Agent header
+        ExternalID:      "sha256...",     // SHA-256 hashed
+    },
+}
+```
+
+### Rules
+- `event_source_url` — MUST be a valid URL. Meta rejects empty.
+- `user_data` — MUST contain at least `client_user_agent`. Without it → HTTP 400.
+- `client_ip_address` — Only from real client requests. For test events → omit it. Invalid IPs → HTTP 400.
+- PII hashing — `email`, `phone`, `external_id` MUST be SHA-256 hashed. `client_ip_address` and `client_user_agent` are NOT hashed.
+- Event dedup — Use `event_id` (UUID). Same ID + name within 48h = deduplicated.
+
+### Test Connection vs Production
+
+| Field | Test Event | Production Event |
+|-------|-----------|-----------------|
+| `event_source_url` | `https://keepx.io/test` | Actual page URL |
+| `client_ip_address` | Don't include | From X-Forwarded-For |
+| `client_user_agent` | `KeepPX/1.0 Connection Test` | From User-Agent header |
+| `external_id` | `test-{pixelID}-{timestamp}` | Hashed real user ID |
+
+### Debugging "Events Not in Meta Events Manager"
+1. Backend logs show CAPI response 200 but not visible? → Wait 20+ minutes for Overview tab
+2. Response 400 → Missing `user_data` or `event_source_url`
+3. Events with `test_event_code` → only in Test Events tab, not Overview
+
+## Verification
+
+After changes to the event pipeline:
+1. Check SDK sends POST to correct backend URL (browser Network tab)
+2. Check backend logs for received events
+3. Check CAPI response status in backend logs (should be 200)
+4. Verify events appear in Meta Events Manager (allow 20 min)
+
+## Related
+
+- `go-service-scaffold` for creating new backend resources
+- `api-endpoint` for adding new endpoints
+- `deploy-check` for pre-deployment verification

--- a/.claude/skills/railway-deploy/SKILL.md
+++ b/.claude/skills/railway-deploy/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: railway-deploy
+description: Railway deployment patterns, Nginx proxy rules, and common pitfalls for Keep-PX monorepo
+---
+
+# Railway Deploy
+
+## When to Activate
+
+Activate this skill when the user says:
+- "Deploy to Railway" / "Fix deployment"
+- "Nginx config" / "Proxy not working" / "502 error"
+- "Dockerfile" / "Docker build" / "Build fails"
+- "Frontend blank page" / "API routes not working in production"
+- "Host header" / "Proxy loop"
+
+## Architecture
+
+Keep-PX runs as 2 separate Railway services:
+
+```
+Railway Project
+├── Backend service  → backend/Dockerfile (Go binary, port 8080)
+└── Frontend service → frontend/Dockerfile (Nginx, port 80)
+    └── nginx.conf proxies /api/ and /p/ → backend internal URL
+```
+
+## Common Pitfalls
+
+| Pitfall | Root Cause | Fix |
+|---------|-----------|-----|
+| Proxy loop (502/infinite redirect) | `Host` header override in nginx.conf | NEVER set `proxy_set_header Host` to backend |
+| SDK events don't reach backend | Missing `/api/` proxy in nginx.conf | Add `location /api/ { proxy_pass $BACKEND_URL; }` |
+| Sale pages 404 | Missing `/p/` route proxy | Add `location /p/ { proxy_pass $BACKEND_URL; }` |
+| Build fails "no Go files" | railway.json buildCommand in wrong dir | Use per-service Dockerfiles, not railway.json |
+| Frontend shows blank page | `VITE_API_URL` not set during build | Pass as Docker build arg |
+
+## Nginx Configuration
+
+```nginx
+# Proxy API routes to backend
+location /api/ {
+    proxy_pass http://$BACKEND_INTERNAL_URL;
+    # DO NOT add: proxy_set_header Host $BACKEND_HOST;
+    # Railway internal networking handles Host headers automatically
+}
+
+# Proxy sale page routes
+location /p/ {
+    proxy_pass http://$BACKEND_INTERNAL_URL;
+}
+
+# Serve frontend SPA with fallback
+location / {
+    try_files $uri $uri/ /index.html;
+}
+```
+
+**Critical rule**: NEVER override the `Host` header when proxying to backend on Railway. This causes infinite redirect loops. Railway's internal networking handles Host headers automatically.
+
+## Deployment Checklist
+
+### Backend Dockerfile
+- Multi-stage build: `golang:alpine` → `alpine`
+- Include `ca-certificates` in final stage (needed for HTTPS to Neon DB and Meta API)
+- Expose port 8080
+- Copy migrations if auto-run on startup
+
+### Frontend Dockerfile
+- Stage 1: `node:alpine` for `npm run build` with `--build-arg VITE_API_URL`
+- Stage 2: `nginx:alpine` to serve static files
+- Use `envsubst` for runtime environment variables in nginx.conf
+- Expose port 80
+
+### Environment Variables
+**Backend service:**
+- `DATABASE_URL` — Neon PostgreSQL connection string
+- `JWT_SECRET` — HMAC signing key
+- `PORT=8080`
+- `CORS_ALLOWED_ORIGINS` — Frontend domain
+
+**Frontend service:**
+- `VITE_API_URL` — Backend public URL (build-time)
+- `BACKEND_URL` — Backend internal Railway URL (runtime, for nginx proxy)
+
+## Adding New Backend Routes
+
+When adding a new route that must be accessible from the frontend in production, remember to add the route prefix to nginx.conf:
+
+```nginx
+# Example: adding /webhooks/ route
+location /webhooks/ {
+    proxy_pass http://$BACKEND_INTERNAL_URL;
+}
+```
+
+Without this, the route works in dev (Vite proxy) but 404s in production.
+
+## Verification
+
+```bash
+# After deploy, check:
+curl -s https://your-app.railway.app/api/v1/auth/login  # Should reach backend
+curl -s https://your-app.railway.app/p/test-slug         # Should reach backend
+curl -s https://your-app.railway.app/                     # Should serve frontend
+```
+
+## Related
+
+- `deploy-check` for pre-deployment quality gates
+- `event-pipeline` for verifying SDK events reach backend after deploy


### PR DESCRIPTION
## Summary
- Add `event-pipeline` skill: sale page co-change checklist, SDK endpoint sync, Meta CAPI required fields
- Add `railway-deploy` skill: Nginx proxy rules, Host header pitfalls, deployment checklist
- Add `e2e-debug` skill: CI failure root cause workflow, Zod schema alignment, dialog timing

## Test plan
- [x] Skills are markdown only — no code changes
- [x] Claude Code recognizes all 3 skills in skill list
- [x] Pre-push quality gates passed (no package changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)