### PR TITLE
fix: remove undefined CDN_DOMAIN env var from nginx CSP

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,7 +22,7 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev ${CDN_DOMAIN}; font-src 'self' data: fonts.gstatic.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev; font-src 'self' data: fonts.gstatic.com" always;
 
     location /assets/ {
         expires 1y;
@@ -34,7 +34,7 @@ server {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev ${CDN_DOMAIN}; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev; font-src 'self' data: fonts.gstatic.com" always;
     }
 
     # Proxy public sale pages to backend API
@@ -76,6 +76,6 @@ server {
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev ${CDN_DOMAIN}; font-src 'self' data: fonts.gstatic.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com; connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com; frame-src js.stripe.com accounts.google.com; img-src 'self' data: *.googleusercontent.com *.r2.dev; font-src 'self' data: fonts.gstatic.com" always;
     }
 }


### PR DESCRIPTION
## Summary
- Remove `${CDN_DOMAIN}` from nginx CSP `img-src` directive in 3 locations
- This variable was never set as a Railway environment variable, causing `envsubst` to leave the literal `${CDN_DOMAIN}` in the config
- Nginx fails to start because it doesn't recognize `cdn_domain` as a valid nginx variable → **crash loop**
- R2 images are already covered by `*.r2.dev` wildcard, so no functionality is lost

## Root Cause
Commit `5bb64ee` (PR #65) added `${CDN_DOMAIN}` to CSP but didn't configure the env var on Railway.

## Test plan
- [ ] PR merges and Railway auto-deploys
- [ ] pixlinks.xyz loads successfully (no more "Application failed to respond")
- [ ] CSP headers still allow R2 images via `*.r2.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)