### PR TITLE
chore: increase db pool and use private networking

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -47,7 +47,7 @@ func main() {
 		logger.Error("failed to parse database URL", "error", err)
 		os.Exit(1)
 	}
-	poolConfig.MaxConns = 25
+	poolConfig.MaxConns = 50
 	poolConfig.MinConns = 5
 	poolConfig.MaxConnLifetime = 1 * time.Hour
 	poolConfig.MaxConnIdleTime = 15 * time.Minute

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -39,8 +39,7 @@ server {
 
     # Proxy public sale pages to backend API
     location /p/ {
-        proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $proxy_host;
+        proxy_pass ${BACKEND_PROXY_URL};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -59,8 +58,7 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass ${BACKEND_URL};
-        proxy_set_header Host $proxy_host;
+        proxy_pass ${BACKEND_PROXY_URL};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- Increase pgxpool `MaxConns` from 25 to 50 for better concurrent request handling
- Use Railway private networking (`BACKEND_PROXY_URL`) for nginx proxy_pass, cutting the double CDN hop
- Keep `BACKEND_URL` for CSP headers (browser needs public URL)

## Changes
| What | Before | After |
|------|--------|-------|
| DB pool | 25 max connections | 50 max connections |
| Proxy target | `https://api.pixlinks.xyz` (public, double CDN hop) | `http://pixlinks-api.railway.internal:8080` (private, direct) |

## Test plan
- [ ] Verify sale pages still load at `pixlinks.xyz/p/{slug}`
- [ ] Verify dashboard API calls still work
- [ ] Check nginx logs for no proxy errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)