### PR TITLE
fix: harden replay feature with 8 production readiness fixes

### DIFF
--- a/backend/internal/handler/replay_handler.go
+++ b/backend/internal/handler/replay_handler.go
@@ -43,6 +43,14 @@ func (h *ReplayHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")
 			return
 		}
+		if errors.Is(err, service.ErrReplaySamePixel) {
+			ErrorJSON(w, http.StatusBadRequest, "source and target pixel cannot be the same")
+			return
+		}
+		if errors.Is(err, service.ErrPixelNoCredentials) {
+			ErrorJSON(w, http.StatusUnprocessableEntity, "target pixel has no Facebook credentials configured")
+			return
+		}
 		ErrorJSON(w, http.StatusInternalServerError, "failed to create replay session")
 		return
 	}
@@ -115,6 +123,14 @@ func (h *ReplayHandler) Preview(w http.ResponseWriter, r *http.Request) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")
 			return
 		}
+		if errors.Is(err, service.ErrReplaySamePixel) {
+			ErrorJSON(w, http.StatusBadRequest, "source and target pixel cannot be the same")
+			return
+		}
+		if errors.Is(err, service.ErrPixelNoCredentials) {
+			ErrorJSON(w, http.StatusUnprocessableEntity, "target pixel has no Facebook credentials configured")
+			return
+		}
 		ErrorJSON(w, http.StatusInternalServerError, "failed to preview replay")
 		return
 	}
@@ -139,8 +155,31 @@ func (h *ReplayHandler) Retry(w http.ResponseWriter, r *http.Request) {
 			ErrorJSON(w, http.StatusNotFound, "pixel not found")
 			return
 		}
+		if errors.Is(err, service.ErrPixelNoCredentials) {
+			ErrorJSON(w, http.StatusUnprocessableEntity, "target pixel has no Facebook credentials configured")
+			return
+		}
 		ErrorJSON(w, http.StatusInternalServerError, "failed to retry replay session")
 		return
 	}
 	JSON(w, http.StatusCreated, APIResponse{Data: session})
+}
+
+func (h *ReplayHandler) EventTypes(w http.ResponseWriter, r *http.Request) {
+	customerID := middleware.GetCustomerID(r.Context())
+	pixelID := r.URL.Query().Get("pixel_id")
+	if pixelID == "" {
+		ErrorJSON(w, http.StatusBadRequest, "pixel_id is required")
+		return
+	}
+	types, err := h.replayService.GetEventTypes(r.Context(), customerID, pixelID)
+	if err != nil {
+		if errors.Is(err, service.ErrPixelNotFound) {
+			ErrorJSON(w, http.StatusNotFound, "pixel not found")
+			return
+		}
+		ErrorJSON(w, http.StatusInternalServerError, "failed to get event types")
+		return
+	}
+	JSON(w, http.StatusOK, APIResponse{Data: types})
 }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -29,9 +29,10 @@ type EventRepository interface {
 	ListByPixelID(ctx context.Context, pixelID string, limit, offset int) ([]*domain.PixelEvent, int, error)
 	ListByCustomerID(ctx context.Context, customerID string, pixelID string, limit, offset int) ([]*domain.PixelEvent, int, error)
 	MarkForwarded(ctx context.Context, id string, responseCode int, eventsReceived int) error
-	GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) ([]*domain.PixelEvent, error)
+	GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time, createdBefore *time.Time) ([]*domain.PixelEvent, error)
 	CountEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) (int, error)
 	GetEventsForReplayPreview(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time, limit int) ([]*domain.PixelEvent, error)
+	GetDistinctEventTypes(ctx context.Context, pixelID string) ([]string, error)
 	ListLatestByCustomerID(ctx context.Context, customerID string, pixelID string, limit int) ([]*domain.RealtimeEvent, error)
 	ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error)
 }

--- a/backend/internal/repository/postgres/event_repo.go
+++ b/backend/internal/repository/postgres/event_repo.go
@@ -150,7 +150,7 @@ func (r *EventRepo) MarkForwarded(ctx context.Context, id string, responseCode i
 	return err
 }
 
-func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) ([]*domain.PixelEvent, error) {
+func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time, createdBefore *time.Time) ([]*domain.PixelEvent, error) {
 	rows, err := r.pool.Query(ctx,
 		`SELECT id, pixel_id, event_name, event_data, user_data, source_url, event_time, forwarded_to_capi, capi_response_code, capi_events_received, created_at, event_id, client_ip, client_user_agent
 		 FROM pixel_events
@@ -158,9 +158,10 @@ func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, even
 		   AND ($2::text[] IS NULL OR event_name = ANY($2::text[]))
 		   AND ($3::timestamptz IS NULL OR event_time >= $3)
 		   AND ($4::timestamptz IS NULL OR event_time <= $4)
+		   AND ($5::timestamptz IS NULL OR created_at < $5)
 		 ORDER BY event_time ASC
 		 LIMIT 100000`,
-		pixelID, eventTypes, from, to,
+		pixelID, eventTypes, from, to, createdBefore,
 	)
 	if err != nil {
 		return nil, err
@@ -191,12 +192,14 @@ func (r *EventRepo) GetEventsForReplay(ctx context.Context, pixelID string, even
 func (r *EventRepo) CountEventsForReplay(ctx context.Context, pixelID string, eventTypes []string, from, to *time.Time) (int, error) {
 	var count int
 	err := r.pool.QueryRow(ctx,
-		`SELECT COUNT(*)
-		 FROM pixel_events
-		 WHERE pixel_id = $1
-		   AND ($2::text[] IS NULL OR event_name = ANY($2::text[]))
-		   AND ($3::timestamptz IS NULL OR event_time >= $3)
-		   AND ($4::timestamptz IS NULL OR event_time <= $4)`,
+		`SELECT COUNT(*) FROM (
+		   SELECT 1 FROM pixel_events
+		   WHERE pixel_id = $1
+		     AND ($2::text[] IS NULL OR event_name = ANY($2::text[]))
+		     AND ($3::timestamptz IS NULL OR event_time >= $3)
+		     AND ($4::timestamptz IS NULL OR event_time <= $4)
+		   LIMIT 100001
+		 ) sub`,
 		pixelID, eventTypes, from, to,
 	).Scan(&count)
 	return count, err
@@ -238,6 +241,24 @@ func (r *EventRepo) GetEventsForReplayPreview(ctx context.Context, pixelID strin
 		events = append(events, e)
 	}
 	return events, rows.Err()
+}
+
+func (r *EventRepo) GetDistinctEventTypes(ctx context.Context, pixelID string) ([]string, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT DISTINCT event_name FROM pixel_events WHERE pixel_id = $1 ORDER BY event_name`, pixelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var types []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		types = append(types, t)
+	}
+	return types, rows.Err()
 }
 
 func (r *EventRepo) ListLatestByCustomerID(ctx context.Context, customerID string, pixelID string, limit int) ([]*domain.RealtimeEvent, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -111,6 +111,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 				r.Post("/", replayHandler.Create)
 				r.Get("/", replayHandler.List)
 				r.Post("/preview", replayHandler.Preview)
+				r.Get("/event-types", replayHandler.EventTypes)
 				r.Get("/{id}", replayHandler.GetByID)
 				r.Post("/{id}/cancel", replayHandler.Cancel)
 				r.Post("/{id}/retry", replayHandler.Retry)

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -124,8 +124,8 @@ func (m *MockEventRepo) MarkForwarded(ctx context.Context, id string, code int, 
 	args := m.Called(ctx, id, code, eventsReceived)
 	return args.Error(0)
 }
-func (m *MockEventRepo) GetEventsForReplay(ctx context.Context, pixelID string, types []string, from, to *time.Time) ([]*domain.PixelEvent, error) {
-	args := m.Called(ctx, pixelID, types, from, to)
+func (m *MockEventRepo) GetEventsForReplay(ctx context.Context, pixelID string, types []string, from, to *time.Time, createdBefore *time.Time) ([]*domain.PixelEvent, error) {
+	args := m.Called(ctx, pixelID, types, from, to, createdBefore)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -141,6 +141,13 @@ func (m *MockEventRepo) GetEventsForReplayPreview(ctx context.Context, pixelID s
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*domain.PixelEvent), args.Error(1)
+}
+func (m *MockEventRepo) GetDistinctEventTypes(ctx context.Context, pixelID string) ([]string, error) {
+	args := m.Called(ctx, pixelID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
 }
 func (m *MockEventRepo) ListLatestByCustomerID(ctx context.Context, customerID string, pixelID string, limit int) ([]*domain.RealtimeEvent, error) {
 	args := m.Called(ctx, customerID, pixelID, limit)

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +20,8 @@ var (
 	ErrReplayNotFound      = errors.New("replay session not found")
 	ErrReplayNotCancellable = errors.New("replay session cannot be cancelled")
 	ErrReplayNotRetryable   = errors.New("replay session cannot be retried")
+	ErrReplaySamePixel      = errors.New("source and target pixel cannot be the same")
+	ErrPixelNoCredentials   = errors.New("target pixel has no Facebook credentials configured")
 )
 
 var ErrInvalidDateFormat = errors.New("invalid date format, expected RFC3339")
@@ -115,6 +118,16 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		return nil, ErrPixelNotFound
 	}
 
+	// Same pixel check
+	if input.SourcePixelID == input.TargetPixelID {
+		return nil, ErrReplaySamePixel
+	}
+
+	// Credential check
+	if targetPixel.FBAccessToken == "" || targetPixel.FBPixelID == "" {
+		return nil, ErrPixelNoCredentials
+	}
+
 	dateFrom, err := parseDateFilter(input.DateFrom)
 	if err != nil {
 		return nil, err
@@ -125,7 +138,7 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 	}
 
 	// Count events to replay
-	events, err := s.eventRepo.GetEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo)
+	events, err := s.eventRepo.GetEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get events for replay: %w", err)
 	}
@@ -276,6 +289,9 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 			if evt.UserData != nil {
 				_ = json.Unmarshal(evt.UserData, &userData)
 			}
+			if _, exists := userData["country"]; !exists {
+				userData["country"] = defaultCountry
+			}
 			if evt.ClientIP != "" {
 				userData["client_ip_address"] = evt.ClientIP
 			}
@@ -418,6 +434,8 @@ func (s *ReplayService) Cancel(ctx context.Context, customerID, sessionID string
 	return cancelled, nil
 }
 
+const maxReplayEvents = 100000
+
 func (s *ReplayService) Preview(ctx context.Context, customerID string, input CreateReplayInput) (*PreviewReplayResult, error) {
 	// Verify source pixel
 	sourcePixel, err := s.pixelRepo.GetByID(ctx, input.SourcePixelID)
@@ -429,6 +447,16 @@ func (s *ReplayService) Preview(ctx context.Context, customerID string, input Cr
 	targetPixel, err := s.pixelRepo.GetByID(ctx, input.TargetPixelID)
 	if err != nil || targetPixel == nil || targetPixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
+	}
+
+	// Same pixel check
+	if input.SourcePixelID == input.TargetPixelID {
+		return nil, ErrReplaySamePixel
+	}
+
+	// Credential check
+	if targetPixel.FBAccessToken == "" || targetPixel.FBPixelID == "" {
+		return nil, ErrPixelNoCredentials
 	}
 
 	dateFrom, err := parseDateFilter(input.DateFrom)
@@ -459,7 +487,12 @@ func (s *ReplayService) Preview(ctx context.Context, customerID string, input Cr
 		timeMode = timeModeOriginal
 	}
 
-	var warning string
+	var warnings []string
+	if totalEvents > maxReplayEvents {
+		warnings = append(warnings, fmt.Sprintf("%d events found, only first %d will be replayed", totalEvents, maxReplayEvents))
+		totalEvents = maxReplayEvents
+	}
+
 	if timeMode == timeModeOriginal && len(sampleEvents) > 0 {
 		var oldest time.Time
 		for _, evt := range sampleEvents {
@@ -470,8 +503,13 @@ func (s *ReplayService) Preview(ctx context.Context, customerID string, input Cr
 		age := time.Since(oldest)
 		if age > 7*24*time.Hour {
 			days := int(age.Hours() / 24)
-			warning = fmt.Sprintf("Warning: oldest event is %d days old. Facebook may reject events older than 7 days. Consider using time_mode: current.", days)
+			warnings = append(warnings, fmt.Sprintf("oldest event is %d days old. Facebook may reject events older than 7 days. Consider using time_mode: current.", days))
 		}
+	}
+
+	var warning string
+	if len(warnings) > 0 {
+		warning = "Warning: " + strings.Join(warnings, ". Also: ")
 	}
 
 	return &PreviewReplayResult{
@@ -501,8 +539,14 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 		return nil, ErrPixelNotFound
 	}
 
+	// Credential check
+	if targetPixel.FBAccessToken == "" || targetPixel.FBPixelID == "" {
+		return nil, ErrPixelNoCredentials
+	}
+
 	// Get all events for replay (we'll use failed batch ranges if available)
-	allEvents, err := s.eventRepo.GetEventsForReplay(ctx, session.SourcePixelID, session.EventTypes, session.DateFrom, session.DateTo)
+	// Use createdBefore to avoid replaying events that arrived after the original session
+	allEvents, err := s.eventRepo.GetEventsForReplay(ctx, session.SourcePixelID, session.EventTypes, session.DateFrom, session.DateTo, &session.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("get events for retry: %w", err)
 	}
@@ -566,4 +610,19 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 	}()
 
 	return newSession, nil
+}
+
+func (s *ReplayService) GetEventTypes(ctx context.Context, customerID, pixelID string) ([]string, error) {
+	pixel, err := s.pixelRepo.GetByID(ctx, pixelID)
+	if err != nil || pixel == nil || pixel.CustomerID != customerID {
+		return nil, ErrPixelNotFound
+	}
+	types, err := s.eventRepo.GetDistinctEventTypes(ctx, pixelID)
+	if err != nil {
+		return nil, fmt.Errorf("get event types: %w", err)
+	}
+	if types == nil {
+		types = []string{}
+	}
+	return types, nil
 }

--- a/backend/internal/service/replay_service_test.go
+++ b/backend/internal/service/replay_service_test.go
@@ -61,7 +61,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
 					}, nil)
@@ -95,7 +95,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
 					}, nil)
@@ -129,7 +129,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
 					}, nil)
@@ -162,7 +162,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-10 * 24 * time.Hour)},
 						{ID: "evt-2", EventName: "Purchase", EventTime: time.Now().Add(-1 * time.Hour)},
@@ -711,12 +711,16 @@ func TestReplayService_Preview(t *testing.T) {
 			},
 			setup: func(rr *MockReplaySessionRepo, er *MockEventRepo, pr *MockPixelRepo) {
 				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
-					ID:         "pixel-1",
-					CustomerID: "cust-1",
+					ID:            "pixel-1",
+					CustomerID:    "cust-1",
+					FBPixelID:     "fb-1",
+					FBAccessToken: "token-1",
 				}, nil)
 				pr.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
-					ID:         "pixel-2",
-					CustomerID: "cust-1",
+					ID:            "pixel-2",
+					CustomerID:    "cust-1",
+					FBPixelID:     "fb-2",
+					FBAccessToken: "token-2",
 				}, nil)
 				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
 					Return(42, nil)
@@ -739,12 +743,16 @@ func TestReplayService_Preview(t *testing.T) {
 			},
 			setup: func(rr *MockReplaySessionRepo, er *MockEventRepo, pr *MockPixelRepo) {
 				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
-					ID:         "pixel-1",
-					CustomerID: "cust-1",
+					ID:            "pixel-1",
+					CustomerID:    "cust-1",
+					FBPixelID:     "fb-1",
+					FBAccessToken: "token-1",
 				}, nil)
 				pr.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
-					ID:         "pixel-2",
-					CustomerID: "cust-1",
+					ID:            "pixel-2",
+					CustomerID:    "cust-1",
+					FBPixelID:     "fb-2",
+					FBAccessToken: "token-2",
 				}, nil)
 				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
 					Return(0, nil)
@@ -819,7 +827,7 @@ func TestReplayService_Retry(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
 					}, nil)
@@ -852,7 +860,7 @@ func TestReplayService_Retry(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
-				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
 					}, nil)
@@ -946,7 +954,7 @@ func TestReplayService_Create_SemaphoreBlock(t *testing.T) {
 	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
 		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
 	}, nil)
-	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 		Return([]*domain.PixelEvent{
 			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
 		}, nil)
@@ -990,7 +998,7 @@ func TestReplayService_Create_ShutdownDuringSemWait(t *testing.T) {
 	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
 		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
 	}, nil)
-	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 		Return([]*domain.PixelEvent{
 			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
 		}, nil)
@@ -1139,4 +1147,180 @@ func TestReplayService_ExecuteReplay_DefaultDelay(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond) // allow small tolerance
 	assert.Equal(t, 2, callCount) // 2 CAPI calls (2 batches)
 	replayRepo.AssertExpectations(t)
+}
+
+func TestReplayService_Create_SamePixel(t *testing.T) {
+	svc, _, _, pixelRepo := newTestReplayService()
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-1"}
+	result, err := svc.Create(context.Background(), "cust-1", input)
+
+	assert.ErrorIs(t, err, ErrReplaySamePixel)
+	assert.Nil(t, result)
+}
+
+func TestReplayService_Create_NoCredentials(t *testing.T) {
+	svc, _, _, pixelRepo := newTestReplayService()
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "", FBAccessToken: "",
+	}, nil)
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-2"}
+	result, err := svc.Create(context.Background(), "cust-1", input)
+
+	assert.ErrorIs(t, err, ErrPixelNoCredentials)
+	assert.Nil(t, result)
+}
+
+func TestReplayService_Preview_SamePixel(t *testing.T) {
+	svc, _, _, pixelRepo := newTestReplayService()
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-1"}
+	result, err := svc.Preview(context.Background(), "cust-1", input)
+
+	assert.ErrorIs(t, err, ErrReplaySamePixel)
+	assert.Nil(t, result)
+}
+
+func TestReplayService_Preview_NoCredentials(t *testing.T) {
+	svc, _, _, pixelRepo := newTestReplayService()
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "", FBAccessToken: "",
+	}, nil)
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-2"}
+	result, err := svc.Preview(context.Background(), "cust-1", input)
+
+	assert.ErrorIs(t, err, ErrPixelNoCredentials)
+	assert.Nil(t, result)
+}
+
+func TestReplayService_Retry_NoCredentials(t *testing.T) {
+	svc, replayRepo, _, pixelRepo := newTestReplayService()
+	replayRepo.On("GetByID", mock.Anything, "session-1").Return(&domain.ReplaySession{
+		ID:            "session-1",
+		CustomerID:    "cust-1",
+		SourcePixelID: "pixel-1",
+		TargetPixelID: "pixel-2",
+		Status:        "failed",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "", FBAccessToken: "",
+	}, nil)
+
+	session, err := svc.Retry(context.Background(), "cust-1", "session-1")
+
+	assert.ErrorIs(t, err, ErrPixelNoCredentials)
+	assert.Nil(t, session)
+}
+
+func TestReplayService_Preview_MaxEventsWarning(t *testing.T) {
+	svc, _, eventRepo, pixelRepo := newTestReplayService()
+	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+		ID: "pixel-1", CustomerID: "cust-1", FBPixelID: "fb-1", FBAccessToken: "token-1",
+	}, nil)
+	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
+	}, nil)
+	eventRepo.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).
+		Return(100001, nil)
+	eventRepo.On("GetEventsForReplayPreview", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), 10).
+		Return([]*domain.PixelEvent{
+			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
+		}, nil)
+
+	input := CreateReplayInput{SourcePixelID: "pixel-1", TargetPixelID: "pixel-2", TimeMode: "current"}
+	result, err := svc.Preview(context.Background(), "cust-1", input)
+
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, maxReplayEvents, result.TotalEvents)
+	assert.Contains(t, result.Warning, "100001 events found")
+	assert.Contains(t, result.Warning, "only first 100000 will be replayed")
+}
+
+func TestReplayService_GetEventTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID string
+		pixelID    string
+		setup      func(*MockEventRepo, *MockPixelRepo)
+		wantTypes  []string
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			customerID: "cust-1",
+			pixelID:    "pixel-1",
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID: "pixel-1", CustomerID: "cust-1",
+				}, nil)
+				er.On("GetDistinctEventTypes", mock.Anything, "pixel-1").Return([]string{"PageView", "Purchase"}, nil)
+			},
+			wantTypes: []string{"PageView", "Purchase"},
+		},
+		{
+			name:       "empty returns empty slice",
+			customerID: "cust-1",
+			pixelID:    "pixel-1",
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID: "pixel-1", CustomerID: "cust-1",
+				}, nil)
+				er.On("GetDistinctEventTypes", mock.Anything, "pixel-1").Return(nil, nil)
+			},
+			wantTypes: []string{},
+		},
+		{
+			name:       "pixel not found",
+			customerID: "cust-1",
+			pixelID:    "nonexistent",
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+			},
+			wantErr: ErrPixelNotFound,
+		},
+		{
+			name:       "pixel not owned",
+			customerID: "cust-2",
+			pixelID:    "pixel-1",
+			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
+				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+					ID: "pixel-1", CustomerID: "cust-1",
+				}, nil)
+			},
+			wantErr: ErrPixelNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, eventRepo, pixelRepo := newTestReplayService()
+			tt.setup(eventRepo, pixelRepo)
+
+			types, err := svc.GetEventTypes(context.Background(), tt.customerID, tt.pixelID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, types)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTypes, types)
+			}
+			pixelRepo.AssertExpectations(t)
+		})
+	}
 }

--- a/frontend/src/hooks/use-replays.ts
+++ b/frontend/src/hooks/use-replays.ts
@@ -91,3 +91,14 @@ export function useReplayPreview() {
     },
   })
 }
+
+export function useEventTypes(pixelId: string | undefined) {
+  return useQuery({
+    queryKey: ['event-types', pixelId],
+    queryFn: async () => {
+      const { data } = await api.get<APIResponse<string[]>>(`/replays/event-types?pixel_id=${pixelId}`)
+      return data.data!
+    },
+    enabled: !!pixelId,
+  })
+}

--- a/frontend/src/pages/ReplayPage.tsx
+++ b/frontend/src/pages/ReplayPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -10,7 +10,8 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { toast } from 'sonner'
 import { usePixels } from '@/hooks/use-pixels'
-import { useReplays, useReplaySession, useCreateReplay, useCancelReplay, useRetryReplay, useReplayPreview } from '@/hooks/use-replays'
+import { useReplays, useReplaySession, useCreateReplay, useCancelReplay, useRetryReplay, useReplayPreview, useEventTypes } from '@/hooks/use-replays'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
 import type { ReplayPreview } from '@/types'
 
 const replaySchema = z.object({
@@ -34,6 +35,14 @@ function statusBadge(status: string) {
   }
 }
 
+function toStartOfDay(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toISOString()
+}
+
+function toEndOfDay(dateStr: string): string {
+  return new Date(dateStr + 'T23:59:59').toISOString()
+}
+
 export function ReplayPage() {
   const { data: pixels } = usePixels()
   const { data: replays, isLoading } = useReplays()
@@ -45,6 +54,8 @@ export function ReplayPage() {
   const { data: activeReplay } = useReplaySession(activeReplayId)
   const [preview, setPreview] = useState<ReplayPreview | null>(null)
   const [pendingFormData, setPendingFormData] = useState<ReplayForm | null>(null)
+  const [selectedEventTypes, setSelectedEventTypes] = useState<string[]>([])
+  const [cancelConfirm, setCancelConfirm] = useState<string | null>(null)
 
   const pixelMap = useMemo(() => {
     const map = new Map<string, string>()
@@ -56,6 +67,7 @@ export function ReplayPage() {
     register,
     handleSubmit,
     getValues,
+    watch,
     formState: { errors },
   } = useForm<ReplayForm>({
     resolver: zodResolver(replaySchema),
@@ -65,13 +77,21 @@ export function ReplayPage() {
     },
   })
 
+  const watchedSourcePixelId = watch('source_pixel_id')
+  const { data: eventTypes } = useEventTypes(watchedSourcePixelId)
+
+  useEffect(() => {
+    setSelectedEventTypes([])
+  }, [watchedSourcePixelId])
+
   const onPreview = async (formData: ReplayForm) => {
     try {
       const result = await previewReplay.mutateAsync({
         source_pixel_id: formData.source_pixel_id,
         target_pixel_id: formData.target_pixel_id,
-        date_from: formData.date_from ? new Date(formData.date_from).toISOString() : undefined,
-        date_to: formData.date_to ? new Date(formData.date_to).toISOString() : undefined,
+        event_types: selectedEventTypes.length > 0 ? selectedEventTypes : undefined,
+        date_from: formData.date_from ? toStartOfDay(formData.date_from) : undefined,
+        date_to: formData.date_to ? toEndOfDay(formData.date_to) : undefined,
       })
       setPreview(result)
       setPendingFormData(formData)
@@ -86,8 +106,9 @@ export function ReplayPage() {
       const result = await createReplay.mutateAsync({
         source_pixel_id: pendingFormData.source_pixel_id,
         target_pixel_id: pendingFormData.target_pixel_id,
-        date_from: pendingFormData.date_from ? new Date(pendingFormData.date_from).toISOString() : undefined,
-        date_to: pendingFormData.date_to ? new Date(pendingFormData.date_to).toISOString() : undefined,
+        event_types: selectedEventTypes.length > 0 ? selectedEventTypes : undefined,
+        date_from: pendingFormData.date_from ? toStartOfDay(pendingFormData.date_from) : undefined,
+        date_to: pendingFormData.date_to ? toEndOfDay(pendingFormData.date_to) : undefined,
         time_mode: pendingFormData.time_mode,
         batch_delay_ms: pendingFormData.batch_delay_ms || undefined,
       })
@@ -170,6 +191,32 @@ export function ReplayPage() {
                   </select>
                   {errors.target_pixel_id && <p className="text-sm text-red-500">{errors.target_pixel_id.message}</p>}
                 </div>
+
+                {eventTypes && eventTypes.length > 0 && (
+                  <div className="space-y-2">
+                    <Label>Event Types (optional)</Label>
+                    <div className="space-y-1.5 max-h-32 overflow-y-auto rounded-md border border-neutral-200 p-2">
+                      {eventTypes.map((type) => (
+                        <label key={type} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={selectedEventTypes.includes(type)}
+                            onChange={(e) => {
+                              setSelectedEventTypes(prev =>
+                                e.target.checked
+                                  ? [...prev, type]
+                                  : prev.filter(t => t !== type)
+                              )
+                            }}
+                            className="rounded border-neutral-300"
+                          />
+                          {type}
+                        </label>
+                      ))}
+                    </div>
+                    <p className="text-xs text-neutral-400">Leave unchecked to include all event types</p>
+                  </div>
+                )}
 
                 <div className="space-y-2">
                   <Label>Date From (optional)</Label>
@@ -328,7 +375,7 @@ export function ReplayPage() {
                     <Button
                       variant="destructive"
                       size="sm"
-                      onClick={() => handleCancel(activeReplay.id)}
+                      onClick={() => setCancelConfirm(activeReplay.id)}
                       disabled={cancelReplay.isPending}
                     >
                       <StopCircle className="h-4 w-4" />
@@ -397,6 +444,34 @@ export function ReplayPage() {
           </Card>
         )}
       </div>
+
+      <Dialog open={cancelConfirm !== null} onOpenChange={(open) => !open && setCancelConfirm(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel Replay?</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to cancel this replay? Events already replayed will not be rolled back.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCancelConfirm(null)}>
+              Keep Running
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (cancelConfirm) {
+                  handleCancel(cancelConfirm)
+                  setCancelConfirm(null)
+                }
+              }}
+              disabled={cancelReplay.isPending}
+            >
+              {cancelReplay.isPending ? 'Cancelling...' : 'Yes, Cancel Replay'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Fix 1 (CRITICAL):** Add `country` default (`th`) in replay `executeReplay` to maintain Facebook EMQ score
- **Fix 2 (CRITICAL):** Validate target pixel has `FBAccessToken` + `FBPixelID` before replay starts (HTTP 422)
- **Fix 3 (HIGH):** Block source == target pixel to prevent self-replay (HTTP 400)
- **Fix 4 (CRITICAL):** Fix 100k event limit mismatch — `CountEventsForReplay` now caps at 100001, Preview warns when exceeded
- **Fix 5 (HIGH):** Add event type filter — new `GET /replays/event-types` endpoint + frontend checkbox UI
- **Fix 6 (HIGH):** Fix date filter timezone — use local midnight instead of UTC midnight for date-only inputs
- **Fix 7 (HIGH):** Fix retry stale event index — add `createdBefore` param to `GetEventsForReplay` so retries only replay events from the original session
- **Fix 8 (MEDIUM):** Add cancel confirmation dialog to prevent accidental cancellation

## Files Changed (9 files, +436/-38)

| File | Fixes |
|------|-------|
| `backend/internal/service/replay_service.go` | 1, 2, 3, 4, 5, 7 |
| `backend/internal/handler/replay_handler.go` | 2, 3, 5 |
| `backend/internal/repository/interfaces.go` | 5, 7 |
| `backend/internal/repository/postgres/event_repo.go` | 4, 5, 7 |
| `backend/internal/router/router.go` | 5 |
| `backend/internal/service/mocks_test.go` | 5, 7 |
| `backend/internal/service/replay_service_test.go` | 1, 2, 3, 4, 7 |
| `frontend/src/hooks/use-replays.ts` | 5 |
| `frontend/src/pages/ReplayPage.tsx` | 5, 6, 8 |

## Test plan
- [ ] `go vet ./...` — passed
- [ ] `go test -race ./...` — all tests pass including 7 new test cases
- [ ] `npm run lint` — 0 errors (2 pre-existing warnings)
- [ ] `npm run test` — 14 tests passed
- [ ] `npm run build` — tsc + vite build success
- [ ] Manual: Create replay with source == target → should get 400 error
- [ ] Manual: Create replay with target pixel missing credentials → should get 422 error
- [ ] Manual: Preview replay with >100k events → should show warning
- [ ] Manual: Cancel button shows confirmation dialog
- [ ] Manual: Event type filter checkboxes appear after selecting source pixel
- [ ] Manual: Date filter in Thai timezone resolves to correct UTC range

🤖 Generated with [Claude Code](https://claude.com/claude-code)