### PR TITLE
feat: redesign billing page with component architecture and toggle UX

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-switch": "^1.2.6",
         "@react-oauth/google": "^0.13.4",
         "@tailwindcss/vite": "^4.2.0",
         "@tanstack/react-query": "^5.90.21",
@@ -1274,6 +1275,197 @@
         "node": ">=18"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-oauth/google": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.4.tgz",
@@ -2208,7 +2400,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-switch": "^1.2.6",
     "@react-oauth/google": "^0.13.4",
     "@tailwindcss/vite": "^4.2.0",
     "@tanstack/react-query": "^5.90.21",

--- a/frontend/src/components/billing/ActiveCreditsSection.tsx
+++ b/frontend/src/components/billing/ActiveCreditsSection.tsx
@@ -1,0 +1,97 @@
+import { Ticket } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { isUnlimited, timeAgo, daysUntil } from '@/lib/utils'
+import type { ReplayCredit } from '@/types'
+
+interface ActiveCreditsSectionProps {
+  credits: ReplayCredit[]
+  onViewPlans?: () => void
+}
+
+export function ActiveCreditsSection({ credits, onViewPlans }: ActiveCreditsSectionProps) {
+  if (credits.length === 0) {
+    return (
+      <section>
+        <h2 className="text-lg font-semibold text-foreground mb-4">เครดิตรีเพลย์</h2>
+        <Card className="border-dashed">
+          <CardContent className="p-8 text-center">
+            <Ticket className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+            <p className="text-sm text-muted-foreground mb-3">
+              ยังไม่มีเครดิตรีเพลย์ — ซื้อแพ็กด้านบนเพื่อเริ่มต้น
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onViewPlans}
+            >
+              ดูแพ็กรีเพลย์
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+    )
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-foreground mb-4">เครดิตรีเพลย์</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {credits.map((credit) => {
+          const remaining = daysUntil(credit.expires_at)
+          const expiringSoon = remaining > 0 && remaining <= 30
+          const ratio = isUnlimited(credit.total_replays)
+            ? 0.1
+            : credit.total_replays > 0
+              ? credit.used_replays / credit.total_replays
+              : 0
+
+          return (
+            <Card
+              key={credit.id}
+              className={expiringSoon ? 'border-amber-400' : ''}
+            >
+              <CardContent className="p-5">
+                <div className="flex items-center justify-between mb-3">
+                  <Badge variant="success">ใช้งาน</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    หมดอายุ {timeAgo(credit.expires_at)}
+                  </span>
+                </div>
+
+                {expiringSoon && (
+                  <p className="text-xs text-amber-600 mb-2">
+                    หมดอายุใน {remaining} วัน
+                  </p>
+                )}
+
+                <p className="text-sm font-medium text-foreground capitalize mb-2">
+                  แพ็ก {credit.pack_type}
+                </p>
+
+                <div className="flex items-center justify-between text-sm mb-2">
+                  <span className="text-muted-foreground">รีเพลย์ที่ใช้แล้ว</span>
+                  <span className="font-semibold text-foreground">
+                    {credit.used_replays} / {isUnlimited(credit.total_replays) ? 'ไม่จำกัด' : credit.total_replays}
+                  </span>
+                </div>
+
+                <div className="h-1.5 bg-secondary rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full"
+                    style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+                  />
+                </div>
+
+                <p className="text-xs text-muted-foreground mt-2">
+                  สูงสุด {credit.max_events_per_replay.toLocaleString()} อีเวนต์ต่อรีเพลย์
+                </p>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/billing/AddonToggleSection.tsx
+++ b/frontend/src/components/billing/AddonToggleSection.tsx
@@ -1,0 +1,135 @@
+import {
+  LayoutGrid,
+  Radio,
+  Zap,
+  CalendarDays,
+  Loader2,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Switch } from '@/components/ui/switch'
+import type { Subscription } from '@/types'
+
+const ADDONS = [
+  {
+    type: 'sale_pages_25',
+    name: 'Sale Pages +25',
+    price: 199,
+    freeLabel: 'ฟรี 5',
+    upgradeLabel: 'เพิ่มเป็น 30 หน้า',
+    icon: LayoutGrid,
+  },
+  {
+    type: 'pixels_40',
+    name: 'Pixels +40',
+    price: 149,
+    freeLabel: 'ฟรี 10',
+    upgradeLabel: 'เพิ่มเป็น 50',
+    icon: Radio,
+  },
+  {
+    type: 'events_1m',
+    name: 'Events 1M',
+    price: 490,
+    freeLabel: 'ฟรี 200K',
+    upgradeLabel: 'เพิ่มเป็น 1M/เดือน',
+    icon: Zap,
+  },
+  {
+    type: 'retention_180',
+    name: 'Retention 180d',
+    price: 390,
+    freeLabel: 'ฟรี 60 วัน',
+    upgradeLabel: 'เพิ่มเป็น 180 วัน',
+    icon: CalendarDays,
+  },
+  {
+    type: 'retention_365',
+    name: 'Retention 365d',
+    price: 690,
+    freeLabel: 'ฟรี 60 วัน',
+    upgradeLabel: 'เพิ่มเป็น 365 วัน',
+    icon: CalendarDays,
+  },
+] as const
+
+interface AddonToggleSectionProps {
+  activeSubscriptions: Subscription[]
+  pendingCheckoutType: string | null
+  isPending: boolean
+  onCheckout: (params: { addon_type: string }) => void
+  onManageBilling: () => void
+}
+
+export function AddonToggleSection({
+  activeSubscriptions,
+  pendingCheckoutType,
+  isPending,
+  onCheckout,
+  onManageBilling,
+}: AddonToggleSectionProps) {
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-4">
+        <h2 className="text-lg font-semibold text-foreground">ส่วนเสริม</h2>
+        <Badge variant="secondary">รายเดือน · ยกเลิกได้ทุกเมื่อ</Badge>
+      </div>
+
+      <Card>
+        <CardContent className="p-0 divide-y divide-border">
+          {ADDONS.map((addon) => {
+            const activeSub = activeSubscriptions.find((s) => s.addon_type === addon.type)
+            const isActive = !!activeSub
+            const isToggling = pendingCheckoutType === addon.type
+
+            return (
+              <div key={addon.type} className="flex items-center gap-4 px-5 py-4">
+                <div className="h-9 w-9 rounded-lg bg-muted flex items-center justify-center shrink-0">
+                  <addon.icon className="h-5 w-5 text-foreground" />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-foreground">{addon.name}</p>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {addon.freeLabel} → {addon.upgradeLabel}
+                  </p>
+                  {isActive && activeSub.current_period_end && (
+                    <p className="text-xs text-emerald-600 mt-0.5">
+                      ต่ออายุ {new Date(activeSub.current_period_end).toLocaleDateString('th-TH')}
+                    </p>
+                  )}
+                </div>
+
+                <div className="text-right shrink-0 mr-2">
+                  <p className="text-sm font-semibold text-foreground">
+                    ฿{addon.price.toLocaleString('th-TH')}
+                  </p>
+                  <p className="text-xs text-muted-foreground">/เดือน</p>
+                </div>
+
+                {isToggling ? (
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground shrink-0" />
+                ) : (
+                  <Switch
+                    checked={isActive}
+                    disabled={isPending}
+                    aria-label={`เปิด/ปิด ${addon.name}`}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        onCheckout({ addon_type: addon.type })
+                      } else {
+                        onManageBilling()
+                      }
+                    }}
+                  />
+                )}
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/frontend/src/components/billing/PurchaseHistorySection.tsx
+++ b/frontend/src/components/billing/PurchaseHistorySection.tsx
@@ -1,0 +1,99 @@
+import { Collapsible } from '@/components/ui/collapsible'
+import { Badge } from '@/components/ui/badge'
+import { formatBaht } from '@/lib/utils'
+import type { Purchase } from '@/types'
+
+interface PurchaseHistorySectionProps {
+  purchases: Purchase[]
+  isLoading: boolean
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const config = {
+    completed: { variant: 'success' as const, label: 'สำเร็จ' },
+    pending: { variant: 'secondary' as const, label: 'รอดำเนินการ' },
+  }
+  const { variant, label } = config[status as keyof typeof config] ?? { variant: 'destructive' as const, label: 'ล้มเหลว' }
+  return <Badge variant={variant}>{label}</Badge>
+}
+
+export function PurchaseHistorySection({ purchases, isLoading }: PurchaseHistorySectionProps) {
+  if (isLoading) {
+    return (
+      <section>
+        <Collapsible title="ประวัติการซื้อ (กำลังโหลด...)">
+          <p className="text-sm text-muted-foreground text-center py-4">กำลังโหลด...</p>
+        </Collapsible>
+      </section>
+    )
+  }
+
+  const count = purchases.length
+  const title = count > 0
+    ? `ประวัติการซื้อ (${count} รายการ)`
+    : 'ประวัติการซื้อ'
+
+  return (
+    <section>
+      <Collapsible title={title}>
+        {count === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            ยังไม่มีประวัติการซื้อ
+          </p>
+        ) : (
+          <>
+            {/* Desktop table */}
+            <div className="hidden sm:block overflow-x-auto">
+              <table className="w-full text-sm" aria-label="ประวัติการซื้อ">
+                <thead className="bg-muted">
+                  <tr>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">วันที่</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">แพ็ก</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">จำนวนเงิน</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">สถานะ</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {purchases.map((purchase) => (
+                    <tr key={purchase.id}>
+                      <td className="px-4 py-3 text-foreground">
+                        {new Date(purchase.created_at).toLocaleDateString('th-TH')}
+                      </td>
+                      <td className="px-4 py-3 text-foreground capitalize">{purchase.pack_type}</td>
+                      <td className="px-4 py-3 text-foreground">
+                        {formatBaht(purchase.amount_satang)} {purchase.currency}
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={purchase.status} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile card list */}
+            <div className="sm:hidden space-y-3">
+              {purchases.map((purchase) => (
+                <div key={purchase.id} className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
+                  <div>
+                    <p className="text-sm font-medium text-foreground capitalize">{purchase.pack_type}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(purchase.created_at).toLocaleDateString('th-TH')}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-foreground">
+                      {formatBaht(purchase.amount_satang)} {purchase.currency}
+                    </p>
+                    <StatusBadge status={purchase.status} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </Collapsible>
+    </section>
+  )
+}

--- a/frontend/src/components/billing/ReplayPackSection.tsx
+++ b/frontend/src/components/billing/ReplayPackSection.tsx
@@ -1,0 +1,139 @@
+import {
+  Zap,
+  Package,
+  Crown,
+  CheckCircle2,
+  CreditCard,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { isUnlimited } from '@/lib/utils'
+
+const REPLAY_PACKS = [
+  {
+    type: 'replay_1',
+    name: 'Starter',
+    price: 299,
+    replays: 1,
+    eventsPerReplay: 100_000,
+    expiryDays: 90,
+    pricePerReplay: 299,
+    icon: Zap,
+    popular: false,
+  },
+  {
+    type: 'replay_3',
+    name: 'Pro',
+    price: 699,
+    replays: 3,
+    eventsPerReplay: 100_000,
+    expiryDays: 180,
+    pricePerReplay: 233,
+    icon: Package,
+    popular: true,
+  },
+  {
+    type: 'replay_unlimited',
+    name: 'Unlimited',
+    price: 1490,
+    replays: -1,
+    eventsPerReplay: 100_000,
+    expiryDays: 365,
+    icon: Crown,
+    popular: false,
+  },
+] as const
+
+interface ReplayPackSectionProps {
+  pendingCheckoutType: string | null
+  isPending: boolean
+  onCheckout: (params: { pack_type: string }) => void
+}
+
+export function ReplayPackSection({ pendingCheckoutType, isPending, onCheckout }: ReplayPackSectionProps) {
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-4">
+        <h2 className="text-lg font-semibold text-foreground">แพ็กรีเพลย์</h2>
+        <Badge variant="secondary">ซื้อครั้งเดียว</Badge>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {REPLAY_PACKS.map((pack) => (
+          <Card
+            key={pack.type}
+            className={
+              pack.popular
+                ? 'border-primary ring-1 ring-primary md:scale-[1.02] relative'
+                : ''
+            }
+          >
+            {pack.popular && (
+              <div className="bg-primary text-primary-foreground text-center text-xs font-medium py-1 rounded-t-lg">
+                ยอดนิยม
+              </div>
+            )}
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="h-9 w-9 rounded-lg bg-muted flex items-center justify-center">
+                  <pack.icon className="h-5 w-5 text-foreground" />
+                </div>
+                <p className="font-semibold text-foreground">{pack.name}</p>
+              </div>
+
+              <div className="mb-1">
+                <span className="text-3xl font-bold text-foreground">
+                  {pack.price.toLocaleString('th-TH')}
+                </span>
+                <span className="text-sm text-muted-foreground"> THB</span>
+              </div>
+              {'pricePerReplay' in pack && (
+                <p className="text-xs text-muted-foreground mb-4">
+                  {pack.pricePerReplay} ฿/รีเพลย์
+                </p>
+              )}
+              {!('pricePerReplay' in pack) && <div className="mb-4" />}
+
+              <ul className="space-y-2 mb-5 text-sm text-muted-foreground">
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                  {isUnlimited(pack.replays) ? 'รีเพลย์ไม่จำกัด' : `${pack.replays} รีเพลย์`}
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                  สูงสุด {pack.eventsPerReplay.toLocaleString()} อีเวนต์/รีเพลย์
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                  ใช้ได้ {pack.expiryDays} วัน
+                </li>
+              </ul>
+
+              <Button
+                className="w-full"
+                variant={pack.popular ? 'default' : 'outline'}
+                onClick={() => onCheckout({ pack_type: pack.type })}
+                disabled={isPending}
+              >
+                {pendingCheckoutType === pack.type ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <CreditCard className="h-4 w-4" />
+                )}
+                {pack.popular ? 'เลือกแพ็กนี้' : 'ซื้อเลย'}
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground text-center mt-3 flex items-center justify-center gap-1">
+        <ShieldCheck className="h-3.5 w-3.5" />
+        ชำระเงินปลอดภัยผ่าน Stripe
+      </p>
+    </section>
+  )
+}

--- a/frontend/src/components/billing/UsageDashboard.tsx
+++ b/frontend/src/components/billing/UsageDashboard.tsx
@@ -1,0 +1,104 @@
+import {
+  Activity,
+  RefreshCw,
+  Clock,
+  LayoutGrid,
+  Radio,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { isUnlimited } from '@/lib/utils'
+import type { CustomerQuota } from '@/types'
+
+interface UsageDashboardProps {
+  quota: CustomerQuota
+}
+
+function progressColor(ratio: number): string {
+  if (ratio >= 0.9) return 'bg-red-500'
+  if (ratio >= 0.7) return 'bg-amber-500'
+  return 'bg-primary'
+}
+
+interface StatCardProps {
+  icon: React.ElementType
+  label: string
+  current: string
+  max?: string
+  ratio?: number
+}
+
+function StatCard({ icon: Icon, label, current, max, ratio }: StatCardProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </div>
+      <p className="text-lg font-bold text-foreground">
+        {current}
+        {max && (
+          <span className="text-sm font-normal text-muted-foreground"> / {max}</span>
+        )}
+      </p>
+      {ratio !== undefined && (
+        <div className="h-1.5 bg-secondary rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${progressColor(ratio)}`}
+            style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function UsageDashboard({ quota }: UsageDashboardProps) {
+  const eventsRatio = quota.max_events_per_month > 0
+    ? quota.events_used_this_month / quota.max_events_per_month
+    : 0
+
+  return (
+    <section>
+      <h2 className="text-sm font-medium text-muted-foreground mb-3">บัญชีของคุณ</h2>
+      <Card>
+        <CardContent className="p-5">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+            <StatCard
+              icon={Activity}
+              label="อีเวนต์เดือนนี้"
+              current={quota.events_used_this_month.toLocaleString()}
+              max={quota.max_events_per_month.toLocaleString()}
+              ratio={eventsRatio}
+            />
+            <StatCard
+              icon={RefreshCw}
+              label="รีเพลย์คงเหลือ"
+              current={
+                isUnlimited(quota.remaining_replays)
+                  ? 'ไม่จำกัด'
+                  : quota.remaining_replays === 0
+                    ? 'ไม่มี'
+                    : String(quota.remaining_replays)
+              }
+            />
+            <StatCard
+              icon={Clock}
+              label="เก็บข้อมูล"
+              current={`${quota.retention_days} วัน`}
+            />
+            <StatCard
+              icon={LayoutGrid}
+              label="Sale Pages"
+              current={`สูงสุด ${quota.max_sale_pages}`}
+            />
+            <StatCard
+              icon={Radio}
+              label="พิกเซล"
+              current={`สูงสุด ${quota.max_pixels}`}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as SwitchPrimitives from '@radix-ui/react-switch'
+import { cn } from '@/lib/utils'
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -25,3 +25,8 @@ export function isUnlimited(value: number): boolean {
 export function timeAgo(date: string | Date): string {
   return formatDistanceToNow(new Date(date), { addSuffix: true, locale: th })
 }
+
+export function daysUntil(date: string | Date): number {
+  const diff = new Date(date).getTime() - Date.now()
+  return Math.ceil(diff / (1000 * 60 * 60 * 24))
+}

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -1,99 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
-import {
-  CreditCard,
-  Package,
-  Zap,
-  Crown,
-  CheckCircle2,
-  Loader2,
-  ExternalLink,
-  ShieldCheck,
-  Database,
-  CalendarDays,
-  LayoutGrid,
-  Radio,
-} from 'lucide-react'
-import { Card, CardContent } from '@/components/ui/card'
+import { ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { toast } from 'sonner'
 import { useBillingOverview, useQuota, useCreateCheckout, useCreatePortalSession } from '@/hooks/use-billing'
-import { formatBaht, isUnlimited, timeAgo } from '@/lib/utils'
-
-const REPLAY_PACKS = [
-  {
-    type: 'replay_1',
-    name: 'Starter',
-    price: 299,
-    replays: 1,
-    eventsPerReplay: 100_000,
-    expiryDays: 90,
-    description: 'เหมาะสำหรับการย้ายพิกเซลครั้งเดียว',
-    icon: Zap,
-    popular: false,
-  },
-  {
-    type: 'replay_3',
-    name: 'Pro',
-    price: 699,
-    replays: 3,
-    eventsPerReplay: 100_000,
-    expiryDays: 180,
-    description: 'สำหรับการเปลี่ยนพิกเซลบ่อย',
-    icon: Package,
-    popular: true,
-  },
-  {
-    type: 'replay_unlimited',
-    name: 'Unlimited',
-    price: 1490,
-    replays: -1,
-    eventsPerReplay: 100_000,
-    expiryDays: 365,
-    description: 'รีเพลย์ไม่จำกัดเป็นเวลา 365 วัน',
-    icon: Crown,
-    popular: false,
-  },
-] as const
-
-const ADDONS = [
-  {
-    type: 'retention_180',
-    name: 'Retention 180d',
-    price: 390,
-    description: 'เก็บข้อมูลอีเวนต์ 180 วัน แทนที่จะเป็น 60 วัน',
-    icon: Database,
-  },
-  {
-    type: 'retention_365',
-    name: 'Retention 365d',
-    price: 690,
-    description: 'เก็บข้อมูลอีเวนต์ครบ 1 ปี',
-    icon: CalendarDays,
-  },
-  {
-    type: 'events_1m',
-    name: 'Events 1M',
-    price: 490,
-    description: 'เพิ่มขีดจำกัดอีเวนต์รายเดือนเป็น 1,000,000',
-    icon: Zap,
-  },
-  {
-    type: 'sale_pages_25',
-    name: 'Sale Pages +25',
-    price: 199,
-    description: 'เพิ่มจำนวนเซลเพจจาก 5 เป็น 30 หน้า',
-    icon: LayoutGrid,
-  },
-  {
-    type: 'pixels_40',
-    name: 'Pixels +40',
-    price: 149,
-    description: 'เพิ่มจำนวนพิกเซลจาก 10 เป็น 50',
-    icon: Radio,
-  },
-] as const
+import { UsageDashboard } from '@/components/billing/UsageDashboard'
+import { ReplayPackSection } from '@/components/billing/ReplayPackSection'
+import { ActiveCreditsSection } from '@/components/billing/ActiveCreditsSection'
+import { AddonToggleSection } from '@/components/billing/AddonToggleSection'
+import { PurchaseHistorySection } from '@/components/billing/PurchaseHistorySection'
 
 export function BillingPage() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -123,20 +38,48 @@ export function BillingPage() {
   }, [searchParams, setSearchParams])
 
   const activeCredits = overview?.credits ?? []
-
   const activeSubscriptions = overview?.subscriptions?.filter(
     (s) => s.status === 'active'
   ) ?? []
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-foreground">การเงิน</h1>
           <p className="text-sm text-muted-foreground mt-1">
             จัดการแพ็กรีเพลย์ ส่วนเสริม และการสมัครใช้งาน
           </p>
         </div>
+      </div>
+
+      {quota && <UsageDashboard quota={quota} />}
+
+      <div id="replay-packs">
+        <ReplayPackSection
+          pendingCheckoutType={pendingCheckoutType}
+          isPending={checkout.isPending}
+          onCheckout={handleCheckout}
+        />
+      </div>
+
+      <ActiveCreditsSection
+        credits={activeCredits}
+        onViewPlans={() => {
+          document.getElementById('replay-packs')?.scrollIntoView({ behavior: 'smooth' })
+        }}
+      />
+
+      <AddonToggleSection
+        activeSubscriptions={activeSubscriptions}
+        pendingCheckoutType={pendingCheckoutType}
+        isPending={checkout.isPending}
+        onCheckout={handleCheckout}
+        onManageBilling={() => portal.mutate()}
+      />
+
+      <div className="flex items-center justify-between">
+        <div />
         <Button
           variant="outline"
           size="sm"
@@ -148,243 +91,10 @@ export function BillingPage() {
         </Button>
       </div>
 
-      {/* Quota Summary */}
-      {quota && (
-        <Card className="mb-6">
-          <CardContent className="p-6">
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-              <div>
-                <p className="text-xs text-muted-foreground">อีเวนต์เดือนนี้</p>
-                <p className="text-lg font-bold text-foreground">
-                  {quota.events_used_this_month.toLocaleString()} / {quota.max_events_per_month.toLocaleString()}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">รีเพลย์คงเหลือ</p>
-                <p className="text-lg font-bold text-foreground">
-                  {isUnlimited(quota.remaining_replays) ? 'ไม่จำกัด' : quota.remaining_replays}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">ระยะเวลาเก็บข้อมูล</p>
-                <p className="text-lg font-bold text-foreground">{quota.retention_days} วัน</p>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">พิกเซลสูงสุด</p>
-                <p className="text-lg font-bold text-foreground">{quota.max_pixels}</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Replay Packs */}
-      <div className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4">แพ็กรีเพลย์</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {REPLAY_PACKS.map((pack) => (
-            <Card
-              key={pack.type}
-              className={pack.popular ? 'border-primary ring-1 ring-primary' : ''}
-            >
-              {pack.popular && (
-                <div className="bg-primary text-primary-foreground text-center text-xs font-medium py-1 rounded-t-lg">
-                  ยอดนิยม
-                </div>
-              )}
-              <CardContent className="p-6">
-                <div className="flex items-center gap-2 mb-3">
-                  <div className="h-9 w-9 rounded-lg bg-muted flex items-center justify-center">
-                    <pack.icon className="h-5 w-5 text-foreground" />
-                  </div>
-                  <div>
-                    <p className="font-semibold text-foreground">{pack.name}</p>
-                    <p className="text-xs text-muted-foreground">{pack.description}</p>
-                  </div>
-                </div>
-                <div className="mb-4">
-                  <span className="text-3xl font-bold text-foreground">{pack.price.toLocaleString('th-TH')}</span>
-                  <span className="text-sm text-muted-foreground"> THB</span>
-                </div>
-                <ul className="space-y-2 mb-4 text-sm text-muted-foreground">
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
-                    {isUnlimited(pack.replays) ? 'รีเพลย์ไม่จำกัด' : `${pack.replays} รีเพลย์`}
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
-                    สูงสุด {pack.eventsPerReplay.toLocaleString()} อีเวนต์/รีเพลย์
-                  </li>
-                  <li className="flex items-center gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
-                    ใช้ได้ {pack.expiryDays} วัน
-                  </li>
-                </ul>
-                <Button
-                  className="w-full"
-                  variant={pack.popular ? 'default' : 'outline'}
-                  onClick={() => handleCheckout({ pack_type: pack.type })}
-                  disabled={checkout.isPending}
-                >
-                  {pendingCheckoutType === pack.type ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <CreditCard className="h-4 w-4" />
-                  )}
-                  ซื้อเลย
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* Active Credits */}
-      {activeCredits.length > 0 && (
-        <div className="mb-8">
-          <h2 className="text-lg font-semibold text-foreground mb-4">เครดิตที่ใช้งานอยู่</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {activeCredits.map((credit) => (
-              <Card key={credit.id}>
-                <CardContent className="p-6">
-                  <div className="flex items-center justify-between mb-3">
-                    <Badge variant="success">ใช้งาน</Badge>
-                    <span className="text-xs text-muted-foreground">
-                      หมดอายุ {timeAgo(credit.expires_at)}
-                    </span>
-                  </div>
-                  <p className="text-sm font-medium text-foreground capitalize mb-2">แพ็ก {credit.pack_type}</p>
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="text-muted-foreground">รีเพลย์ที่ใช้แล้ว</span>
-                    <span className="font-semibold text-foreground">
-                      {credit.used_replays} / {isUnlimited(credit.total_replays) ? 'ไม่จำกัด' : credit.total_replays}
-                    </span>
-                  </div>
-                  <div className="mt-2">
-                    <div className="h-2 bg-secondary rounded-full overflow-hidden">
-                      <div
-                        className="h-full bg-primary rounded-full"
-                        style={{
-                          width: isUnlimited(credit.total_replays)
-                            ? '10%'
-                            : `${Math.min((credit.used_replays / credit.total_replays) * 100, 100)}%`,
-                        }}
-                      />
-                    </div>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    สูงสุด {credit.max_events_per_replay.toLocaleString()} อีเวนต์ต่อรีเพลย์
-                  </p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Add-ons */}
-      <div className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4">ส่วนเสริม</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {ADDONS.map((addon) => {
-            const isActive = activeSubscriptions.some((s) => s.addon_type === addon.type)
-            return (
-              <Card key={addon.type}>
-                <CardContent className="p-6">
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="h-9 w-9 rounded-lg bg-muted flex items-center justify-center">
-                      <addon.icon className="h-5 w-5 text-foreground" />
-                    </div>
-                    <div>
-                      <p className="font-semibold text-foreground">{addon.name}</p>
-                      <p className="text-xs text-muted-foreground">{addon.description}</p>
-                    </div>
-                  </div>
-                  <div className="mb-4">
-                    <span className="text-3xl font-bold text-foreground">{addon.price.toLocaleString('th-TH')}</span>
-                    <span className="text-sm text-muted-foreground"> THB/เดือน</span>
-                  </div>
-                  {isActive ? (
-                    <Button variant="outline" className="w-full" disabled>
-                      <ShieldCheck className="h-4 w-4" />
-                      ใช้งานอยู่
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      className="w-full"
-                      onClick={() => handleCheckout({ addon_type: addon.type })}
-                      disabled={checkout.isPending}
-                    >
-                      {pendingCheckoutType === addon.type ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <CreditCard className="h-4 w-4" />
-                      )}
-                      สมัครใช้งาน
-                    </Button>
-                  )}
-                </CardContent>
-              </Card>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* Purchase History */}
-      <div>
-        <h2 className="text-lg font-semibold text-foreground mb-4">ประวัติการซื้อ</h2>
-        <Card>
-          <CardContent className="p-0">
-            {overviewLoading ? (
-              <div className="p-6 text-center text-sm text-muted-foreground">กำลังโหลด...</div>
-            ) : !overview?.purchases || overview.purchases.length === 0 ? (
-              <div className="p-6 text-center text-sm text-muted-foreground">
-                ยังไม่มีประวัติการซื้อ
-              </div>
-            ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-muted">
-                    <tr>
-                      <th className="text-left px-4 py-3 font-medium text-muted-foreground">วันที่</th>
-                      <th className="text-left px-4 py-3 font-medium text-muted-foreground">แพ็ก</th>
-                      <th className="text-left px-4 py-3 font-medium text-muted-foreground">จำนวนเงิน</th>
-                      <th className="text-left px-4 py-3 font-medium text-muted-foreground">สถานะ</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {overview.purchases.map((purchase) => (
-                      <tr key={purchase.id}>
-                        <td className="px-4 py-3 text-foreground">
-                          {new Date(purchase.created_at).toLocaleDateString('th-TH')}
-                        </td>
-                        <td className="px-4 py-3 text-foreground capitalize">{purchase.pack_type}</td>
-                        <td className="px-4 py-3 text-foreground">
-                          {formatBaht(purchase.amount_satang)} {purchase.currency}
-                        </td>
-                        <td className="px-4 py-3">
-                          <Badge
-                            variant={
-                              purchase.status === 'completed'
-                                ? 'success'
-                                : purchase.status === 'pending'
-                                  ? 'secondary'
-                                  : 'destructive'
-                            }
-                          >
-                            {purchase.status === 'completed' ? 'สำเร็จ' : purchase.status === 'pending' ? 'รอดำเนินการ' : 'ล้มเหลว'}
-                          </Badge>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+      <PurchaseHistorySection
+        purchases={overview?.purchases ?? []}
+        isLoading={overviewLoading}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- แตก monolithic `BillingPage.tsx` (390 lines) ออกเป็น 6 sub-components (~95 lines orchestrator)
- เพิ่ม Switch component (Radix UI) สำหรับ toggle add-on subscriptions เปิด/ปิดง่าย
- เพิ่ม color-coded progress bars (green <70%, amber 70-90%, red >90%) ใน Usage Dashboard
- เพิ่ม empty state สำหรับ credits section พร้อม CTA scroll ไปซื้อแพ็ก
- Purchase history เป็น collapsible (default ซ่อน) + mobile card layout
- เพิ่ม `daysUntil()` utility ใน utils.ts + accessibility improvements (aria-label)

## New Files
| File | Description |
|------|-------------|
| `components/ui/switch.tsx` | shadcn Switch (Radix UI) |
| `components/billing/UsageDashboard.tsx` | 5 stat cards + progress bars |
| `components/billing/ReplayPackSection.tsx` | 3 pricing cards + trust signal |
| `components/billing/ActiveCreditsSection.tsx` | Credits + empty state |
| `components/billing/AddonToggleSection.tsx` | Toggle switch add-on list |
| `components/billing/PurchaseHistorySection.tsx` | Collapsible table + mobile cards |

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 13/13 passed
- [x] `npm run build` — success
- [ ] Visual check: responsive layout (375px, 768px, 1280px)
- [ ] Toggle switch: ON → Stripe checkout, OFF → Stripe portal
- [ ] Empty state: no credits → dashed card with CTA
- [ ] Progress bars: color thresholds work correctly
- [ ] Collapsible history: default collapsed, expand shows table

🤖 Generated with [Claude Code](https://claude.com/claude-code)