### PR TITLE
fix: restore proxy host header for public backend URL

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,6 +40,7 @@ server {
     # Proxy public sale pages to backend API
     location /p/ {
         proxy_pass ${BACKEND_PROXY_URL};
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -59,6 +60,7 @@ server {
     # Proxy API requests to backend
     location /api/ {
         proxy_pass ${BACKEND_PROXY_URL};
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- Railway private networking timed out (services likely in different regions)
- Reverted `BACKEND_PROXY_URL` env var to public URL (`https://api.pixlinks.xyz`)
- Re-added `proxy_set_header Host $proxy_host` to prevent routing loop

## Context
PR #71 attempted to use Railway private networking but internal DNS resolution timed out on both IPv4 and IPv6. This fix restores the working public URL proxy while keeping the separate `BACKEND_PROXY_URL` env var for future private networking when both services are in the same region.

## Test plan
- [ ] Verify sale pages load at `pixlinks.xyz/p/{slug}`
- [ ] Verify no 502/504 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)