### PR TITLE
fix: add COOP header for Google Sign-In popup

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,6 +21,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
 
     location /assets/ {
@@ -32,6 +33,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 
@@ -68,6 +70,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com; font-src 'self' data: fonts.gstatic.com" always;
     }
 }


### PR DESCRIPTION
## Summary

- เพิ่ม `Cross-Origin-Opener-Policy: same-origin-allow-popups` header ใน nginx.conf ทั้ง 3 location blocks
- แก้ error `Cross-Origin-Opener-Policy policy would block the window.postMessage call` ที่เกิดจาก Google Sign-In popup
- ให้ popup สามารถส่ง `postMessage` กลับมาที่ opener window ได้ โดยยังคง protect จาก cross-origin opener ที่ไม่ได้ตั้งใจเปิด

## Test plan

- [ ] CI passes
- [ ] หลัง deploy: Google Sign-In ไม่มี COOP error ใน browser console
- [ ] Login flow ทำงานปกติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)