### PR TITLE
feat: send user_data from sale pages and improve IP extraction for EMQ

### DIFF
--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"encoding/json"
 	"math"
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -40,7 +42,7 @@ func (h *EventHandler) Ingest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientIP := r.RemoteAddr
+	clientIP := extractClientIP(r)
 	clientUA := r.Header.Get("User-Agent")
 
 	var fbc, fbp string
@@ -163,4 +165,24 @@ func (h *EventHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	JSON(w, http.StatusOK, APIResponse{Data: event})
+}
+
+// extractClientIP returns the real client IP by checking CDN/proxy headers first,
+// then falling back to r.RemoteAddr. This improves Facebook EMQ score by providing
+// the actual visitor IP instead of a load balancer or proxy address.
+//
+// Note: r.RemoteAddr may already be normalised by chimiddleware.RealIP (registered
+// globally in router.go), which rewrites it from X-Real-IP / X-Forwarded-For.
+func extractClientIP(r *http.Request) string {
+	for _, h := range []string{"CF-Connecting-IP", "True-Client-IP"} {
+		if raw := r.Header.Get(h); raw != "" {
+			if ip := net.ParseIP(strings.TrimSpace(raw)); ip != nil {
+				return ip.String()
+			}
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/backend/internal/handler/event_handler_test.go
+++ b/backend/internal/handler/event_handler_test.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractClientIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		remote   string
+		expected string
+	}{
+		{
+			name:     "CF-Connecting-IP header takes priority",
+			headers:  map[string]string{"CF-Connecting-IP": "1.2.3.4"},
+			remote:   "10.0.0.1:12345",
+			expected: "1.2.3.4",
+		},
+		{
+			name:     "True-Client-IP fallback when no CF header",
+			headers:  map[string]string{"True-Client-IP": "5.6.7.8"},
+			remote:   "10.0.0.1:12345",
+			expected: "5.6.7.8",
+		},
+		{
+			name:     "CF-Connecting-IP wins over True-Client-IP",
+			headers:  map[string]string{"CF-Connecting-IP": "1.2.3.4", "True-Client-IP": "5.6.7.8"},
+			remote:   "10.0.0.1:12345",
+			expected: "1.2.3.4",
+		},
+		{
+			name:     "RemoteAddr with port stripped",
+			headers:  map[string]string{},
+			remote:   "192.168.1.1:54321",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "RemoteAddr without port returned as-is",
+			headers:  map[string]string{},
+			remote:   "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "IPv6 RemoteAddr with port stripped",
+			headers:  map[string]string{},
+			remote:   "[::1]:8080",
+			expected: "::1",
+		},
+		{
+			name:     "invalid header value falls back to RemoteAddr",
+			headers:  map[string]string{"CF-Connecting-IP": "not-an-ip"},
+			remote:   "10.0.0.1:12345",
+			expected: "10.0.0.1",
+		},
+		{
+			name:     "header with leading/trailing whitespace trimmed",
+			headers:  map[string]string{"CF-Connecting-IP": " 1.2.3.4 "},
+			remote:   "10.0.0.1:12345",
+			expected: "1.2.3.4",
+		},
+		{
+			name:     "comma-separated list in header falls back to RemoteAddr",
+			headers:  map[string]string{"CF-Connecting-IP": "1.2.3.4, 10.0.0.1"},
+			remote:   "172.16.0.1:8080",
+			expected: "172.16.0.1",
+		},
+		{
+			name:     "empty header value ignored",
+			headers:  map[string]string{"CF-Connecting-IP": "", "True-Client-IP": ""},
+			remote:   "10.0.0.1:12345",
+			expected: "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest("POST", "/api/v1/events/ingest", nil)
+			for k, v := range tt.headers {
+				r.Header.Set(k, v)
+			}
+			r.RemoteAddr = tt.remote
+
+			got := extractClientIP(r)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -136,6 +136,37 @@ func TestEventService_Ingest(t *testing.T) {
 			wantCreated: 1,
 		},
 		{
+			name:       "sdk user_data fields pass through to stored event",
+			customerID: "cust-1",
+			input: IngestBatchInput{
+				Events: []IngestEventInput{
+					{
+						PixelID:   "pixel-1",
+						EventName: "PageView",
+						EventData: json.RawMessage(`{}`),
+						UserData:  json.RawMessage(`{"fbp":"fb.1.1709150000000.456789","fbc":"fb.1.1709150000000.test123","external_id":"usr-ext-001"}`),
+					},
+				},
+			},
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID:         "pixel-1",
+					CustomerID: "cust-1",
+					IsActive:   true,
+				}, nil)
+				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
+					var ud map[string]interface{}
+					if err := json.Unmarshal(e.UserData, &ud); err != nil {
+						return false
+					}
+					return ud["fbp"] == "fb.1.1709150000000.456789" &&
+						ud["fbc"] == "fb.1.1709150000000.test123" &&
+						ud["external_id"] == "usr-ext-001"
+				})).Return(nil)
+			},
+			wantCreated: 1,
+		},
+		{
 			name:       "event_id generated when empty",
 			customerID: "cust-1",
 			input: IngestBatchInput{
@@ -167,7 +198,7 @@ func TestEventService_Ingest(t *testing.T) {
 			tt.setup(eventRepo, pixelRepo)
 
 			created, err := svc.Ingest(context.Background(), tt.customerID, tt.input, ClientContext{
-				IP:        "192.168.1.1:12345",
+				IP:        "192.168.1.1",
 				UserAgent: "TestAgent/1.0",
 			})
 

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -188,6 +188,40 @@
             });
         }
 
+        function getCookie(name) {
+            var match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+            return match ? decodeURIComponent(match[1]) : '';
+        }
+
+        function getUserData() {
+            var ud = {};
+            var fbpVal = getCookie('_fbp');
+            var fbcVal = getCookie('_fbc');
+            if (fbpVal) ud.fbp = fbpVal;
+            if (fbcVal) {
+                ud.fbc = fbcVal;
+            } else {
+                var search = window.location.search.substring(1);
+                var pairs = search.split('&');
+                for (var i = 0; i < pairs.length; i++) {
+                    var pair = pairs[i].split('=');
+                    if (decodeURIComponent(pair[0]) === 'fbclid') {
+                        ud.fbc = 'fb.1.' + Date.now() + '.' + decodeURIComponent(pair[1] || '');
+                        break;
+                    }
+                }
+            }
+            if (fbpVal) {
+                ud.external_id = fbpVal;
+            } else {
+                var eid = '';
+                try { eid = localStorage.getItem('_px_eid') || ''; } catch(e) {}
+                if (!eid) { eid = genId(); try { localStorage.setItem('_px_eid', eid); } catch(e) {} }
+                ud.external_id = eid;
+            }
+            return ud;
+        }
+
         function dualTrack(eventName, params) {
             var eid = genId();
             if (typeof fbq === 'function') {
@@ -206,6 +240,7 @@
                             pixel_id: '{{deref .Page.PixelID}}',
                             event_name: eventName,
                             event_data: params || {},
+                            user_data: getUserData(),
                             source_url: window.location.href,
                             event_time: new Date().toISOString(),
                             event_id: eid

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -289,6 +289,40 @@
             });
         }
 
+        function getCookie(name) {
+            var match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+            return match ? decodeURIComponent(match[1]) : '';
+        }
+
+        function getUserData() {
+            var ud = {};
+            var fbpVal = getCookie('_fbp');
+            var fbcVal = getCookie('_fbc');
+            if (fbpVal) ud.fbp = fbpVal;
+            if (fbcVal) {
+                ud.fbc = fbcVal;
+            } else {
+                var search = window.location.search.substring(1);
+                var pairs = search.split('&');
+                for (var i = 0; i < pairs.length; i++) {
+                    var pair = pairs[i].split('=');
+                    if (decodeURIComponent(pair[0]) === 'fbclid') {
+                        ud.fbc = 'fb.1.' + Date.now() + '.' + decodeURIComponent(pair[1] || '');
+                        break;
+                    }
+                }
+            }
+            if (fbpVal) {
+                ud.external_id = fbpVal;
+            } else {
+                var eid = '';
+                try { eid = localStorage.getItem('_px_eid') || ''; } catch(e) {}
+                if (!eid) { eid = genId(); try { localStorage.setItem('_px_eid', eid); } catch(e) {} }
+                ud.external_id = eid;
+            }
+            return ud;
+        }
+
         function dualTrack(eventName, params) {
             var eid = genId();
             if (typeof fbq === 'function') {
@@ -307,6 +341,7 @@
                             pixel_id: '{{deref .Page.PixelID}}',
                             event_name: eventName,
                             event_data: params || {},
+                            user_data: getUserData(),
                             source_url: window.location.href,
                             event_time: new Date().toISOString(),
                             event_id: eid


### PR DESCRIPTION
## Summary
- Sale page JavaScript (`simple.html`, `blocks.html`) now sends `user_data` (fbp, fbc, external_id) via request body, fixing the cross-domain cookie issue that prevented Facebook from receiving browser/click identifiers
- Added `extractClientIP()` helper with `net.ParseIP` validation that checks CF-Connecting-IP → True-Client-IP → RemoteAddr for accurate visitor IP
- Added 10 table-driven tests for IP extraction (including edge cases: invalid IP, whitespace, comma-separated list) and 1 test for user_data pass-through

## Expected Impact
| Parameter | Before | After |
|-----------|--------|-------|
| fbp | 11% | ~90%+ |
| fbc | 0% | ~30-50% (FB ad traffic only) |
| external_id | 44% | ~95%+ |
| IP | 55% | ~90%+ |
| **EMQ** | **3.7/10** | **~6-7/10** |

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (10 handler tests + 1 service test added)
- [x] Pre-push quality gates pass
- [ ] CI pipeline (lint → vet → test → build)
- [ ] After deploy: open sale page, verify Network tab shows `user_data` with fbp/fbc/external_id
- [ ] After 48h: check EMQ score in Facebook Events Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)