### PR TITLE
fix: use proxy_host for backend proxy to prevent routing loop

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,7 +40,7 @@ server {
     # Proxy public sale pages to backend API
     location /p/ {
         proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -60,7 +60,7 @@ server {
     # Proxy API requests to backend
     location /api/ {
         proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- Change `proxy_set_header Host $host` to `proxy_set_header Host $proxy_host` for `/p/` and `/api/` locations
- Fixes routing loop where Railway edge routes request back to frontend instead of API service

## Root Cause
Nginx was proxying to `https://api.pixlinks.xyz` but sending `Host: pixlinks.xyz` (the frontend domain). Railway edge uses the Host header for routing, so it routed back to the frontend → infinite loop → 504 timeout.

Using `$proxy_host` sends `Host: api.pixlinks.xyz` so Railway correctly routes to the API service.

## Test plan
- [ ] Verify sale pages load at `pixlinks.xyz/p/{slug}` (no more 502/504)
- [ ] Verify API proxy routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)