### PR TITLE
fix: increase nginx proxy buffer size to prevent 502 on sale pages

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -47,6 +47,9 @@ server {
         proxy_connect_timeout 10s;
         proxy_send_timeout 30s;
         proxy_read_timeout 60s;
+        proxy_buffer_size 16k;
+        proxy_buffers 4 16k;
+        proxy_busy_buffers_size 16k;
         # Sale page headers (separate from dashboard CSP)
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -64,6 +67,9 @@ server {
         proxy_connect_timeout 10s;
         proxy_send_timeout 30s;
         proxy_read_timeout 60s;
+        proxy_buffer_size 16k;
+        proxy_buffers 4 16k;
+        proxy_busy_buffers_size 16k;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- Increase nginx `proxy_buffer_size` from default 4-8KB to 16KB for `/p/` and `/api/` proxy locations
- Fixes "upstream sent too big header" errors causing 502 on sale page routes (`/p/{slug}`)
- Railway edge proxy returns large response headers that exceed nginx defaults

## Root Cause
Nginx logs showed repeated errors:
```
upstream sent too big header while reading response header from upstream
```
Backend was healthy (200 on direct API call), but nginx couldn't buffer the response headers from Railway's HTTPS edge proxy.

## Test plan
- [ ] Deploy to Railway and verify sale pages load at `pixlinks.xyz/p/{slug}`
- [ ] Verify API proxy still works (`/api/` routes)
- [ ] Confirm no 502 errors in nginx logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)