### PR TITLE
fix: resolve event_id VARCHAR(36) overflow breaking all event ingestion

### DIFF
--- a/backend/db/migrations/000010_widen_event_id.down.sql
+++ b/backend/db/migrations/000010_widen_event_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pixel_events ALTER COLUMN event_id TYPE VARCHAR(36);

--- a/backend/db/migrations/000010_widen_event_id.up.sql
+++ b/backend/db/migrations/000010_widen_event_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pixel_events ALTER COLUMN event_id TYPE VARCHAR(64);

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -225,7 +225,7 @@
                     user_data: getUserData(),
                     source_url: window.location.href,
                     event_time: new Date().toISOString(),
-                    event_id: eid + '-' + pid.substr(0, 8)
+                    event_id: eid
                 };
             });
             try {

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -326,7 +326,7 @@
                     user_data: getUserData(),
                     source_url: window.location.href,
                     event_time: new Date().toISOString(),
-                    event_id: eid + '-' + pid.substr(0, 8)
+                    event_id: eid
                 };
             });
             try {


### PR DESCRIPTION
## Summary
- **Root cause**: Template JS generated `event_id` as `UUID + '-' + pixelID.substr(0,8)` = 45 chars, but DB column was `VARCHAR(36)` — causing 100% event ingestion failure since multi-pixel deploy
- Reverted `event_id` to UUID-only format in both `simple.html` and `blocks.html` templates — composite index `(pixel_id, event_id)` already ensures per-pixel uniqueness
- Added safety migration widening `event_id` column to `VARCHAR(64)` to prevent similar issues in the future
- Migration already applied to production Neon database

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [x] Migration applied to production DB — verified `event_id` column is now VARCHAR(64)
- [ ] After deploy: verify events are being stored (check `pixel_events` table for new records)
- [ ] After deploy: verify no `[ERRO] create event failed` in backend logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)