### PR TITLE
fix: add Google domains to CSP headers for OAuth login

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,7 +21,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net; style-src 'self' 'unsafe-inline'; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data:" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
 
     location /assets/ {
         expires 1y;
@@ -32,7 +32,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net; style-src 'self' 'unsafe-inline'; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data:" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 
     # Proxy public sale pages to backend API
@@ -68,6 +68,6 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net; style-src 'self' 'unsafe-inline'; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data:" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 }


### PR DESCRIPTION
## Summary
- เพิ่ม `accounts.google.com` ใน `script-src` ของ CSP headers
- เพิ่ม `fonts.googleapis.com` ใน `style-src` ของ CSP headers
- เพิ่ม `fonts.gstatic.com` ใน `font-src` ของ CSP headers
- แก้ทั้ง 3 จุดที่ประกาศ CSP ใน nginx.conf (server-level, /assets/, /)

## Root Cause
PR #54 (security headers) เพิ่ม Content-Security-Policy แต่ไม่ได้ whitelist Google domains ทำให้ Google OAuth login button หายไปเพราะ browser บล็อก `accounts.google.com/gsi/client` script

## Test Plan
- [ ] Verify Google login button appears on pixlinks.xyz/login
- [ ] Verify Google OAuth flow works end-to-end
- [ ] Verify Google Fonts load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>