### PR TITLE
feat: add fbc, fbp, country to CAPI user_data for EMQ improvement

### DIFF
--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -43,7 +43,20 @@ func (h *EventHandler) Ingest(w http.ResponseWriter, r *http.Request) {
 	clientIP := r.RemoteAddr
 	clientUA := r.Header.Get("User-Agent")
 
-	created, err := h.eventService.Ingest(r.Context(), customerID, input, clientIP, clientUA)
+	var fbc, fbp string
+	if c, err := r.Cookie("_fbc"); err == nil {
+		fbc = c.Value
+	}
+	if c, err := r.Cookie("_fbp"); err == nil {
+		fbp = c.Value
+	}
+
+	created, err := h.eventService.Ingest(r.Context(), customerID, input, service.ClientContext{
+		IP:        clientIP,
+		UserAgent: clientUA,
+		FBC:       fbc,
+		FBP:       fbp,
+	})
 	if err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "ingestion failed")
 		return

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,6 +37,14 @@ func NewEventService(
 	}
 }
 
+// ClientContext holds HTTP request data for enriching CAPI user_data.
+type ClientContext struct {
+	IP        string
+	UserAgent string
+	FBC       string // _fbc cookie (Facebook Click ID)
+	FBP       string // _fbp cookie (Facebook Browser ID)
+}
+
 type IngestEventInput struct {
 	PixelID   string          `json:"pixel_id" validate:"required"`
 	EventName string          `json:"event_name" validate:"required"`
@@ -49,7 +59,7 @@ type IngestBatchInput struct {
 	Events []IngestEventInput `json:"events" validate:"required,min=1,max=100"`
 }
 
-func (s *EventService) Ingest(ctx context.Context, customerID string, input IngestBatchInput, clientIP, clientUA string) (int, error) {
+func (s *EventService) Ingest(ctx context.Context, customerID string, input IngestBatchInput, client ClientContext) (int, error) {
 	created := 0
 	for _, eventInput := range input.Events {
 		// Verify pixel belongs to customer
@@ -75,9 +85,9 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 			eventData = json.RawMessage(`{}`)
 		}
 
-		// Strip port from clientIP
-		ip := clientIP
-		if host, _, err := net.SplitHostPort(clientIP); err == nil {
+		// Strip port from client IP
+		ip := client.IP
+		if host, _, err := net.SplitHostPort(client.IP); err == nil {
 			ip = host
 		}
 
@@ -96,7 +106,7 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 			EventTime:       eventTime,
 			EventID:         eventID,
 			ClientIP:        ip,
-			ClientUserAgent: clientUA,
+			ClientUserAgent: client.UserAgent,
 		}
 
 		if err := s.eventRepo.Create(ctx, event); err != nil {
@@ -105,14 +115,14 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 		}
 
 		// Forward to Facebook CAPI asynchronously
-		go s.forwardToCAPI(context.Background(), event, pixel)
+		go s.forwardToCAPI(context.Background(), event, pixel, client)
 
 		created++
 	}
 	return created, nil
 }
 
-func (s *EventService) forwardToCAPI(ctx context.Context, event *domain.PixelEvent, pixel *domain.Pixel) {
+func (s *EventService) forwardToCAPI(ctx context.Context, event *domain.PixelEvent, pixel *domain.Pixel, client ClientContext) {
 	var customData map[string]interface{}
 	if event.EventData != nil {
 		_ = json.Unmarshal(event.EventData, &customData)
@@ -132,6 +142,27 @@ func (s *EventService) forwardToCAPI(ctx context.Context, event *domain.PixelEve
 	}
 	if event.ClientUserAgent != "" {
 		userData["client_user_agent"] = event.ClientUserAgent
+	}
+
+	// Facebook Click ID — priority: SDK > cookie > fbclid in URL
+	if _, exists := userData["fbc"]; !exists {
+		if isValidFBCookie(client.FBC) {
+			userData["fbc"] = client.FBC
+		} else if fbclid := extractFBClid(event.SourceURL); fbclid != "" {
+			userData["fbc"] = fmt.Sprintf("fb.1.%d.%s", event.EventTime.UnixMilli(), fbclid)
+		}
+	}
+
+	// Facebook Browser ID — priority: SDK > cookie
+	if _, exists := userData["fbp"]; !exists {
+		if isValidFBCookie(client.FBP) {
+			userData["fbp"] = client.FBP
+		}
+	}
+
+	// Default country for Thailand
+	if _, exists := userData["country"]; !exists {
+		userData["country"] = defaultCountry
 	}
 
 	// Hash PII fields
@@ -197,7 +228,12 @@ func (s *EventService) ListLatest(ctx context.Context, customerID, pixelID strin
 	return events, nil
 }
 
-const realtimeEventLimit = 50
+const (
+	realtimeEventLimit = 50
+	maxFBCookieLen     = 500 // max length for _fbc/_fbp cookie values
+	maxFBClidLen       = 200 // max length for fbclid URL parameter
+	defaultCountry     = "th" // Pixlinks v1 operates in Thailand only
+)
 
 func (s *EventService) ListRecent(ctx context.Context, customerID string, since time.Time, pixelID string) ([]*domain.RealtimeEvent, error) {
 	events, err := s.eventRepo.ListRecentByCustomerID(ctx, customerID, since, pixelID, realtimeEventLimit)
@@ -216,4 +252,29 @@ func (s *EventService) GetByID(ctx context.Context, id string) (*domain.PixelEve
 		return nil, fmt.Errorf("get event: %w", err)
 	}
 	return event, nil
+}
+
+// isValidFBCookie checks that a Facebook cookie value has the expected "fb." prefix
+// and does not exceed the maximum allowed length.
+func isValidFBCookie(value string) bool {
+	return value != "" && len(value) <= maxFBCookieLen && strings.HasPrefix(value, "fb.")
+}
+
+// extractFBClid extracts the fbclid query parameter from an HTTP(S) URL.
+func extractFBClid(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	fbclid := u.Query().Get("fbclid")
+	if len(fbclid) > maxFBClidLen {
+		return ""
+	}
+	return fbclid
 }

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,12 +166,132 @@ func TestEventService_Ingest(t *testing.T) {
 			svc, eventRepo, pixelRepo := newTestEventService()
 			tt.setup(eventRepo, pixelRepo)
 
-			created, err := svc.Ingest(context.Background(), tt.customerID, tt.input, "192.168.1.1:12345", "TestAgent/1.0")
+			created, err := svc.Ingest(context.Background(), tt.customerID, tt.input, ClientContext{
+				IP:        "192.168.1.1:12345",
+				UserAgent: "TestAgent/1.0",
+			})
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCreated, created)
 			eventRepo.AssertExpectations(t)
 			pixelRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEventService_Ingest_WithFBCookies(t *testing.T) {
+	svc, eventRepo, pixelRepo := newTestEventService()
+
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID:            "pixel-1",
+		CustomerID:    "cust-1",
+		IsActive:      true,
+		FBPixelID:     "fb-pixel-1",
+		FBAccessToken: "token-1",
+	}, nil)
+	eventRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(nil)
+
+	input := IngestBatchInput{
+		Events: []IngestEventInput{
+			{
+				PixelID:   "pixel-1",
+				EventName: "PageView",
+				EventData: json.RawMessage(`{}`),
+			},
+		},
+	}
+
+	created, err := svc.Ingest(context.Background(), "cust-1", input, ClientContext{
+		IP:        "10.0.0.1",
+		UserAgent: "TestAgent/1.0",
+		FBC:       "fb.1.1709150000000.test123",
+		FBP:       "fb.1.1709150000000.456789",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, created)
+	eventRepo.AssertExpectations(t)
+	pixelRepo.AssertExpectations(t)
+}
+
+func TestExtractFBClid(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputURL string
+		expected string
+	}{
+		{
+			name:     "URL with fbclid",
+			inputURL: "https://example.com?fbclid=abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "URL without fbclid",
+			inputURL: "https://example.com?utm=test",
+			expected: "",
+		},
+		{
+			name:     "empty URL",
+			inputURL: "",
+			expected: "",
+		},
+		{
+			name:     "malformed URL",
+			inputURL: "://bad",
+			expected: "",
+		},
+		{
+			name:     "fbclid with empty value",
+			inputURL: "https://example.com?fbclid=",
+			expected: "",
+		},
+		{
+			name:     "fbclid among multiple params",
+			inputURL: "https://example.com?utm_source=fb&fbclid=xyz789&ref=home",
+			expected: "xyz789",
+		},
+		{
+			name:     "non-http scheme rejected",
+			inputURL: "javascript:void(0)?fbclid=evil",
+			expected: "",
+		},
+		{
+			name:     "http scheme accepted",
+			inputURL: "http://example.com?fbclid=abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "relative URL rejected (no scheme)",
+			inputURL: "/path?fbclid=abc",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractFBClid(tt.inputURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsValidFBCookie(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{"valid fbc", "fb.1.1709150000000.test123", true},
+		{"valid fbp", "fb.1.1709150000000.456789", true},
+		{"empty string", "", false},
+		{"no fb prefix", "notfb.1.123.abc", false},
+		{"too long", "fb." + strings.Repeat("x", 500), false},
+		{"just fb.", "fb.", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isValidFBCookie(tt.value))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add `ClientContext` struct to carry HTTP cookies (fbc/fbp) alongside IP/User-Agent through the event ingestion pipeline
- Enrich Facebook CAPI `user_data` with `fbc` (click ID), `fbp` (browser ID), and default `country` ("th") to improve Event Match Quality score
- Cookie values validated with `fb.` prefix check and 500-char length cap; `fbclid` URL extraction restricted to HTTP(S) with 200-char limit
- Priority chain: SDK-provided user_data > cookie > URL-extracted fbclid (no overwrite)

## Files Changed (3)
- `backend/internal/service/event_service.go` — `ClientContext`, `isValidFBCookie`, `extractFBClid`, enrichment in `forwardToCAPI`
- `backend/internal/handler/event_handler.go` — Read `_fbc`/`_fbp` cookies, pass `ClientContext` to `Ingest`
- `backend/internal/service/event_service_test.go` — Updated `Ingest` call sites, added `TestExtractFBClid` (9 cases), `TestIsValidFBCookie` (6 cases), `TestEventService_Ingest_WithFBCookies`

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all existing + 17 new test cases)
- [ ] Manual test: send event with `_fbc`/`_fbp` cookies via curl, verify CAPI payload includes fbc/fbp/country
- [ ] After deploy: check Facebook Events Manager → Test Events for fbc/fbp/country fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)