### PR TITLE
fix: add backend URL to CSP connect-src for API access

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,7 +21,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
 
     location /assets/ {
         expires 1y;
@@ -32,7 +32,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 
     # Proxy public sale pages to backend API
@@ -68,6 +68,6 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 }


### PR DESCRIPTION
## Summary

- เพิ่ม `${BACKEND_URL}` ใน CSP `connect-src` ทั้ง 3 จุดของ `frontend/nginx.conf`
- แก้ปัญหา browser บล็อก API calls ใน production เพราะ `'self'` = `pixlinks.xyz` แต่ API อยู่ที่ `api.pixlinks.xyz`
- ใช้ env variable เดียวกับ `proxy_pass` ที่มีอยู่แล้ว — `envsubst` แทนค่าอัตโนมัติตอน container start

## Test plan

- [ ] CI passes (lint, test, build)
- [ ] หลัง deploy: `curl -sI https://pixlinks.xyz/login | grep content-security-policy` เห็น `connect-src 'self' https://api.pixlinks.xyz`
- [ ] Login + Dashboard ทำงานปกติ ไม่มี CSP error ใน browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)