### PR TITLE
fix: add accounts.google.com to CSP style-src

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,7 +21,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
 
     location /assets/ {
         expires 1y;
@@ -32,7 +32,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 
     # Proxy public sale pages to backend API
@@ -68,6 +68,6 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 }


### PR DESCRIPTION
## Summary
- เพิ่ม `accounts.google.com` ใน `style-src` ของ CSP headers ทั้ง 3 จุดใน nginx.conf
- Google Sign-In โหลด stylesheet จาก `accounts.google.com/gsi/style` ซึ่งถูก CSP บล็อก

## Root Cause
PR #56 เพิ่ม `accounts.google.com` ใน `script-src` แต่ Google Sign-In ยังโหลด CSS จาก domain เดียวกัน ทำให้ stylesheet ถูกบล็อกโดย `style-src`

## Test Plan
- [ ] Verify Google Sign-In button renders correctly on pixlinks.xyz/login
- [ ] No CSP errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)