### PR TITLE
fix: add replay concurrency limit, CAPI rate limit retry, and orphan recovery

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/jaochai/pixlinks/backend/internal/config"
+	"github.com/jaochai/pixlinks/backend/internal/repository/postgres"
 	"github.com/jaochai/pixlinks/backend/internal/router"
 )
 
@@ -63,6 +64,15 @@ func main() {
 	if err := runMigrations(cfg.DatabaseURL, logger); err != nil {
 		logger.Error("failed to run migrations", "error", err)
 		os.Exit(1)
+	}
+
+	// Recover orphaned replay sessions from previous crash/restart
+	replaySessionRepo := postgres.NewReplaySessionRepo(pool)
+	recovered, err := replaySessionRepo.RecoverOrphanedSessions(context.Background())
+	if err != nil {
+		logger.Error("failed to recover orphaned replay sessions", "error", err)
+	} else if recovered > 0 {
+		logger.Warn("recovered orphaned replay sessions", "count", recovered)
 	}
 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())

--- a/backend/internal/facebook/capi.go
+++ b/backend/internal/facebook/capi.go
@@ -111,6 +111,15 @@ func IsAuthError(err error) bool {
 	return false
 }
 
+// IsRateLimitError checks if the error is a CAPIError with a 429 status code.
+func IsRateLimitError(err error) bool {
+	var capiErr *CAPIError
+	if errors.As(err, &capiErr) {
+		return capiErr.StatusCode == 429
+	}
+	return false
+}
+
 func (c *CAPIClient) SendEvent(ctx context.Context, pixelID, accessToken, testEventCode string, event CAPIEvent) (*CAPIResponse, error) {
 	return c.SendEvents(ctx, pixelID, accessToken, testEventCode, []CAPIEvent{event})
 }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -46,6 +46,7 @@ type ReplaySessionRepository interface {
 	GetStatus(ctx context.Context, id string) (string, error)
 	UpdateFailedBatches(ctx context.Context, id string, failedBatchRanges []byte) error
 	CancelSession(ctx context.Context, id string) (*domain.ReplaySession, error)
+	RecoverOrphanedSessions(ctx context.Context) (int, error)
 }
 
 type SalePageRepository interface {

--- a/backend/internal/repository/postgres/replay_session_repo.go
+++ b/backend/internal/repository/postgres/replay_session_repo.go
@@ -127,3 +127,19 @@ func (r *ReplaySessionRepo) UpdateFailedBatches(ctx context.Context, id string, 
 	)
 	return err
 }
+
+func (r *ReplaySessionRepo) RecoverOrphanedSessions(ctx context.Context) (int, error) {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE replay_sessions
+		 SET status = 'failed',
+		     error_message = CASE
+		         WHEN status = 'running' THEN 'server restarted during replay'
+		         ELSE 'server restarted before replay started'
+		     END,
+		     completed_at = NOW()
+		 WHERE status IN ('running', 'pending')`)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -43,7 +43,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 	authService := service.NewAuthService(customerRepo, refreshTokenRepo, cfg)
 	pixelService := service.NewPixelService(pixelRepo, capiClient, logger)
 	eventService := service.NewEventService(eventRepo, pixelRepo, capiClient, logger)
-	replayService := service.NewReplayService(shutdownCtx, replaySessionRepo, eventRepo, pixelRepo, capiClient, logger)
+	replayService := service.NewReplayService(shutdownCtx, replaySessionRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 	analyticsService := service.NewAnalyticsService(pool)
 	salePageService := service.NewSalePageService(salePageRepo, customerRepo, pixelRepo)
 

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -206,3 +206,7 @@ func (m *MockReplaySessionRepo) CancelSession(ctx context.Context, id string) (*
 	}
 	return args.Get(0).(*domain.ReplaySession), args.Error(1)
 }
+func (m *MockReplaySessionRepo) RecoverOrphanedSessions(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Int(0), args.Error(1)
+}

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -25,6 +25,11 @@ var ErrInvalidDateFormat = errors.New("invalid date format, expected RFC3339")
 
 const timeModeOriginal = "original"
 
+const (
+	maxRetries        = 3
+	defaultBatchDelay = 200 * time.Millisecond
+)
+
 type ReplayService struct {
 	replayRepo  repository.ReplaySessionRepository
 	eventRepo   repository.EventRepository
@@ -33,6 +38,7 @@ type ReplayService struct {
 	logger      *slog.Logger
 	shutdownCtx context.Context
 	wg          sync.WaitGroup
+	sem         chan struct{} // concurrent replay limiter
 }
 
 func NewReplayService(
@@ -42,7 +48,11 @@ func NewReplayService(
 	pixelRepo repository.PixelRepository,
 	capiClient *facebook.CAPIClient,
 	logger *slog.Logger,
+	maxConcurrentReplays int,
 ) *ReplayService {
+	if maxConcurrentReplays <= 0 {
+		maxConcurrentReplays = 5
+	}
 	return &ReplayService{
 		replayRepo:  replayRepo,
 		eventRepo:   eventRepo,
@@ -50,6 +60,7 @@ func NewReplayService(
 		capiClient:  capiClient,
 		logger:      logger,
 		shutdownCtx: shutdownCtx,
+		sem:         make(chan struct{}, maxConcurrentReplays),
 	}
 }
 
@@ -157,14 +168,51 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		return nil, fmt.Errorf("create replay session: %w", err)
 	}
 
-	// Start replay in background
+	// Start replay in background (semaphore-limited)
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		s.executeReplay(s.shutdownCtx, session, targetPixel, events)
+		select {
+		case s.sem <- struct{}{}:
+			defer func() { <-s.sem }()
+			s.executeReplay(s.shutdownCtx, session, targetPixel, events)
+		case <-s.shutdownCtx.Done():
+			s.logger.Warn("replay skipped due to shutdown", "session_id", session.ID)
+			writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := s.replayRepo.UpdateStatusWithError(writeCtx, session.ID, "failed", "server shutdown before replay started"); err != nil {
+				s.logger.Error("failed to mark session failed on shutdown", "error", err, "session_id", session.ID)
+			}
+		}
 	}()
 
 	return &CreateReplayResult{Session: session, Warning: warning}, nil
+}
+
+func (s *ReplayService) sendBatchWithRetry(ctx context.Context, pixelID, accessToken string, events []facebook.CAPIEvent) (*facebook.CAPIResponse, error) {
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		resp, err := s.capiClient.SendEvents(ctx, pixelID, accessToken, "", events)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if facebook.IsAuthError(err) {
+			return nil, err // fail fast
+		}
+		if facebook.IsRateLimitError(err) && attempt < maxRetries {
+			backoff := time.Duration(1<<uint(attempt)) * time.Second // 1s, 2s, 4s
+			s.logger.Warn("CAPI rate limited, retrying", "attempt", attempt+1, "backoff", backoff)
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		break // other errors don't retry
+	}
+	return nil, lastErr
 }
 
 func (s *ReplayService) executeReplay(ctx context.Context, session *domain.ReplaySession, targetPixel *domain.Pixel, events []*domain.PixelEvent) {
@@ -241,7 +289,7 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 
 		// Replay sends to the live endpoint; test_event_code is intentionally
 		// omitted so replayed events do not appear in FB Test Events tool.
-		_, err = s.capiClient.SendEvents(ctx, targetPixel.FBPixelID, targetPixel.FBAccessToken, "", capiEvents)
+		_, err = s.sendBatchWithRetry(ctx, targetPixel.FBPixelID, targetPixel.FBAccessToken, capiEvents)
 		if err != nil {
 			lastErr = err
 			// Fail-fast on auth error (any batch) — token is invalid, no point continuing
@@ -264,8 +312,16 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 		}
 
 		// Batch delay between batches (skip after the last batch)
-		if session.BatchDelayMs > 0 && end < len(events) {
-			time.Sleep(time.Duration(session.BatchDelayMs) * time.Millisecond)
+		delay := time.Duration(session.BatchDelayMs) * time.Millisecond
+		if delay == 0 {
+			delay = defaultBatchDelay
+		}
+		if end < len(events) {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 
@@ -491,11 +547,22 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 		return nil, fmt.Errorf("create retry replay session: %w", err)
 	}
 
-	// Start replay in background
+	// Start replay in background (semaphore-limited)
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		s.executeReplay(s.shutdownCtx, newSession, targetPixel, retryEvents)
+		select {
+		case s.sem <- struct{}{}:
+			defer func() { <-s.sem }()
+			s.executeReplay(s.shutdownCtx, newSession, targetPixel, retryEvents)
+		case <-s.shutdownCtx.Done():
+			s.logger.Warn("replay skipped due to shutdown", "session_id", newSession.ID)
+			writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := s.replayRepo.UpdateStatusWithError(writeCtx, newSession.ID, "failed", "server shutdown before replay started"); err != nil {
+				s.logger.Error("failed to mark session failed on shutdown", "error", err, "session_id", newSession.ID)
+			}
+		}
 	}()
 
 	return newSession, nil

--- a/backend/internal/service/replay_service_test.go
+++ b/backend/internal/service/replay_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -18,12 +19,16 @@ import (
 )
 
 func newTestReplayService() (*ReplayService, *MockReplaySessionRepo, *MockEventRepo, *MockPixelRepo) {
+	return newTestReplayServiceWithConcurrency(5)
+}
+
+func newTestReplayServiceWithConcurrency(maxConcurrent int) (*ReplayService, *MockReplaySessionRepo, *MockEventRepo, *MockPixelRepo) {
 	replayRepo := new(MockReplaySessionRepo)
 	eventRepo := new(MockEventRepo)
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient("http://localhost:9999")
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, maxConcurrent)
 	return svc, replayRepo, eventRepo, pixelRepo
 }
 
@@ -254,7 +259,7 @@ func TestReplayService_ExecuteReplay_AuthErrorFailFast(t *testing.T) {
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient(fakeServer.URL)
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 
 	session := &domain.ReplaySession{
 		ID:            "session-1",
@@ -309,7 +314,7 @@ func TestReplayService_ExecuteReplay_TimeModeCurrentUsesNow(t *testing.T) {
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient(fakeServer.URL)
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 
 	oldTime := time.Now().Add(-30 * 24 * time.Hour) // 30 days ago
 	session := &domain.ReplaySession{
@@ -361,7 +366,7 @@ func TestReplayService_ExecuteReplay_BatchDelay(t *testing.T) {
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient(fakeServer.URL)
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 
 	session := &domain.ReplaySession{
 		ID:            "session-1",
@@ -412,7 +417,7 @@ func TestReplayService_ExecuteReplay_NonAuthErrorContinues(t *testing.T) {
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient(fakeServer.URL)
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 
 	session := &domain.ReplaySession{
 		ID:            "session-1",
@@ -459,7 +464,7 @@ func TestReplayService_ExecuteReplay_CancellationCheck(t *testing.T) {
 	pixelRepo := new(MockPixelRepo)
 	capiClient := facebook.NewCAPIClient(fakeServer.URL)
 	logger := slog.Default()
-	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger)
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
 
 	session := &domain.ReplaySession{
 		ID:            "session-1",
@@ -928,4 +933,210 @@ func TestReplayService_Retry(t *testing.T) {
 			replayRepo.AssertExpectations(t)
 		})
 	}
+}
+
+func TestReplayService_Create_SemaphoreBlock(t *testing.T) {
+	// Use maxConcurrent=1 to test semaphore blocking
+	svc, replayRepo, eventRepo, pixelRepo := newTestReplayServiceWithConcurrency(1)
+
+	// Set up pixel mocks
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
+	}, nil)
+	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+		Return([]*domain.PixelEvent{
+			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
+		}, nil)
+	replayRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.ReplaySession")).Return(nil)
+	replayRepo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil).Maybe()
+	replayRepo.On("UpdateProgress", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return(nil).Maybe()
+	replayRepo.On("UpdateStatusWithError", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil).Maybe()
+	replayRepo.On("GetStatus", mock.Anything, mock.AnythingOfType("string")).Return("running", nil).Maybe()
+	replayRepo.On("UpdateFailedBatches", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8")).Return(nil).Maybe()
+
+	// Fill the semaphore (cap=1)
+	svc.sem <- struct{}{}
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-2"}
+	result, err := svc.Create(context.Background(), "cust-1", input)
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Give goroutine a moment to start and block on semaphore
+	time.Sleep(50 * time.Millisecond)
+
+	// Release semaphore so goroutine can proceed
+	<-svc.sem
+
+	// Wait for background goroutine to finish
+	svc.Shutdown()
+}
+
+func TestReplayService_Create_ShutdownDuringSemWait(t *testing.T) {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	replayRepo := new(MockReplaySessionRepo)
+	eventRepo := new(MockEventRepo)
+	pixelRepo := new(MockPixelRepo)
+	capiClient := facebook.NewCAPIClient("http://localhost:9999")
+	logger := slog.Default()
+	svc := NewReplayService(shutdownCtx, replayRepo, eventRepo, pixelRepo, capiClient, logger, 1)
+
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
+	}, nil)
+	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+		Return([]*domain.PixelEvent{
+			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
+		}, nil)
+	replayRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.ReplaySession")).Return(nil)
+	replayRepo.On("UpdateStatusWithError", mock.Anything, mock.AnythingOfType("string"), "failed", "server shutdown before replay started").Return(nil)
+
+	// Fill the semaphore so goroutine will block
+	svc.sem <- struct{}{}
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-2"}
+	result, err := svc.Create(context.Background(), "cust-1", input)
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Give goroutine a moment to start waiting on semaphore
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel shutdown context → goroutine should exit with "failed"
+	shutdownCancel()
+	svc.Shutdown()
+
+	// Verify UpdateStatusWithError was called with fresh context (not the cancelled one)
+	replayRepo.AssertCalled(t, "UpdateStatusWithError", mock.Anything, mock.AnythingOfType("string"), "failed", "server shutdown before replay started")
+
+	// Release the occupied semaphore slot
+	<-svc.sem
+}
+
+func TestReplayService_SendBatchWithRetry_RateLimit(t *testing.T) {
+	callCount := 0
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(facebook.CAPIResponse{EventsReceived: 1})
+	}))
+	defer fakeServer.Close()
+
+	capiClient := facebook.NewCAPIClient(fakeServer.URL)
+	svc := &ReplayService{capiClient: capiClient, logger: slog.Default()}
+
+	resp, err := svc.sendBatchWithRetry(context.Background(), "pixel-1", "token-1", []facebook.CAPIEvent{
+		{EventName: "PageView", EventTime: time.Now().Unix()},
+	})
+
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 1, resp.EventsReceived)
+	assert.Equal(t, 3, callCount) // 2 retries + 1 success
+}
+
+func TestReplayService_SendBatchWithRetry_AuthFailFast(t *testing.T) {
+	callCount := 0
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"invalid token"}`))
+	}))
+	defer fakeServer.Close()
+
+	capiClient := facebook.NewCAPIClient(fakeServer.URL)
+	svc := &ReplayService{capiClient: capiClient, logger: slog.Default()}
+
+	resp, err := svc.sendBatchWithRetry(context.Background(), "pixel-1", "token-1", []facebook.CAPIEvent{
+		{EventName: "PageView", EventTime: time.Now().Unix()},
+	})
+
+	assert.Error(t, err)
+	assert.True(t, facebook.IsAuthError(err))
+	assert.Nil(t, resp)
+	assert.Equal(t, 1, callCount) // no retry on auth error
+}
+
+func TestReplayService_SendBatchWithRetry_MaxRetries(t *testing.T) {
+	callCount := 0
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer fakeServer.Close()
+
+	capiClient := facebook.NewCAPIClient(fakeServer.URL)
+	svc := &ReplayService{capiClient: capiClient, logger: slog.Default()}
+
+	resp, err := svc.sendBatchWithRetry(context.Background(), "pixel-1", "token-1", []facebook.CAPIEvent{
+		{EventName: "PageView", EventTime: time.Now().Unix()},
+	})
+
+	assert.Error(t, err)
+	assert.True(t, facebook.IsRateLimitError(err))
+	assert.Nil(t, resp)
+	assert.Equal(t, maxRetries+1, callCount) // initial + 3 retries
+}
+
+func TestReplayService_ExecuteReplay_DefaultDelay(t *testing.T) {
+	// Verify that batch_delay_ms=0 uses defaultBatchDelay (200ms)
+	callCount := 0
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(facebook.CAPIResponse{EventsReceived: 1})
+	}))
+	defer fakeServer.Close()
+
+	replayRepo := new(MockReplaySessionRepo)
+	eventRepo := new(MockEventRepo)
+	pixelRepo := new(MockPixelRepo)
+	capiClient := facebook.NewCAPIClient(fakeServer.URL)
+	logger := slog.Default()
+	svc := NewReplayService(context.Background(), replayRepo, eventRepo, pixelRepo, capiClient, logger, 5)
+
+	session := &domain.ReplaySession{
+		ID:           "session-1",
+		CustomerID:   "cust-1",
+		TotalEvents:  2,
+		TimeMode:     "original",
+		BatchDelayMs: 0, // should use defaultBatchDelay
+	}
+	targetPixel := &domain.Pixel{
+		ID: "pixel-2", FBPixelID: "fb-2", FBAccessToken: "token-2",
+	}
+
+	// Create 1001 events to force 2 batches (1000 + 1)
+	events := make([]*domain.PixelEvent, 1001)
+	for i := range events {
+		events[i] = &domain.PixelEvent{
+			ID: fmt.Sprintf("evt-%d", i), EventName: "PageView", EventTime: time.Now(),
+		}
+	}
+
+	replayRepo.On("UpdateStatus", mock.Anything, "session-1", "running").Return(nil)
+	replayRepo.On("GetStatus", mock.Anything, "session-1").Return("running", nil)
+	replayRepo.On("UpdateProgress", mock.Anything, "session-1", mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return(nil)
+	replayRepo.On("UpdateStatus", mock.Anything, "session-1", "completed").Return(nil)
+
+	start := time.Now()
+	svc.executeReplay(context.Background(), session, targetPixel, events)
+	elapsed := time.Since(start)
+
+	// Should have at least ~200ms delay between batches
+	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond) // allow small tolerance
+	assert.Equal(t, 2, callCount) // 2 CAPI calls (2 batches)
+	replayRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary
- Add semaphore (cap=5) to limit concurrent replay goroutines — prevents resource exhaustion
- Add `sendBatchWithRetry` with exponential backoff (1s, 2s, 4s) for Facebook CAPI 429 rate limits
- Add `RecoverOrphanedSessions` to mark stale running/pending sessions as failed on server startup
- Add default 200ms batch delay between CAPI batches when `batch_delay_ms` is not set
- Fix shutdown-path DB write to use fresh context instead of cancelled `shutdownCtx`

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (6 new test cases)
- [x] New tests: semaphore blocking, shutdown during sem wait, rate limit retry, auth fail-fast, max retries exhausted, default batch delay
- [ ] CI pipeline passes
- [ ] Verify deploy on Railway — check orphan recovery log on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)