### PR TITLE
feat: add realtime stats cards, event rate chart, and type breakdown

### DIFF
--- a/frontend/src/hooks/__tests__/use-realtime-stats.test.ts
+++ b/frontend/src/hooks/__tests__/use-realtime-stats.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { computeRealtimeStats } from '../use-realtime-stats'
+import type { RealtimeEvent } from '@/types'
+
+function makeEvent(overrides: Partial<RealtimeEvent> = {}): RealtimeEvent {
+  return {
+    id: crypto.randomUUID(),
+    pixel_id: 'px-1',
+    pixel_name: 'Test Pixel',
+    event_name: 'PageView',
+    source_url: 'https://example.com',
+    forwarded_to_capi: true,
+    event_time: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('computeRealtimeStats', () => {
+  it('returns zero/default stats for empty events', () => {
+    const { stats, timeBuckets, eventTypeCounts } = computeRealtimeStats([])
+
+    expect(stats.eventsPerMinute).toBe(0)
+    expect(stats.capiSuccessRate).toBe(0)
+    expect(stats.topEventType).toBe('-')
+    expect(stats.totalEvents).toBe(0)
+    expect(timeBuckets).toHaveLength(30)
+    expect(timeBuckets.every((b) => b.count === 0)).toBe(true)
+    expect(eventTypeCounts).toHaveLength(0)
+  })
+
+  it('counts events per minute from last 60 seconds', () => {
+    const now = new Date()
+    const recent = makeEvent({ created_at: new Date(now.getTime() - 10_000).toISOString() })
+    const old = makeEvent({ created_at: new Date(now.getTime() - 120_000).toISOString() })
+
+    const { stats } = computeRealtimeStats([recent, old])
+    expect(stats.eventsPerMinute).toBe(1)
+    expect(stats.totalEvents).toBe(2)
+  })
+
+  it('calculates CAPI success rate', () => {
+    const events = [
+      makeEvent({ forwarded_to_capi: true }),
+      makeEvent({ forwarded_to_capi: true }),
+      makeEvent({ forwarded_to_capi: false }),
+      makeEvent({ forwarded_to_capi: false }),
+    ]
+
+    const { stats } = computeRealtimeStats(events)
+    expect(stats.capiSuccessRate).toBe(50)
+  })
+
+  it('identifies top event type', () => {
+    const events = [
+      makeEvent({ event_name: 'PageView' }),
+      makeEvent({ event_name: 'PageView' }),
+      makeEvent({ event_name: 'Purchase' }),
+      makeEvent({ event_name: 'Lead' }),
+      makeEvent({ event_name: 'Lead' }),
+      makeEvent({ event_name: 'Lead' }),
+    ]
+
+    const { stats, eventTypeCounts } = computeRealtimeStats(events)
+    expect(stats.topEventType).toBe('Lead')
+    expect(eventTypeCounts[0]!.name).toBe('Lead')
+    expect(eventTypeCounts[0]!.count).toBe(3)
+    expect(eventTypeCounts[0]!.percentage).toBe(50)
+    expect(eventTypeCounts).toHaveLength(3)
+  })
+
+  it('distributes events into time buckets', () => {
+    const now = Date.now()
+    // Event 5 seconds ago — should land in the last bucket
+    const events = [
+      makeEvent({ created_at: new Date(now - 5_000).toISOString() }),
+      makeEvent({ created_at: new Date(now - 5_000).toISOString() }),
+    ]
+
+    const { timeBuckets } = computeRealtimeStats(events)
+    const lastBucket = timeBuckets[timeBuckets.length - 1]!
+    expect(lastBucket.count).toBe(2)
+  })
+
+  it('ignores events older than 5 min window in time buckets', () => {
+    const now = Date.now()
+    const events = [
+      makeEvent({ created_at: new Date(now - 6 * 60 * 1000).toISOString() }),
+    ]
+
+    const { timeBuckets } = computeRealtimeStats(events)
+    const totalInBuckets = timeBuckets.reduce((sum, b) => sum + b.count, 0)
+    expect(totalInBuckets).toBe(0)
+  })
+
+  it('sorts event type counts descending by count', () => {
+    const events = [
+      makeEvent({ event_name: 'A' }),
+      makeEvent({ event_name: 'B' }),
+      makeEvent({ event_name: 'B' }),
+      makeEvent({ event_name: 'C' }),
+      makeEvent({ event_name: 'C' }),
+      makeEvent({ event_name: 'C' }),
+    ]
+
+    const { eventTypeCounts } = computeRealtimeStats(events)
+    expect(eventTypeCounts.map((t) => t.name)).toEqual(['C', 'B', 'A'])
+  })
+
+  it('handles 100% CAPI success rate', () => {
+    const events = [
+      makeEvent({ forwarded_to_capi: true }),
+      makeEvent({ forwarded_to_capi: true }),
+    ]
+
+    const { stats } = computeRealtimeStats(events)
+    expect(stats.capiSuccessRate).toBe(100)
+  })
+
+  it('handles 0% CAPI success rate', () => {
+    const events = [
+      makeEvent({ forwarded_to_capi: false }),
+      makeEvent({ forwarded_to_capi: false }),
+    ]
+
+    const { stats } = computeRealtimeStats(events)
+    expect(stats.capiSuccessRate).toBe(0)
+  })
+})

--- a/frontend/src/hooks/use-realtime-events.ts
+++ b/frontend/src/hooks/use-realtime-events.ts
@@ -26,7 +26,7 @@ export function useRealtimeEvents() {
       )
       return data.data ?? []
     },
-    refetchInterval: isPaused ? false : 5000,
+    refetchInterval: isPaused ? false : 2000,
   })
 
   useEffect(() => {

--- a/frontend/src/hooks/use-realtime-stats.ts
+++ b/frontend/src/hooks/use-realtime-stats.ts
@@ -1,0 +1,98 @@
+import { useMemo } from 'react'
+import type { RealtimeEvent } from '@/types'
+
+export interface TimeBucket {
+  label: string
+  count: number
+}
+
+export interface EventTypeCount {
+  name: string
+  count: number
+  percentage: number
+}
+
+export interface RealtimeStats {
+  eventsPerMinute: number
+  capiSuccessRate: number
+  topEventType: string
+  totalEvents: number
+}
+
+export interface UseRealtimeStatsReturn {
+  stats: RealtimeStats
+  timeBuckets: TimeBucket[]
+  eventTypeCounts: EventTypeCount[]
+}
+
+const BUCKET_COUNT = 30
+const BUCKET_INTERVAL_S = 10
+const WINDOW_MS = BUCKET_COUNT * BUCKET_INTERVAL_S * 1000 // 5 min
+
+export function computeRealtimeStats(events: RealtimeEvent[]): UseRealtimeStatsReturn {
+  const now = Date.now()
+  const totalEvents = events.length
+
+  // Events per minute — count events with created_at within last 60s
+  const oneMinuteAgo = now - 60_000
+  const eventsPerMinute = events.filter(
+    (e) => new Date(e.created_at).getTime() >= oneMinuteAgo
+  ).length
+
+  // CAPI success rate
+  const forwarded = events.filter((e) => e.forwarded_to_capi).length
+  const capiSuccessRate = totalEvents > 0 ? Math.round((forwarded / totalEvents) * 100) : 0
+
+  // Event type counts
+  const typeMap = new Map<string, number>()
+  for (const e of events) {
+    typeMap.set(e.event_name, (typeMap.get(e.event_name) ?? 0) + 1)
+  }
+
+  const eventTypeCounts: EventTypeCount[] = [...typeMap.entries()]
+    .map(([name, count]) => ({
+      name,
+      count,
+      percentage: totalEvents > 0 ? Math.round((count / totalEvents) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+
+  const topEventType = eventTypeCounts[0]?.name ?? '-'
+
+  // Time buckets — 30 x 10s = 5 min window
+  const windowStart = now - WINDOW_MS
+  const timeBuckets: TimeBucket[] = Array.from({ length: BUCKET_COUNT }, (_, i) => {
+    const bucketStart = windowStart + i * BUCKET_INTERVAL_S * 1000
+    const mins = Math.floor(((i + 1) * BUCKET_INTERVAL_S) / 60)
+    const secs = ((i + 1) * BUCKET_INTERVAL_S) % 60
+    return {
+      label: `${mins}:${secs.toString().padStart(2, '0')}`,
+      count: 0,
+      _start: bucketStart,
+    }
+  })
+
+  for (const e of events) {
+    const t = new Date(e.created_at).getTime()
+    if (t < windowStart) continue
+    const idx = Math.min(
+      Math.floor((t - windowStart) / (BUCKET_INTERVAL_S * 1000)),
+      BUCKET_COUNT - 1
+    )
+    const bucket = timeBuckets[idx]
+    if (bucket) bucket.count++
+  }
+
+  // Remove internal _start field
+  const cleanBuckets = timeBuckets.map(({ label, count }) => ({ label, count }))
+
+  return {
+    stats: { eventsPerMinute, capiSuccessRate, topEventType, totalEvents },
+    timeBuckets: cleanBuckets,
+    eventTypeCounts,
+  }
+}
+
+export function useRealtimeStats(events: RealtimeEvent[]): UseRealtimeStatsReturn {
+  return useMemo(() => computeRealtimeStats(events), [events])
+}

--- a/frontend/src/pages/RealtimeEventsPage.tsx
+++ b/frontend/src/pages/RealtimeEventsPage.tsx
@@ -1,9 +1,20 @@
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Pause, Play, Trash2, Check, X } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Pause, Play, Trash2, Check, X, Zap, CheckCircle, Tag, Hash } from 'lucide-react'
 import { useRealtimeEvents } from '@/hooks/use-realtime-events'
+import { useRealtimeStats } from '@/hooks/use-realtime-stats'
 import { usePixels } from '@/hooks/use-pixels'
 import { formatDistanceToNow } from 'date-fns'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
 
 const eventBadgeVariant = (name: string) => {
   switch (name) {
@@ -22,9 +33,49 @@ const eventBadgeVariant = (name: string) => {
   }
 }
 
+interface StatCardProps {
+  title: string
+  value: number | string
+  subtitle?: string
+  icon: React.ReactNode
+}
+
+function StatCard({ title, value, subtitle, icon }: StatCardProps) {
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-neutral-500">{title}</p>
+            <p className="text-2xl font-bold text-neutral-900 mt-1">{value}</p>
+            {subtitle && <p className="text-xs text-neutral-400 mt-1">{subtitle}</p>}
+          </div>
+          <div className="h-10 w-10 rounded-lg bg-indigo-50 flex items-center justify-center text-indigo-600">
+            {icon}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  PageView: 'bg-neutral-400',
+  Purchase: 'bg-emerald-500',
+  Lead: 'bg-indigo-500',
+  CompleteRegistration: 'bg-indigo-400',
+  AddToCart: 'bg-amber-500',
+  InitiateCheckout: 'bg-amber-400',
+}
+
+function getEventColor(name: string): string {
+  return EVENT_TYPE_COLORS[name] ?? 'bg-neutral-300'
+}
+
 export function RealtimeEventsPage() {
   const { events, isLive, isPaused, togglePause, clear, pixelId, setPixelId } =
     useRealtimeEvents()
+  const { stats, timeBuckets, eventTypeCounts } = useRealtimeStats(events)
   const { data: pixels } = usePixels()
 
   return (
@@ -33,7 +84,14 @@ export function RealtimeEventsPage() {
         <div className="flex items-center gap-3">
           <div>
             <h1 className="text-2xl font-bold text-neutral-900">Realtime Events</h1>
-            <p className="text-sm text-neutral-500 mt-1">{events.length} events</p>
+            <p className="text-sm text-neutral-500 mt-1">
+              {events.length} events{' '}
+              {stats.eventsPerMinute > 0 && (
+                <span className="text-indigo-600 font-medium">
+                  ({stats.eventsPerMinute}/min)
+                </span>
+              )}
+            </p>
           </div>
           <Badge variant={isLive ? 'success' : 'warning'}>{isLive ? 'Live' : 'Paused'}</Badge>
         </div>
@@ -64,6 +122,107 @@ export function RealtimeEventsPage() {
         </select>
       </div>
 
+      {/* Stat Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <StatCard
+          title="Events/Min"
+          value={stats.eventsPerMinute}
+          subtitle="Last 60 seconds"
+          icon={<Zap className="h-5 w-5" />}
+        />
+        <StatCard
+          title="CAPI Success"
+          value={`${stats.capiSuccessRate}%`}
+          subtitle="Forwarded to Facebook"
+          icon={<CheckCircle className="h-5 w-5" />}
+        />
+        <StatCard
+          title="Top Event"
+          value={stats.topEventType}
+          subtitle={
+            eventTypeCounts[0]
+              ? `${eventTypeCounts[0].count} events (${eventTypeCounts[0].percentage}%)`
+              : undefined
+          }
+          icon={<Tag className="h-5 w-5" />}
+        />
+        <StatCard
+          title="Total Events"
+          value={stats.totalEvents.toLocaleString()}
+          subtitle="In current session"
+          icon={<Hash className="h-5 w-5" />}
+        />
+      </div>
+
+      {/* Charts */}
+      {events.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+          {/* Event Rate Chart */}
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="text-base">Event Rate (5 min window)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart data={timeBuckets}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 10, fill: '#737373' }}
+                    interval={4}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 12, fill: '#737373' }}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      borderRadius: '8px',
+                      border: '1px solid #e5e5e5',
+                      fontSize: '12px',
+                    }}
+                  />
+                  <Bar dataKey="count" fill="#4f46e5" radius={[2, 2, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+
+          {/* Event Type Breakdown */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Event Types</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {eventTypeCounts.slice(0, 6).map((type) => (
+                  <div key={type.name}>
+                    <div className="flex items-center justify-between mb-1">
+                      <Badge variant={eventBadgeVariant(type.name)} className="text-xs">
+                        {type.name}
+                      </Badge>
+                      <span className="text-xs text-neutral-500">
+                        {type.count} ({type.percentage}%)
+                      </span>
+                    </div>
+                    <div className="h-2 bg-neutral-100 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${getEventColor(type.name)}`}
+                        style={{ width: `${type.percentage}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+                {eventTypeCounts.length === 0 && (
+                  <p className="text-sm text-neutral-400 text-center py-4">No data</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Event Table */}
       {events.length === 0 ? (
         <div className="text-center py-16 border border-dashed border-neutral-300 rounded-lg">
           <div className="animate-pulse mb-3">


### PR DESCRIPTION
## Summary
- เพิ่ม 4 stat cards บนหน้า Realtime Events: Events/Min, CAPI Success Rate, Top Event, Total Events
- เพิ่ม BarChart แสดง event rate ทุก 10 วินาที (5 min window) และ Event Type Breakdown แบบ progress bars
- ลด polling interval จาก 5s เป็น 2s เพื่อให้ข้อมูลอัปเดตเร็วขึ้น
- ทั้งหมดเป็น frontend-only — คำนวณจาก event buffer ที่มีอยู่ ไม่มี backend changes

## Changes
| File | Action |
|------|--------|
| `frontend/src/hooks/use-realtime-stats.ts` | **NEW** — stats computation hook (pure function + useMemo) |
| `frontend/src/hooks/__tests__/use-realtime-stats.test.ts` | **NEW** — 9 unit tests |
| `frontend/src/hooks/use-realtime-events.ts` | **EDIT** — polling 5s → 2s |
| `frontend/src/pages/RealtimeEventsPage.tsx` | **EDIT** — stat cards, charts, breakdown UI |

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 14 tests passed (9 new)
- [x] `npm run build` — success
- [ ] Manual: verify stat cards update in realtime with live events
- [ ] Manual: verify bar chart shows correct 5-min distribution
- [ ] Manual: verify event type breakdown percentages match

🤖 Generated with [Claude Code](https://claude.com/claude-code)