### PR TITLE
feat: add sale pages +25 and pixels +40 subscription add-ons

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,6 +35,8 @@ STRIPE_PRICE_REPLAY_UNLIMITED=price_xxx
 STRIPE_PRICE_RETENTION_180=price_xxx
 STRIPE_PRICE_RETENTION_365=price_xxx
 STRIPE_PRICE_EVENTS_1M=price_xxx
+STRIPE_PRICE_SALE_PAGES_25=price_xxx
+STRIPE_PRICE_PIXELS_40=price_xxx
 
 # Frontend URL (for Stripe redirect after checkout)
 FRONTEND_URL=http://localhost:5173

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	StripePriceRetention180    string `env:"STRIPE_PRICE_RETENTION_180"`
 	StripePriceRetention365    string `env:"STRIPE_PRICE_RETENTION_365"`
 	StripePriceEvents1M        string `env:"STRIPE_PRICE_EVENTS_1M"`
+	StripePriceSalePages25     string `env:"STRIPE_PRICE_SALE_PAGES_25"`
+	StripePricePixels40        string `env:"STRIPE_PRICE_PIXELS_40"`
 	FrontendURL                string `env:"FRONTEND_URL" envDefault:"http://localhost:5173"`
 
 	// Token encryption (32-byte hex-encoded key, optional)

--- a/backend/internal/domain/billing.go
+++ b/backend/internal/domain/billing.go
@@ -14,6 +14,8 @@ const (
 	AddonRetention180 = "retention_180"
 	AddonRetention365 = "retention_365"
 	AddonEvents1M     = "events_1m"
+	AddonSalePages25  = "sale_pages_25"
+	AddonPixels40     = "pixels_40"
 )
 
 // Purchase statuses

--- a/backend/internal/domain/quota.go
+++ b/backend/internal/domain/quota.go
@@ -14,6 +14,8 @@ const (
 	Addon1MEventsPerMonth = 1_000_000
 	AddonRetention180Days = 180
 	AddonRetention365Days = 365
+	AddonSalePages25Extra = 25
+	AddonPixels40Extra    = 40
 )
 
 // CustomerQuota represents the resolved effective limits for a customer.

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -43,13 +43,14 @@ type PackConfig struct {
 }
 
 type BillingService struct {
-	purchaseRepo repository.PurchaseRepository
-	creditRepo   repository.ReplayCreditRepository
-	subRepo      repository.SubscriptionRepository
-	customerRepo repository.CustomerRepository
-	webhookRepo  repository.WebhookEventRepository
-	cfg          *config.Config
-	packConfigs  map[string]PackConfig
+	purchaseRepo  repository.PurchaseRepository
+	creditRepo    repository.ReplayCreditRepository
+	subRepo       repository.SubscriptionRepository
+	customerRepo  repository.CustomerRepository
+	webhookRepo   repository.WebhookEventRepository
+	cfg           *config.Config
+	packConfigs   map[string]PackConfig
+	addonPriceIDs map[string]string // addon type -> Stripe price ID
 }
 
 func NewBillingService(
@@ -96,6 +97,14 @@ func NewBillingService(
 			MaxEventsPerReplay: domain.FreeMaxEventsPerReplay,
 			ExpiryDays:         365,
 		},
+	}
+
+	s.addonPriceIDs = map[string]string{
+		domain.AddonRetention180: cfg.StripePriceRetention180,
+		domain.AddonRetention365: cfg.StripePriceRetention365,
+		domain.AddonEvents1M:     cfg.StripePriceEvents1M,
+		domain.AddonSalePages25:  cfg.StripePriceSalePages25,
+		domain.AddonPixels40:     cfg.StripePricePixels40,
 	}
 
 	return s
@@ -475,28 +484,19 @@ func (s *BillingService) GetBillingOverview(ctx context.Context, customerID stri
 
 // addonPriceID maps an addon type to its Stripe price ID.
 func (s *BillingService) addonPriceID(addonType string) (string, error) {
-	switch addonType {
-	case domain.AddonRetention180:
-		return s.cfg.StripePriceRetention180, nil
-	case domain.AddonRetention365:
-		return s.cfg.StripePriceRetention365, nil
-	case domain.AddonEvents1M:
-		return s.cfg.StripePriceEvents1M, nil
-	default:
+	priceID, ok := s.addonPriceIDs[addonType]
+	if !ok {
 		return "", fmt.Errorf("unknown addon type: %s", addonType)
 	}
+	return priceID, nil
 }
 
 // resolveAddonType maps a Stripe price ID back to an addon type.
 func (s *BillingService) resolveAddonType(priceID string) string {
-	switch priceID {
-	case s.cfg.StripePriceRetention180:
-		return domain.AddonRetention180
-	case s.cfg.StripePriceRetention365:
-		return domain.AddonRetention365
-	case s.cfg.StripePriceEvents1M:
-		return domain.AddonEvents1M
-	default:
-		return "unknown"
+	for addonType, id := range s.addonPriceIDs {
+		if id == priceID {
+			return addonType
+		}
 	}
+	return "unknown"
 }

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -37,6 +37,8 @@ func newTestBillingService() (
 		StripePriceRetention180:    "price_retention_180",
 		StripePriceRetention365:    "price_retention_365",
 		StripePriceEvents1M:        "price_events_1m",
+		StripePriceSalePages25:     "price_sale_pages_25",
+		StripePricePixels40:        "price_pixels_40",
 		FrontendURL:                "http://localhost:5173",
 	}
 
@@ -352,6 +354,58 @@ func TestBillingService_ProcessWebhookEvent(t *testing.T) {
 		assert.Error(t, err)
 		webhookRepo.AssertExpectations(t)
 	})
+}
+
+func TestBillingService_AddonPriceID(t *testing.T) {
+	svc, _, _, _, _, _ := newTestBillingService()
+
+	tests := []struct {
+		addonType string
+		wantPrice string
+		wantErr   bool
+	}{
+		{domain.AddonRetention180, "price_retention_180", false},
+		{domain.AddonRetention365, "price_retention_365", false},
+		{domain.AddonEvents1M, "price_events_1m", false},
+		{domain.AddonSalePages25, "price_sale_pages_25", false},
+		{domain.AddonPixels40, "price_pixels_40", false},
+		{"unknown", "", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.addonType, func(t *testing.T) {
+			price, err := svc.addonPriceID(tc.addonType)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantPrice, price)
+			}
+		})
+	}
+}
+
+func TestBillingService_ResolveAddonType(t *testing.T) {
+	svc, _, _, _, _, _ := newTestBillingService()
+
+	tests := []struct {
+		priceID       string
+		wantAddonType string
+	}{
+		{"price_retention_180", domain.AddonRetention180},
+		{"price_retention_365", domain.AddonRetention365},
+		{"price_events_1m", domain.AddonEvents1M},
+		{"price_sale_pages_25", domain.AddonSalePages25},
+		{"price_pixels_40", domain.AddonPixels40},
+		{"price_unknown", "unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.priceID, func(t *testing.T) {
+			addonType := svc.resolveAddonType(tc.priceID)
+			assert.Equal(t, tc.wantAddonType, addonType)
+		})
+	}
 }
 
 func TestBillingService_CreateReplayPackCheckout(t *testing.T) {

--- a/backend/internal/service/quota_service.go
+++ b/backend/internal/service/quota_service.go
@@ -68,6 +68,10 @@ func (s *QuotaService) GetCustomerQuota(ctx context.Context, customerID string) 
 			}
 		case domain.AddonEvents1M:
 			quota.MaxEventsPerMonth += int64(domain.Addon1MEventsPerMonth)
+		case domain.AddonSalePages25:
+			quota.MaxSalePages += domain.AddonSalePages25Extra
+		case domain.AddonPixels40:
+			quota.MaxPixels += domain.AddonPixels40Extra
 		}
 	}
 

--- a/backend/internal/service/quota_service_test.go
+++ b/backend/internal/service/quota_service_test.go
@@ -132,6 +132,46 @@ func TestQuotaService_GetCustomerQuota(t *testing.T) {
 		usageRepo.AssertExpectations(t)
 	})
 
+	t.Run("with sale pages addon increases limit", func(t *testing.T) {
+		svc, creditRepo, subRepo, usageRepo, _, _ := newTestQuotaService()
+
+		subRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.Subscription{
+			{AddonType: domain.AddonSalePages25, Status: domain.SubStatusActive},
+		}, nil)
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{}, nil)
+		usageRepo.On("GetCurrentMonth", mock.Anything, "cust-1").Return(nil, nil)
+
+		quota, err := svc.GetCustomerQuota(context.Background(), "cust-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.FreeMaxSalePages+domain.AddonSalePages25Extra, quota.MaxSalePages)
+		assert.Equal(t, domain.FreeMaxPixels, quota.MaxPixels) // pixels unchanged
+
+		subRepo.AssertExpectations(t)
+		creditRepo.AssertExpectations(t)
+		usageRepo.AssertExpectations(t)
+	})
+
+	t.Run("with pixels addon increases limit", func(t *testing.T) {
+		svc, creditRepo, subRepo, usageRepo, _, _ := newTestQuotaService()
+
+		subRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.Subscription{
+			{AddonType: domain.AddonPixels40, Status: domain.SubStatusActive},
+		}, nil)
+		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{}, nil)
+		usageRepo.On("GetCurrentMonth", mock.Anything, "cust-1").Return(nil, nil)
+
+		quota, err := svc.GetCustomerQuota(context.Background(), "cust-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.FreeMaxPixels+domain.AddonPixels40Extra, quota.MaxPixels)
+		assert.Equal(t, domain.FreeMaxSalePages, quota.MaxSalePages) // sale pages unchanged
+
+		subRepo.AssertExpectations(t)
+		creditRepo.AssertExpectations(t)
+		usageRepo.AssertExpectations(t)
+	})
+
 	t.Run("with usage this month", func(t *testing.T) {
 		svc, creditRepo, subRepo, usageRepo, _, _ := newTestQuotaService()
 		usage := &domain.EventUsage{EventCount: 50000}

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -11,6 +11,8 @@ import {
   ShieldCheck,
   Database,
   CalendarDays,
+  LayoutGrid,
+  Radio,
 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -76,6 +78,20 @@ const ADDONS = [
     price: 490,
     description: 'เพิ่มขีดจำกัดอีเวนต์รายเดือนเป็น 1,000,000',
     icon: Zap,
+  },
+  {
+    type: 'sale_pages_25',
+    name: 'Sale Pages +25',
+    price: 199,
+    description: 'เพิ่มจำนวนเซลเพจจาก 5 เป็น 30 หน้า',
+    icon: LayoutGrid,
+  },
+  {
+    type: 'pixels_40',
+    name: 'Pixels +40',
+    price: 149,
+    description: 'เพิ่มจำนวนพิกเซลจาก 10 เป็น 50',
+    icon: Radio,
   },
 ] as const
 
@@ -269,7 +285,7 @@ export function BillingPage() {
       {/* Add-ons */}
       <div className="mb-8">
         <h2 className="text-lg font-semibold text-foreground mb-4">ส่วนเสริม</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {ADDONS.map((addon) => {
             const isActive = activeSubscriptions.some((s) => s.addon_type === addon.type)
             return (


### PR DESCRIPTION
## Summary
- เพิ่ม 2 subscription add-ons ใหม่: **Sale Pages +25** (199฿/เดือน) และ **Pixels +40** (149฿/เดือน)
- Refactor addon price mapping จาก parallel switch statements เป็น map lookup (consistent กับ `packConfigs` pattern)
- เพิ่ม test cases ครอบคลุม addon price mapping และ quota calculation

## Changes
| File | Change |
|------|--------|
| `domain/billing.go` | Add `AddonSalePages25`, `AddonPixels40` constants |
| `domain/quota.go` | Add `AddonSalePages25Extra = 25`, `AddonPixels40Extra = 40` |
| `config/config.go` | Add 2 Stripe price ID env vars |
| `service/billing_service.go` | Add `addonPriceIDs` map, refactor `addonPriceID()` + `resolveAddonType()` |
| `service/quota_service.go` | Add 2 cases for MaxSalePages/MaxPixels in `GetCustomerQuota()` |
| `pages/BillingPage.tsx` | Add 2 ADDONS entries, responsive grid `sm:grid-cols-2 lg:grid-cols-3` |
| `.env.example` | Add `STRIPE_PRICE_SALE_PAGES_25`, `STRIPE_PRICE_PIXELS_40` |

## Stripe Configuration (Done)
- Created products + prices in Stripe Test Mode
- Set Railway env vars via MCP

## Test plan
- [x] `go vet ./...` — no errors
- [x] `go test -race ./...` — all pass including new test cases
- [x] `npm run lint` — no errors
- [x] `npm run build` — successful
- [ ] Post-deploy: verify 5 add-ons visible on /billing page
- [ ] Test checkout flow for Sale Pages +25
- [ ] Test checkout flow for Pixels +40

🤖 Generated with [Claude Code](https://claude.com/claude-code)