### PR TITLE
fix: resolve credit race conditions, webhook idempotency, and performance

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,7 +15,9 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.11.1
+	github.com/stripe/stripe-go/v82 v82.5.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.269.0
 )
@@ -51,7 +53,6 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stripe/stripe-go/v82 v82.5.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
@@ -59,7 +60,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -31,7 +31,9 @@ type CustomerRepository interface {
 type PixelRepository interface {
 	Create(ctx context.Context, pixel *domain.Pixel) error
 	GetByID(ctx context.Context, id string) (*domain.Pixel, error)
+	GetByIDs(ctx context.Context, ids []string) ([]*domain.Pixel, error)
 	ListByCustomerID(ctx context.Context, customerID string) ([]*domain.Pixel, error)
+	CountByCustomerID(ctx context.Context, customerID string) (int, error)
 	Update(ctx context.Context, pixel *domain.Pixel) error
 	Delete(ctx context.Context, id string) error
 }
@@ -58,6 +60,7 @@ type ReplaySessionRepository interface {
 	UpdateProgress(ctx context.Context, id string, replayed, failed int) error
 	UpdateStatus(ctx context.Context, id string, status string) error
 	UpdateStatusWithError(ctx context.Context, id string, status string, errorMsg string) error
+	UpdateTotalEvents(ctx context.Context, id string, total int) error
 	GetStatus(ctx context.Context, id string) (string, error)
 	UpdateFailedBatches(ctx context.Context, id string, failedBatchRanges []byte) error
 	CancelSession(ctx context.Context, id string) (*domain.ReplaySession, error)
@@ -69,6 +72,7 @@ type SalePageRepository interface {
 	GetByID(ctx context.Context, id string) (*domain.SalePage, error)
 	GetBySlug(ctx context.Context, slug string) (*domain.SalePage, error)
 	ListByCustomerID(ctx context.Context, customerID string) ([]*domain.SalePage, error)
+	CountByCustomerID(ctx context.Context, customerID string) (int, error)
 	Update(ctx context.Context, page *domain.SalePage) error
 	Delete(ctx context.Context, id string) error
 	SlugExists(ctx context.Context, slug string) (bool, error)
@@ -109,6 +113,7 @@ type SubscriptionRepository interface {
 	Create(ctx context.Context, sub *domain.Subscription) error
 	GetByStripeSubscriptionID(ctx context.Context, stripeSubID string) (*domain.Subscription, error)
 	GetActiveByCustomerID(ctx context.Context, customerID string) ([]*domain.Subscription, error)
+	GetMaxEventsPerMonth(ctx context.Context, customerID string) (int64, error)
 	Update(ctx context.Context, sub *domain.Subscription) error
 	ListByCustomerID(ctx context.Context, customerID string) ([]*domain.Subscription, error)
 }
@@ -120,6 +125,6 @@ type EventUsageRepository interface {
 }
 
 type WebhookEventRepository interface {
-	Exists(ctx context.Context, stripeEventID string) (bool, error)
-	Create(ctx context.Context, stripeEventID, eventType string) error
+	CreateIfNotExists(ctx context.Context, stripeEventID string, eventType string) (inserted bool, err error)
+	Delete(ctx context.Context, stripeEventID string) error
 }

--- a/backend/internal/repository/postgres/pixel_repo.go
+++ b/backend/internal/repository/postgres/pixel_repo.go
@@ -66,6 +66,39 @@ func (r *PixelRepo) GetByID(ctx context.Context, id string) (*domain.Pixel, erro
 	return p, nil
 }
 
+func (r *PixelRepo) GetByIDs(ctx context.Context, ids []string) ([]*domain.Pixel, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, customer_id, fb_pixel_id, fb_access_token, name, is_active, status, backup_pixel_id, test_event_code, created_at, updated_at
+		 FROM pixels WHERE id = ANY($1)`, ids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var pixels []*domain.Pixel
+	for rows.Next() {
+		p := &domain.Pixel{}
+		if err := rows.Scan(&p.ID, &p.CustomerID, &p.FBPixelID, &p.FBAccessToken, &p.Name, &p.IsActive, &p.Status, &p.BackupPixelID, &p.TestEventCode, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, err
+		}
+		p.FBAccessToken = r.decryptToken(p.FBAccessToken)
+		pixels = append(pixels, p)
+	}
+	return pixels, rows.Err()
+}
+
+func (r *PixelRepo) CountByCustomerID(ctx context.Context, customerID string) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM pixels WHERE customer_id = $1`, customerID,
+	).Scan(&count)
+	return count, err
+}
+
 func (r *PixelRepo) ListByCustomerID(ctx context.Context, customerID string) ([]*domain.Pixel, error) {
 	rows, err := r.pool.Query(ctx,
 		`SELECT id, customer_id, fb_pixel_id, fb_access_token, name, is_active, status, backup_pixel_id, test_event_code, created_at, updated_at

--- a/backend/internal/repository/postgres/replay_session_repo.go
+++ b/backend/internal/repository/postgres/replay_session_repo.go
@@ -97,6 +97,14 @@ func (r *ReplaySessionRepo) UpdateStatusWithError(ctx context.Context, id string
 	return err
 }
 
+func (r *ReplaySessionRepo) UpdateTotalEvents(ctx context.Context, id string, total int) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE replay_sessions SET total_events = $2 WHERE id = $1`,
+		id, total,
+	)
+	return err
+}
+
 func (r *ReplaySessionRepo) GetStatus(ctx context.Context, id string) (string, error) {
 	var status string
 	err := r.pool.QueryRow(ctx,

--- a/backend/internal/repository/postgres/sale_page_repo.go
+++ b/backend/internal/repository/postgres/sale_page_repo.go
@@ -84,6 +84,14 @@ func (r *SalePageRepo) GetBySlug(ctx context.Context, slug string) (*domain.Sale
 	return p, nil
 }
 
+func (r *SalePageRepo) CountByCustomerID(ctx context.Context, customerID string) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM sale_pages WHERE customer_id = $1`, customerID,
+	).Scan(&count)
+	return count, err
+}
+
 func (r *SalePageRepo) ListByCustomerID(ctx context.Context, customerID string) ([]*domain.SalePage, error) {
 	rows, err := r.pool.Query(ctx,
 		`SELECT id, customer_id, name, slug, template_name, content, is_published, created_at, updated_at

--- a/backend/internal/repository/postgres/subscription_repo.go
+++ b/backend/internal/repository/postgres/subscription_repo.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 )
 
@@ -82,6 +83,20 @@ func (r *SubscriptionRepo) GetActiveByCustomerID(ctx context.Context, customerID
 		subs = append(subs, s)
 	}
 	return subs, rows.Err()
+}
+
+func (r *SubscriptionRepo) GetMaxEventsPerMonth(ctx context.Context, customerID string) (int64, error) {
+	var extra int64
+	err := r.pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(CASE WHEN addon_type = 'events_1m' THEN 1000000 ELSE 0 END), 0)
+		 FROM subscriptions
+		 WHERE customer_id = $1 AND status = 'active'`,
+		customerID,
+	).Scan(&extra)
+	if err != nil {
+		return 0, err
+	}
+	return int64(domain.FreeMaxEventsPerMonth) + extra, nil
 }
 
 func (r *SubscriptionRepo) Update(ctx context.Context, s *domain.Subscription) error {

--- a/backend/internal/repository/postgres/webhook_event_repo.go
+++ b/backend/internal/repository/postgres/webhook_event_repo.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -14,19 +15,25 @@ func NewWebhookEventRepo(pool *pgxpool.Pool) *WebhookEventRepo {
 	return &WebhookEventRepo{pool: pool}
 }
 
-func (r *WebhookEventRepo) Exists(ctx context.Context, stripeEventID string) (bool, error) {
-	var exists bool
+func (r *WebhookEventRepo) CreateIfNotExists(ctx context.Context, stripeEventID string, eventType string) (bool, error) {
+	var id string
 	err := r.pool.QueryRow(ctx,
-		`SELECT EXISTS(SELECT 1 FROM stripe_webhook_events WHERE stripe_event_id = $1)`,
-		stripeEventID,
-	).Scan(&exists)
-	return exists, err
+		`INSERT INTO stripe_webhook_events (stripe_event_id, event_type) VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING stripe_event_id`,
+		stripeEventID, eventType,
+	).Scan(&id)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil // duplicate
+		}
+		return false, err
+	}
+	return true, nil
 }
 
-func (r *WebhookEventRepo) Create(ctx context.Context, stripeEventID, eventType string) error {
+func (r *WebhookEventRepo) Delete(ctx context.Context, stripeEventID string) error {
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO stripe_webhook_events (stripe_event_id, event_type) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
-		stripeEventID, eventType,
+		`DELETE FROM stripe_webhook_events WHERE stripe_event_id = $1`,
+		stripeEventID,
 	)
 	return err
 }

--- a/backend/internal/service/analytics_service.go
+++ b/backend/internal/service/analytics_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
 )
 
 type AnalyticsService struct {
@@ -30,37 +31,40 @@ type OverviewStats struct {
 func (s *AnalyticsService) GetOverview(ctx context.Context, customerID string) (*OverviewStats, error) {
 	stats := &OverviewStats{}
 
-	err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*), COUNT(*) FILTER (WHERE is_active) FROM pixels WHERE customer_id = $1`, customerID,
-	).Scan(&stats.TotalPixels, &stats.ActivePixels)
-	if err != nil {
-		return nil, fmt.Errorf("count pixels: %w", err)
-	}
+	g, ctx := errgroup.WithContext(ctx)
 
-	err = s.pool.QueryRow(ctx,
-		`SELECT
-			COUNT(*),
-			COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE),
-			COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE - INTERVAL '1 day'
-			                   AND pe.event_time < CURRENT_DATE),
-			COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE - INTERVAL '7 days'),
-			COUNT(*) FILTER (WHERE pe.forwarded_to_capi)
-		 FROM pixel_events pe
-		 JOIN pixels p ON p.id = pe.pixel_id
-		 WHERE p.customer_id = $1`, customerID,
-	).Scan(&stats.TotalEvents, &stats.EventsToday, &stats.EventsYesterday, &stats.EventsThisWeek, &stats.ForwardedEvents)
-	if err != nil {
-		return nil, fmt.Errorf("count events: %w", err)
-	}
+	g.Go(func() error {
+		return s.pool.QueryRow(ctx,
+			`SELECT COUNT(*), COUNT(*) FILTER (WHERE is_active) FROM pixels WHERE customer_id = $1`, customerID,
+		).Scan(&stats.TotalPixels, &stats.ActivePixels)
+	})
 
-	err = s.pool.QueryRow(ctx,
-		`SELECT
-			COUNT(*),
-			COUNT(*) FILTER (WHERE status IN ('running', 'pending'))
-		 FROM replay_sessions WHERE customer_id = $1`, customerID,
-	).Scan(&stats.TotalReplays, &stats.ActiveReplays)
-	if err != nil {
-		return nil, fmt.Errorf("count replays: %w", err)
+	g.Go(func() error {
+		return s.pool.QueryRow(ctx,
+			`SELECT
+				COUNT(*),
+				COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE),
+				COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE - INTERVAL '1 day'
+				                   AND pe.event_time < CURRENT_DATE),
+				COUNT(*) FILTER (WHERE pe.event_time >= CURRENT_DATE - INTERVAL '7 days'),
+				COUNT(*) FILTER (WHERE pe.forwarded_to_capi)
+			 FROM pixel_events pe
+			 JOIN pixels p ON p.id = pe.pixel_id
+			 WHERE p.customer_id = $1`, customerID,
+		).Scan(&stats.TotalEvents, &stats.EventsToday, &stats.EventsYesterday, &stats.EventsThisWeek, &stats.ForwardedEvents)
+	})
+
+	g.Go(func() error {
+		return s.pool.QueryRow(ctx,
+			`SELECT
+				COUNT(*),
+				COUNT(*) FILTER (WHERE status IN ('running', 'pending'))
+			 FROM replay_sessions WHERE customer_id = $1`, customerID,
+		).Scan(&stats.TotalReplays, &stats.ActiveReplays)
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("get overview: %w", err)
 	}
 
 	return stats, nil

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -12,6 +12,8 @@ import (
 	checkoutsession "github.com/stripe/stripe-go/v82/checkout/session"
 	stripecustomer "github.com/stripe/stripe-go/v82/customer"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/jaochai/pixlinks/backend/internal/config"
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
@@ -269,24 +271,24 @@ func (s *BillingService) CreateCustomerPortalSession(ctx context.Context, custom
 	return sess.URL, nil
 }
 
-// ProcessWebhookEvent checks idempotency and processes the webhook event.
-// Returns nil if the event was already processed (duplicate).
+// ProcessWebhookEvent atomically claims the event via CreateIfNotExists, processes it,
+// and rolls back the claim on failure so retries can succeed.
 func (s *BillingService) ProcessWebhookEvent(ctx context.Context, stripeEventID, eventType string, process func() error) error {
-	exists, err := s.webhookRepo.Exists(ctx, stripeEventID)
+	inserted, err := s.webhookRepo.CreateIfNotExists(ctx, stripeEventID, eventType)
 	if err != nil {
-		return fmt.Errorf("check webhook event: %w", err)
+		return fmt.Errorf("claim webhook event: %w", err)
 	}
-	if exists {
+	if !inserted {
 		slog.Info("skipping duplicate webhook event", "stripe_event_id", stripeEventID, "event_type", eventType)
 		return nil
 	}
 
 	if err := process(); err != nil {
+		// Roll back the claim so Stripe retries can succeed
+		if delErr := s.webhookRepo.Delete(ctx, stripeEventID); delErr != nil {
+			slog.Error("failed to roll back webhook event claim", "stripe_event_id", stripeEventID, "error", delErr)
+		}
 		return err
-	}
-
-	if err := s.webhookRepo.Create(ctx, stripeEventID, eventType); err != nil {
-		slog.Warn("failed to record webhook event", "stripe_event_id", stripeEventID, "error", err)
 	}
 
 	return nil
@@ -424,25 +426,41 @@ func (s *BillingService) cancelSubscription(ctx context.Context, sub *stripe.Sub
 
 // GetBillingOverview returns all billing information for a customer.
 func (s *BillingService) GetBillingOverview(ctx context.Context, customerID string) (*BillingOverview, error) {
-	purchases, err := s.purchaseRepo.ListByCustomerID(ctx, customerID)
-	if err != nil {
-		return nil, fmt.Errorf("list purchases: %w", err)
+	var (
+		purchases     []*domain.Purchase
+		credits       []*domain.ReplayCredit
+		subscriptions []*domain.Subscription
+	)
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		purchases, err = s.purchaseRepo.ListByCustomerID(gCtx, customerID)
+		return err
+	})
+
+	g.Go(func() error {
+		var err error
+		credits, err = s.creditRepo.GetActiveByCustomerID(gCtx, customerID)
+		return err
+	})
+
+	g.Go(func() error {
+		var err error
+		subscriptions, err = s.subRepo.ListByCustomerID(gCtx, customerID)
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("get billing overview: %w", err)
 	}
+
 	if purchases == nil {
 		purchases = []*domain.Purchase{}
 	}
-
-	credits, err := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
-	if err != nil {
-		return nil, fmt.Errorf("list credits: %w", err)
-	}
 	if credits == nil {
 		credits = []*domain.ReplayCredit{}
-	}
-
-	subscriptions, err := s.subRepo.ListByCustomerID(ctx, customerID)
-	if err != nil {
-		return nil, fmt.Errorf("list subscriptions: %w", err)
 	}
 	if subscriptions == nil {
 		subscriptions = []*domain.Subscription{}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -296,7 +296,7 @@ func TestBillingService_ProcessWebhookEvent(t *testing.T) {
 	t.Run("idempotent - duplicate event skipped", func(t *testing.T) {
 		svc, _, _, _, _, webhookRepo := newTestBillingService()
 
-		webhookRepo.On("Exists", mock.Anything, "evt_duplicate").Return(true, nil)
+		webhookRepo.On("CreateIfNotExists", mock.Anything, "evt_duplicate", "checkout.session.completed").Return(false, nil)
 
 		processCalled := false
 		err := svc.ProcessWebhookEvent(context.Background(), "evt_duplicate", "checkout.session.completed", func() error {
@@ -312,8 +312,7 @@ func TestBillingService_ProcessWebhookEvent(t *testing.T) {
 	t.Run("new event - processes and records", func(t *testing.T) {
 		svc, _, _, _, _, webhookRepo := newTestBillingService()
 
-		webhookRepo.On("Exists", mock.Anything, "evt_new").Return(false, nil)
-		webhookRepo.On("Create", mock.Anything, "evt_new", "checkout.session.completed").Return(nil)
+		webhookRepo.On("CreateIfNotExists", mock.Anything, "evt_new", "checkout.session.completed").Return(true, nil)
 
 		processCalled := false
 		err := svc.ProcessWebhookEvent(context.Background(), "evt_new", "checkout.session.completed", func() error {
@@ -326,10 +325,11 @@ func TestBillingService_ProcessWebhookEvent(t *testing.T) {
 		webhookRepo.AssertExpectations(t)
 	})
 
-	t.Run("process error propagated", func(t *testing.T) {
+	t.Run("process error - deletes record for retry", func(t *testing.T) {
 		svc, _, _, _, _, webhookRepo := newTestBillingService()
 
-		webhookRepo.On("Exists", mock.Anything, "evt_fail").Return(false, nil)
+		webhookRepo.On("CreateIfNotExists", mock.Anything, "evt_fail", "checkout.session.completed").Return(true, nil)
+		webhookRepo.On("Delete", mock.Anything, "evt_fail").Return(nil)
 
 		processErr := errors.New("processing failed")
 		err := svc.ProcessWebhookEvent(context.Background(), "evt_fail", "checkout.session.completed", func() error {
@@ -340,10 +340,10 @@ func TestBillingService_ProcessWebhookEvent(t *testing.T) {
 		webhookRepo.AssertExpectations(t)
 	})
 
-	t.Run("exists check error propagated", func(t *testing.T) {
+	t.Run("insert error propagated", func(t *testing.T) {
 		svc, _, _, _, _, webhookRepo := newTestBillingService()
 
-		webhookRepo.On("Exists", mock.Anything, "evt_db_err").Return(false, errors.New("db error"))
+		webhookRepo.On("CreateIfNotExists", mock.Anything, "evt_db_err", "checkout.session.completed").Return(false, errors.New("db error"))
 
 		err := svc.ProcessWebhookEvent(context.Background(), "evt_db_err", "checkout.session.completed", func() error {
 			return nil
@@ -444,9 +444,12 @@ func TestBillingService_GetBillingOverview(t *testing.T) {
 	})
 
 	t.Run("purchase repo error", func(t *testing.T) {
-		svc, purchaseRepo, _, _, _, _ := newTestBillingService()
+		svc, purchaseRepo, creditRepo, subRepo, _, _ := newTestBillingService()
 
 		purchaseRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return(nil, errors.New("db error"))
+		// These may or may not be called due to errgroup cancellation
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return(nil, nil).Maybe()
+		subRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return(nil, nil).Maybe()
 
 		_, err := svc.GetBillingOverview(context.Background(), "cust-1")
 

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -70,14 +70,29 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 		}
 	}
 
+	// Batch fetch all unique pixel IDs to avoid N+1 queries
+	uniqueIDs := make(map[string]struct{})
+	for _, e := range input.Events {
+		uniqueIDs[e.PixelID] = struct{}{}
+	}
+	ids := make([]string, 0, len(uniqueIDs))
+	for id := range uniqueIDs {
+		ids = append(ids, id)
+	}
+	pixels, err := s.pixelRepo.GetByIDs(ctx, ids)
+	if err != nil {
+		s.logger.Error("batch get pixels failed", "error", err)
+		return 0, fmt.Errorf("batch get pixels: %w", err)
+	}
+	pixelMap := make(map[string]*domain.Pixel, len(pixels))
+	for _, p := range pixels {
+		pixelMap[p.ID] = p
+	}
+
 	created := 0
 	for _, eventInput := range input.Events {
-		// Verify pixel belongs to customer
-		pixel, err := s.pixelRepo.GetByID(ctx, eventInput.PixelID)
-		if err != nil {
-			s.logger.Error("get pixel failed", "error", err, "pixel_id", eventInput.PixelID)
-			continue
-		}
+		// Verify pixel belongs to customer via pre-fetched map
+		pixel := pixelMap[eventInput.PixelID]
 		if pixel == nil || pixel.CustomerID != customerID || !pixel.IsActive {
 			s.logger.Warn("pixel not found or inactive", "pixel_id", eventInput.PixelID)
 			continue

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -45,11 +45,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 				er.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(true, nil)
 			},
 			wantCreated: 1,
@@ -68,11 +68,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 				er.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(false, nil)
 			},
 			wantCreated: 0,
@@ -89,7 +89,7 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"nonexistent"}).Return([]*domain.Pixel{}, nil)
 			},
 			wantCreated: 0,
 		},
@@ -105,11 +105,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-2"}).Return([]*domain.Pixel{{
 					ID:         "pixel-2",
 					CustomerID: "cust-1",
 					IsActive:   false,
-				}, nil)
+				}}, nil)
 			},
 			wantCreated: 0,
 		},
@@ -125,11 +125,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 			},
 			wantCreated: 0,
 		},
@@ -147,11 +147,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
 					return e.EventID == "custom-event-id-123"
 				})).Return(true, nil)
@@ -172,11 +172,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
 					var ud map[string]interface{}
 					if err := json.Unmarshal(e.UserData, &ud); err != nil {
@@ -202,11 +202,11 @@ func TestEventService_Ingest(t *testing.T) {
 				},
 			},
 			setup: func(er *MockEventRepo, pr *MockPixelRepo) {
-				pr.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 					ID:         "pixel-1",
 					CustomerID: "cust-1",
 					IsActive:   true,
-				}, nil)
+				}}, nil)
 				er.On("Create", mock.Anything, mock.MatchedBy(func(e *domain.PixelEvent) bool {
 					return e.EventID != "" && len(e.EventID) == 36
 				})).Return(true, nil)
@@ -236,13 +236,13 @@ func TestEventService_Ingest(t *testing.T) {
 func TestEventService_Ingest_WithFBCookies(t *testing.T) {
 	svc, eventRepo, pixelRepo := newTestEventService()
 
-	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+	pixelRepo.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 		ID:            "pixel-1",
 		CustomerID:    "cust-1",
 		IsActive:      true,
 		FBPixelID:     "fb-pixel-1",
 		FBAccessToken: "token-1",
-	}, nil)
+	}}, nil)
 	eventRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(true, nil)
 
 	input := IngestBatchInput{
@@ -354,15 +354,15 @@ func TestEventService_Ingest_BackupPixelFanOut(t *testing.T) {
 	svc, eventRepo, pixelRepo := newTestEventService()
 
 	backupID := "pixel-backup"
-	pixelRepo.On("GetByID", mock.Anything, "pixel-1").Return(&domain.Pixel{
+	pixelRepo.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
 		ID:            "pixel-1",
 		CustomerID:    "cust-1",
 		IsActive:      true,
 		FBPixelID:     "fb-pixel-1",
 		FBAccessToken: "token-1",
 		BackupPixelID: &backupID,
-	}, nil)
-	// The backup pixel lookup happens in a goroutine — set it up so it doesn't panic
+	}}, nil)
+	// The backup pixel lookup happens in a goroutine via GetByID — set it up so it doesn't panic
 	pixelRepo.On("GetByID", mock.Anything, "pixel-backup").Return(&domain.Pixel{
 		ID:            "pixel-backup",
 		CustomerID:    "cust-1",

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -96,6 +96,10 @@ func (m *MockSubscriptionRepo) GetActiveByCustomerID(ctx context.Context, custom
 	}
 	return args.Get(0).([]*domain.Subscription), args.Error(1)
 }
+func (m *MockSubscriptionRepo) GetMaxEventsPerMonth(ctx context.Context, customerID string) (int64, error) {
+	args := m.Called(ctx, customerID)
+	return args.Get(0).(int64), args.Error(1)
+}
 func (m *MockSubscriptionRepo) Update(ctx context.Context, sub *domain.Subscription) error {
 	args := m.Called(ctx, sub)
 	return args.Error(0)
@@ -155,6 +159,10 @@ func (m *MockSalePageRepo) ListByCustomerID(ctx context.Context, customerID stri
 	}
 	return args.Get(0).([]*domain.SalePage), args.Error(1)
 }
+func (m *MockSalePageRepo) CountByCustomerID(ctx context.Context, customerID string) (int, error) {
+	args := m.Called(ctx, customerID)
+	return args.Int(0), args.Error(1)
+}
 func (m *MockSalePageRepo) Update(ctx context.Context, page *domain.SalePage) error {
 	args := m.Called(ctx, page)
 	return args.Error(0)
@@ -171,12 +179,12 @@ func (m *MockSalePageRepo) SlugExists(ctx context.Context, slug string) (bool, e
 // MockWebhookEventRepo
 type MockWebhookEventRepo struct{ mock.Mock }
 
-func (m *MockWebhookEventRepo) Exists(ctx context.Context, stripeEventID string) (bool, error) {
-	args := m.Called(ctx, stripeEventID)
+func (m *MockWebhookEventRepo) CreateIfNotExists(ctx context.Context, stripeEventID, eventType string) (bool, error) {
+	args := m.Called(ctx, stripeEventID, eventType)
 	return args.Bool(0), args.Error(1)
 }
-func (m *MockWebhookEventRepo) Create(ctx context.Context, stripeEventID, eventType string) error {
-	args := m.Called(ctx, stripeEventID, eventType)
+func (m *MockWebhookEventRepo) Delete(ctx context.Context, stripeEventID string) error {
+	args := m.Called(ctx, stripeEventID)
 	return args.Error(0)
 }
 
@@ -272,12 +280,23 @@ func (m *MockPixelRepo) GetByID(ctx context.Context, id string) (*domain.Pixel, 
 	}
 	return args.Get(0).(*domain.Pixel), args.Error(1)
 }
+func (m *MockPixelRepo) GetByIDs(ctx context.Context, ids []string) ([]*domain.Pixel, error) {
+	args := m.Called(ctx, ids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Pixel), args.Error(1)
+}
 func (m *MockPixelRepo) ListByCustomerID(ctx context.Context, customerID string) ([]*domain.Pixel, error) {
 	args := m.Called(ctx, customerID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*domain.Pixel), args.Error(1)
+}
+func (m *MockPixelRepo) CountByCustomerID(ctx context.Context, customerID string) (int, error) {
+	args := m.Called(ctx, customerID)
+	return args.Int(0), args.Error(1)
 }
 func (m *MockPixelRepo) Update(ctx context.Context, p *domain.Pixel) error {
 	args := m.Called(ctx, p)
@@ -416,6 +435,10 @@ func (m *MockReplaySessionRepo) CancelSession(ctx context.Context, id string) (*
 func (m *MockReplaySessionRepo) RecoverOrphanedSessions(ctx context.Context) (int, error) {
 	args := m.Called(ctx)
 	return args.Int(0), args.Error(1)
+}
+func (m *MockReplaySessionRepo) UpdateTotalEvents(ctx context.Context, id string, totalEvents int) error {
+	args := m.Called(ctx, id, totalEvents)
+	return args.Error(0)
 }
 
 // MockNotificationRepo

--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
 )
@@ -36,17 +38,31 @@ func (s *NotificationService) List(ctx context.Context, customerID string, limit
 		limit = 20
 	}
 
-	notifications, err := s.repo.ListByCustomerID(ctx, customerID, limit)
-	if err != nil {
+	var (
+		notifications []*domain.Notification
+		unreadCount   int
+	)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		notifications, err = s.repo.ListByCustomerID(ctx, customerID, limit)
+		return err
+	})
+
+	g.Go(func() error {
+		var err error
+		unreadCount, err = s.repo.CountUnread(ctx, customerID)
+		return err
+	})
+
+	if err := g.Wait(); err != nil {
 		return nil, fmt.Errorf("list notifications: %w", err)
 	}
+
 	if notifications == nil {
 		notifications = []*domain.Notification{}
-	}
-
-	unreadCount, err := s.repo.CountUnread(ctx, customerID)
-	if err != nil {
-		return nil, fmt.Errorf("count unread notifications: %w", err)
 	}
 
 	return &NotificationListResult{

--- a/backend/internal/service/quota_service.go
+++ b/backend/internal/service/quota_service.go
@@ -105,12 +105,12 @@ func (s *QuotaService) GetCustomerQuota(ctx context.Context, customerID string) 
 // CheckAndIncrementEventQuota atomically checks and increments the event usage
 // counter, preventing race conditions in concurrent ingestion.
 func (s *QuotaService) CheckAndIncrementEventQuota(ctx context.Context, customerID string, count int64) error {
-	quota, err := s.GetCustomerQuota(ctx, customerID)
+	maxEvents, err := s.subRepo.GetMaxEventsPerMonth(ctx, customerID)
 	if err != nil {
-		return err
+		return fmt.Errorf("get max events per month: %w", err)
 	}
 
-	if err := s.usageRepo.CheckAndIncrement(ctx, customerID, count, quota.MaxEventsPerMonth); err != nil {
+	if err := s.usageRepo.CheckAndIncrement(ctx, customerID, count, maxEvents); err != nil {
 		if errors.Is(err, repository.ErrQuotaExceeded) {
 			return ErrQuotaEventsExceeded
 		}
@@ -126,12 +126,12 @@ func (s *QuotaService) CheckPixelCreationQuota(ctx context.Context, customerID s
 		return err
 	}
 
-	pixels, err := s.pixelRepo.ListByCustomerID(ctx, customerID)
+	count, err := s.pixelRepo.CountByCustomerID(ctx, customerID)
 	if err != nil {
-		return err
+		return fmt.Errorf("count pixels: %w", err)
 	}
 
-	if len(pixels) >= quota.MaxPixels {
+	if count >= quota.MaxPixels {
 		return ErrQuotaPixelsExceeded
 	}
 	return nil
@@ -144,20 +144,54 @@ func (s *QuotaService) CheckSalePageCreationQuota(ctx context.Context, customerI
 		return err
 	}
 
-	pages, err := s.salePageRepo.ListByCustomerID(ctx, customerID)
+	count, err := s.salePageRepo.CountByCustomerID(ctx, customerID)
 	if err != nil {
-		return err
+		return fmt.Errorf("count sale pages: %w", err)
 	}
 
-	if len(pages) >= quota.MaxSalePages {
+	if count >= quota.MaxSalePages {
 		return ErrQuotaSalePagesExceeded
 	}
 	return nil
 }
 
 // ConsumeReplayCredit atomically consumes one replay from the customer's active credits.
+// Pre-flight validation checks credit availability and event limits before consuming.
 // Returns the credit used so the caller can access MaxEventsPerReplay.
 func (s *QuotaService) ConsumeReplayCredit(ctx context.Context, customerID string, eventCount int) (*domain.ReplayCredit, error) {
+	// Pre-flight: check credits exist and event count is within limits before consuming
+	credits, err := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("check active credits: %w", err)
+	}
+	if len(credits) == 0 {
+		return nil, ErrQuotaReplayNotAllowed
+	}
+
+	// Verify at least one credit can handle the event count
+	hasValidCredit := false
+	for _, c := range credits {
+		if c.RemainingReplays() != 0 && (c.MaxEventsPerReplay == 0 || eventCount <= c.MaxEventsPerReplay) {
+			hasValidCredit = true
+			break
+		}
+	}
+	if !hasValidCredit {
+		// Check if it's an event limit issue vs no remaining replays
+		hasRemaining := false
+		for _, c := range credits {
+			if c.RemainingReplays() != 0 {
+				hasRemaining = true
+				break
+			}
+		}
+		if !hasRemaining {
+			return nil, ErrQuotaReplayNotAllowed
+		}
+		return nil, ErrQuotaReplayEventsExceeded
+	}
+
+	// Now atomically consume
 	credit, err := s.creditRepo.ConsumeOneCredit(ctx, customerID)
 	if err != nil {
 		return nil, fmt.Errorf("consume credit: %w", err)
@@ -165,6 +199,8 @@ func (s *QuotaService) ConsumeReplayCredit(ctx context.Context, customerID strin
 	if credit == nil {
 		return nil, ErrQuotaReplayNotAllowed
 	}
+
+	// Final check on consumed credit's actual MaxEventsPerReplay
 	if credit.MaxEventsPerReplay > 0 && eventCount > credit.MaxEventsPerReplay {
 		return nil, ErrQuotaReplayEventsExceeded
 	}

--- a/backend/internal/service/quota_service_test.go
+++ b/backend/internal/service/quota_service_test.go
@@ -157,9 +157,8 @@ func TestQuotaService_GetCustomerQuota(t *testing.T) {
 
 func TestQuotaService_CheckAndIncrementEventQuota(t *testing.T) {
 	t.Run("under limit passes", func(t *testing.T) {
-		svc, creditRepo, subRepo, usageRepo, _, _ := newTestQuotaService()
-		usage := &domain.EventUsage{EventCount: 100000}
-		setupFreePlanMocks(subRepo, creditRepo, usageRepo, usage)
+		svc, _, subRepo, usageRepo, _, _ := newTestQuotaService()
+		subRepo.On("GetMaxEventsPerMonth", mock.Anything, "cust-1").Return(int64(domain.FreeMaxEventsPerMonth), nil)
 		usageRepo.On("CheckAndIncrement", mock.Anything, "cust-1", int64(10), int64(domain.FreeMaxEventsPerMonth)).Return(nil)
 
 		err := svc.CheckAndIncrementEventQuota(context.Background(), "cust-1", 10)
@@ -168,9 +167,8 @@ func TestQuotaService_CheckAndIncrementEventQuota(t *testing.T) {
 	})
 
 	t.Run("quota exceeded returns error", func(t *testing.T) {
-		svc, creditRepo, subRepo, usageRepo, _, _ := newTestQuotaService()
-		usage := &domain.EventUsage{EventCount: int64(domain.FreeMaxEventsPerMonth)}
-		setupFreePlanMocks(subRepo, creditRepo, usageRepo, usage)
+		svc, _, subRepo, usageRepo, _, _ := newTestQuotaService()
+		subRepo.On("GetMaxEventsPerMonth", mock.Anything, "cust-1").Return(int64(domain.FreeMaxEventsPerMonth), nil)
 		usageRepo.On("CheckAndIncrement", mock.Anything, "cust-1", int64(1), int64(domain.FreeMaxEventsPerMonth)).Return(repository.ErrQuotaExceeded)
 
 		err := svc.CheckAndIncrementEventQuota(context.Background(), "cust-1", 1)
@@ -184,9 +182,7 @@ func TestQuotaService_CheckPixelCreationQuota(t *testing.T) {
 		svc, creditRepo, subRepo, usageRepo, pixelRepo, _ := newTestQuotaService()
 		setupFreePlanMocks(subRepo, creditRepo, usageRepo, nil)
 
-		pixelRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return([]*domain.Pixel{
-			{ID: "p1"}, {ID: "p2"},
-		}, nil)
+		pixelRepo.On("CountByCustomerID", mock.Anything, "cust-1").Return(2, nil)
 
 		err := svc.CheckPixelCreationQuota(context.Background(), "cust-1")
 
@@ -198,12 +194,7 @@ func TestQuotaService_CheckPixelCreationQuota(t *testing.T) {
 		svc, creditRepo, subRepo, usageRepo, pixelRepo, _ := newTestQuotaService()
 		setupFreePlanMocks(subRepo, creditRepo, usageRepo, nil)
 
-		// Create FreeMaxPixels pixels
-		pixels := make([]*domain.Pixel, domain.FreeMaxPixels)
-		for i := range pixels {
-			pixels[i] = &domain.Pixel{ID: "p" + string(rune('0'+i))}
-		}
-		pixelRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return(pixels, nil)
+		pixelRepo.On("CountByCustomerID", mock.Anything, "cust-1").Return(domain.FreeMaxPixels, nil)
 
 		err := svc.CheckPixelCreationQuota(context.Background(), "cust-1")
 
@@ -216,12 +207,14 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("success - has credit", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _ := newTestQuotaService()
 
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(&domain.ReplayCredit{
+		activeCredit := &domain.ReplayCredit{
 			ID:                 "credit-1",
 			TotalReplays:       3,
 			UsedReplays:        1,
 			MaxEventsPerReplay: domain.FreeMaxEventsPerReplay,
-		}, nil)
+		}
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
 
@@ -234,7 +227,7 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("no credits available", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _ := newTestQuotaService()
 
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(nil, nil)
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{}, nil)
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
 
@@ -245,10 +238,12 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("exceeds max events per replay", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _ := newTestQuotaService()
 
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(&domain.ReplayCredit{
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{{
 			ID:                 "credit-1",
+			TotalReplays:       3,
+			UsedReplays:        0,
 			MaxEventsPerReplay: 1000,
-		}, nil)
+		}}, nil)
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 5000)
 
@@ -259,10 +254,14 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("unlimited events per replay (0 limit)", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _ := newTestQuotaService()
 
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(&domain.ReplayCredit{
+		activeCredit := &domain.ReplayCredit{
 			ID:                 "credit-1",
+			TotalReplays:       3,
+			UsedReplays:        0,
 			MaxEventsPerReplay: 0,
-		}, nil)
+		}
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 999999)
 
@@ -274,6 +273,12 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("consume credit repo error", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _ := newTestQuotaService()
 
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{{
+			ID:                 "credit-1",
+			TotalReplays:       3,
+			UsedReplays:        0,
+			MaxEventsPerReplay: 0,
+		}}, nil)
 		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(nil, errors.New("db error"))
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -179,18 +179,6 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		return nil, fmt.Errorf("get events for replay: %w", err)
 	}
 
-	// Consume a replay credit if quota service is available
-	if s.quotaService != nil {
-		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(events))
-		if err != nil {
-			return nil, err
-		}
-		// Cap events to the credit's limit if lower than the global max
-		if credit.MaxEventsPerReplay > 0 && len(events) > credit.MaxEventsPerReplay {
-			events = events[:credit.MaxEventsPerReplay]
-		}
-	}
-
 	// Default TimeMode to "original"
 	timeMode := input.TimeMode
 	if timeMode == "" {
@@ -213,6 +201,7 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		}
 	}
 
+	// Create session FIRST (before consuming credit) so we have a record
 	session := &domain.ReplaySession{
 		CustomerID:    customerID,
 		SourcePixelID: input.SourcePixelID,
@@ -227,6 +216,26 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 
 	if err := s.replayRepo.Create(ctx, session); err != nil {
 		return nil, fmt.Errorf("create replay session: %w", err)
+	}
+
+	// Consume a replay credit if quota service is available
+	if s.quotaService != nil {
+		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(events))
+		if err != nil {
+			// Mark session as failed since credit consumption failed
+			if updateErr := s.replayRepo.UpdateStatusWithError(ctx, session.ID, "failed", err.Error()); updateErr != nil {
+				s.logger.Error("failed to mark session failed after credit error", "error", updateErr, "session_id", session.ID)
+			}
+			return nil, err
+		}
+		// Cap events to the credit's limit if lower than the global max
+		if credit.MaxEventsPerReplay > 0 && len(events) > credit.MaxEventsPerReplay {
+			events = events[:credit.MaxEventsPerReplay]
+			session.TotalEvents = len(events)
+			if updateErr := s.replayRepo.UpdateTotalEvents(ctx, session.ID, len(events)); updateErr != nil {
+				s.logger.Warn("failed to update total events after cap", "error", updateErr, "session_id", session.ID)
+			}
+		}
 	}
 
 	// Start replay in background (semaphore-limited)
@@ -607,7 +616,7 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 		retryEvents = allEvents
 	}
 
-	// Create a NEW session (preserve history)
+	// Create a NEW session FIRST (preserve history, before consuming credit)
 	newSession := &domain.ReplaySession{
 		CustomerID:    customerID,
 		SourcePixelID: session.SourcePixelID,
@@ -622,6 +631,26 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 
 	if err := s.replayRepo.Create(ctx, newSession); err != nil {
 		return nil, fmt.Errorf("create retry replay session: %w", err)
+	}
+
+	// Consume a replay credit if quota service is available
+	if s.quotaService != nil {
+		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(retryEvents))
+		if err != nil {
+			// Mark session as failed since credit consumption failed
+			if updateErr := s.replayRepo.UpdateStatusWithError(ctx, newSession.ID, "failed", err.Error()); updateErr != nil {
+				s.logger.Error("failed to mark retry session failed after credit error", "error", updateErr, "session_id", newSession.ID)
+			}
+			return nil, err
+		}
+		// Cap events to the credit's limit if lower
+		if credit.MaxEventsPerReplay > 0 && len(retryEvents) > credit.MaxEventsPerReplay {
+			retryEvents = retryEvents[:credit.MaxEventsPerReplay]
+			newSession.TotalEvents = len(retryEvents)
+			if updateErr := s.replayRepo.UpdateTotalEvents(ctx, newSession.ID, len(retryEvents)); updateErr != nil {
+				s.logger.Warn("failed to update total events after cap", "error", updateErr, "session_id", newSession.ID)
+			}
+		}
 	}
 
 	// Start replay in background (semaphore-limited)


### PR DESCRIPTION
## Summary

- **CRITICAL**: Reorder replay creation — session persisted BEFORE credit consumed, preventing credit loss on DB failure
- **CRITICAL**: Pre-flight validation in `ConsumeReplayCredit` checks event limits BEFORE consuming credit
- **HIGH**: Retry now consumes credit (was free unlimited retries)
- **HIGH**: Atomic webhook idempotency via `INSERT...ON CONFLICT RETURNING` + delete-on-failure
- **HIGH**: Batch pixel lookup (`GetByIDs`) eliminates N+1 queries in event ingestion
- **HIGH**: Narrow `GetMaxEventsPerMonth` query replaces 3-query `GetCustomerQuota` on ingest hot path
- **MEDIUM**: Parallel queries via errgroup in analytics, billing, and notification services
- **MEDIUM**: `CountByCustomerID` replaces full list fetch for quota checks

## Test plan

- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (no data races)
- [ ] CI passes (backend + e2e)
- [ ] Verify replay creation works with credit deduction
- [ ] Verify webhook idempotency — duplicate Stripe events are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)