### PR TITLE
refactor: remove browser pixel, send events via CAPI only

### DIFF
--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -153,26 +153,6 @@
         </div>
     </div>
 
-    {{if .FBPixelID}}
-    <!-- Meta Pixel Code -->
-    <script>
-    !function(f,b,e,v,n,t,s)
-    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-    n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t,s)}(window,document,'script',
-    'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '{{.FBPixelID}}');
-    fbq('track', 'PageView');
-    </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id={{.FBPixelID}}&ev=PageView&noscript=1"
-    /></noscript>
-    <!-- End Meta Pixel Code -->
-    {{end}}
-
     <script>
     (function() {
         var ctaEventName = '{{.BlocksContent.Tracking.CTAEventName}}' || 'Lead';
@@ -224,9 +204,6 @@
 
         function dualTrack(eventName, params) {
             var eid = genId();
-            if (typeof fbq === 'function') {
-                fbq('track', eventName, params, {eventID: eid});
-            }
             {{if and .APIKey .Page.PixelID}}
             try {
                 fetch('{{.BaseURL}}/api/v1/events/ingest', {

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -254,26 +254,6 @@
         </div>
     </div>
 
-    {{if .FBPixelID}}
-    <!-- Meta Pixel Code -->
-    <script>
-    !function(f,b,e,v,n,t,s)
-    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-    n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t,s)}(window,document,'script',
-    'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '{{.FBPixelID}}');
-    fbq('track', 'PageView');
-    </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id={{.FBPixelID}}&ev=PageView&noscript=1"
-    /></noscript>
-    <!-- End Meta Pixel Code -->
-    {{end}}
-
     <script>
     (function() {
         var ctaEventName = '{{.Content.Tracking.CTAEventName}}' || 'Lead';
@@ -325,9 +305,6 @@
 
         function dualTrack(eventName, params) {
             var eid = genId();
-            if (typeof fbq === 'function') {
-                fbq('track', eventName, params, {eventID: eid});
-            }
             {{if and .APIKey .Page.PixelID}}
             try {
                 fetch('{{.BaseURL}}/api/v1/events/ingest', {


### PR DESCRIPTION
## Summary
- Remove Meta Pixel base code (`fbevents.js`) and `fbq('track', ...)` calls from both sale page templates
- Events now sent exclusively through Conversions API via backend — no browser-side pixel
- More reliable tracking: immune to ad blockers, single event source simplifies dedup

## Test plan
- [x] `go vet` + `go test -race` pass
- [x] Pre-push quality gates pass
- [ ] CI pipeline
- [ ] After deploy: verify sale page no longer loads `fbevents.js` (Network tab)
- [ ] Verify CAPI events still arrive in Facebook Events Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)