### PR TITLE
fix: nullable error_message causes 500 on replay list

### DIFF
--- a/backend/internal/domain/replay.go
+++ b/backend/internal/domain/replay.go
@@ -16,7 +16,7 @@ type ReplaySession struct {
 	DateTo         *time.Time `json:"date_to,omitempty"`
 	TimeMode       string     `json:"time_mode"`
 	BatchDelayMs   int        `json:"batch_delay_ms"`
-	ErrorMessage   string     `json:"error_message,omitempty"`
+	ErrorMessage   *string    `json:"error_message,omitempty"`
 	StartedAt      *time.Time `json:"started_at,omitempty"`
 	CompletedAt    *time.Time `json:"completed_at,omitempty"`
 	CreatedAt      time.Time  `json:"created_at"`


### PR DESCRIPTION
## Summary

- `ErrorMessage` field in `ReplaySession` domain model was `string` but DB column `error_message` is nullable `TEXT`
- pgx cannot scan SQL NULL into Go `string`, causing 500 on `GET /api/v1/replays` when any replay session exists
- Fix: change to `*string` which pgx can scan NULL into as `nil`

## Test plan

- [x] `go vet ./...` + `go test -race ./...` pass
- [ ] E2E: navigate to Replay Center, verify replay history loads without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)