### PR TITLE
fix: backend production readiness fixes

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -33,7 +33,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 
@@ -59,7 +59,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 
@@ -84,7 +84,7 @@ func (h *AuthHandler) GoogleAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 

--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -39,7 +39,7 @@ func (h *EventHandler) Ingest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 
@@ -157,9 +157,10 @@ func (h *EventHandler) ListRecent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *EventHandler) GetByID(w http.ResponseWriter, r *http.Request) {
+	customerID := middleware.GetCustomerID(r.Context())
 	eventID := chi.URLParam(r, "id")
 
-	event, err := h.eventService.GetByID(r.Context(), eventID)
+	event, err := h.eventService.GetByID(r.Context(), customerID, eventID)
 	if err != nil {
 		ErrorJSON(w, http.StatusInternalServerError, "failed to get event")
 		return

--- a/backend/internal/handler/pixel_handler.go
+++ b/backend/internal/handler/pixel_handler.go
@@ -46,7 +46,7 @@ func (h *PixelHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 

--- a/backend/internal/handler/replay_handler.go
+++ b/backend/internal/handler/replay_handler.go
@@ -59,7 +59,7 @@ func (h *ReplayHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 
@@ -121,7 +121,7 @@ func (h *ReplayHandler) Preview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 

--- a/backend/internal/handler/sale_page_handler.go
+++ b/backend/internal/handler/sale_page_handler.go
@@ -105,7 +105,7 @@ func (h *SalePageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.validate.Struct(input); err != nil {
-		ErrorJSON(w, http.StatusBadRequest, err.Error())
+		ErrorJSON(w, http.StatusBadRequest, FormatValidationErrors(err))
 		return
 	}
 

--- a/backend/internal/handler/validation.go
+++ b/backend/internal/handler/validation.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// FormatValidationErrors converts validator.ValidationErrors into
+// user-friendly messages that do not leak internal struct field names.
+func FormatValidationErrors(err error) string {
+	ve, ok := err.(validator.ValidationErrors)
+	if !ok {
+		return "invalid request"
+	}
+
+	msgs := make([]string, 0, len(ve))
+	for _, fe := range ve {
+		field := strings.ToLower(fe.Field())
+		switch fe.Tag() {
+		case "required":
+			msgs = append(msgs, fmt.Sprintf("%s is required", field))
+		case "min":
+			msgs = append(msgs, fmt.Sprintf("%s must be at least %s", field, fe.Param()))
+		case "max":
+			msgs = append(msgs, fmt.Sprintf("%s must be at most %s", field, fe.Param()))
+		case "oneof":
+			msgs = append(msgs, fmt.Sprintf("%s must be one of: %s", field, fe.Param()))
+		case "email":
+			msgs = append(msgs, fmt.Sprintf("%s must be a valid email", field))
+		case "url":
+			msgs = append(msgs, fmt.Sprintf("%s must be a valid URL", field))
+		default:
+			msgs = append(msgs, fmt.Sprintf("%s is invalid", field))
+		}
+	}
+	return strings.Join(msgs, "; ")
+}

--- a/backend/internal/middleware/bodylimit.go
+++ b/backend/internal/middleware/bodylimit.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// MaxBodySize returns middleware that limits the maximum request body size.
+// Requests exceeding maxBytes will receive a 413 Request Entity Too Large response.
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/middleware/bodylimit_test.go
+++ b/backend/internal/middleware/bodylimit_test.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxBodySize_UnderLimit(t *testing.T) {
+	handler := MaxBodySize(1024)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMaxBodySize_OverLimit(t *testing.T) {
+	handler := MaxBodySize(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := strings.Repeat("x", 100)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -46,6 +46,9 @@ func RateLimitWithContext(ctx context.Context, rps int) func(http.Handler) http.
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// r.RemoteAddr is already rewritten to the real client IP by
+			// chi's RealIP middleware (registered before this in router.go),
+			// which reads X-Real-IP / X-Forwarded-For headers.
 			ip, _, err := net.SplitHostPort(r.RemoteAddr)
 			if err != nil {
 				ip = r.RemoteAddr

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -52,6 +52,7 @@ type EventRepository interface {
 	ListLatestByCustomerID(ctx context.Context, customerID string, pixelID string, limit int) ([]*domain.RealtimeEvent, error)
 	ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error)
 	DeleteOlderThan(ctx context.Context, before time.Time, batchSize int) (int64, error)
+	DeleteExpiredByPlan(ctx context.Context, batchSize int) (int64, error)
 }
 
 type ReplaySessionRepository interface {
@@ -107,7 +108,7 @@ type ReplayCreditRepository interface {
 	GetByID(ctx context.Context, id string) (*domain.ReplayCredit, error)
 	GetActiveByCustomerID(ctx context.Context, customerID string) ([]*domain.ReplayCredit, error)
 	IncrementUsed(ctx context.Context, id string) error
-	ConsumeOneCredit(ctx context.Context, customerID string) (*domain.ReplayCredit, error)
+	ConsumeOneCredit(ctx context.Context, customerID string, maxEventCount int) (*domain.ReplayCredit, error)
 }
 
 type SubscriptionRepository interface {
@@ -121,6 +122,7 @@ type SubscriptionRepository interface {
 
 type EventUsageRepository interface {
 	IncrementCount(ctx context.Context, customerID string, count int64) error
+	DecrementCount(ctx context.Context, customerID string, count int64) error
 	GetCurrentMonth(ctx context.Context, customerID string) (*domain.EventUsage, error)
 	CheckAndIncrement(ctx context.Context, customerID string, count int64, maxAllowed int64) error
 }

--- a/backend/internal/repository/postgres/event_repo.go
+++ b/backend/internal/repository/postgres/event_repo.go
@@ -314,6 +314,26 @@ func (r *EventRepo) DeleteOlderThan(ctx context.Context, before time.Time, batch
 	return tag.RowsAffected(), nil
 }
 
+func (r *EventRepo) DeleteExpiredByPlan(ctx context.Context, batchSize int) (int64, error) {
+	tag, err := r.pool.Exec(ctx,
+		`DELETE FROM pixel_events WHERE id IN (
+			SELECT pe.id FROM pixel_events pe
+			JOIN pixels p ON p.id = pe.pixel_id
+			JOIN customers c ON c.id = p.customer_id
+			WHERE (c.plan = 'sandbox' AND pe.created_at < NOW() - INTERVAL '7 days')
+			   OR (c.plan = 'launch'  AND pe.created_at < NOW() - INTERVAL '60 days')
+			   OR (c.plan = 'shield'  AND pe.created_at < NOW() - INTERVAL '180 days')
+			   OR (c.plan = 'vault'   AND pe.created_at < NOW() - INTERVAL '365 days')
+			LIMIT $1
+		)`,
+		batchSize,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
 func (r *EventRepo) ListRecentByCustomerID(ctx context.Context, customerID string, since time.Time, pixelID string, limit int) ([]*domain.RealtimeEvent, error) {
 	rows, err := r.pool.Query(ctx,
 		`SELECT pe.id, pe.pixel_id, p.name AS pixel_name, pe.event_name,

--- a/backend/internal/repository/postgres/event_usage_repo.go
+++ b/backend/internal/repository/postgres/event_usage_repo.go
@@ -29,6 +29,15 @@ func (r *EventUsageRepo) IncrementCount(ctx context.Context, customerID string, 
 	return err
 }
 
+func (r *EventUsageRepo) DecrementCount(ctx context.Context, customerID string, count int64) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE event_usage SET event_count = GREATEST(0, event_count - $2), updated_at = NOW()
+		 WHERE customer_id = $1 AND month = date_trunc('month', CURRENT_DATE)`,
+		customerID, count,
+	)
+	return err
+}
+
 func (r *EventUsageRepo) CheckAndIncrement(ctx context.Context, customerID string, count int64, maxAllowed int64) error {
 	tag, err := r.pool.Exec(ctx,
 		`INSERT INTO event_usage (customer_id, month, event_count)

--- a/backend/internal/repository/postgres/pixel_repo.go
+++ b/backend/internal/repository/postgres/pixel_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -22,6 +23,9 @@ func NewPixelRepo(pool *pgxpool.Pool, encryptor *crypto.TokenEncryptor) *PixelRe
 
 func (r *PixelRepo) encryptToken(token string) (string, error) {
 	if r.encryptor == nil || token == "" {
+		if r.encryptor == nil && token != "" {
+			slog.Warn("storing FB access token without encryption — set TOKEN_ENCRYPTION_KEY")
+		}
 		return token, nil
 	}
 	return r.encryptor.Encrypt(token)

--- a/backend/internal/repository/postgres/replay_credit_repo.go
+++ b/backend/internal/repository/postgres/replay_credit_repo.go
@@ -102,7 +102,7 @@ func (r *ReplayCreditRepo) IncrementUsed(ctx context.Context, id string) error {
 // SKIP LOCKED to prevent race conditions when multiple concurrent requests try
 // to consume credits simultaneously.
 // Returns nil, nil if no credits are available.
-func (r *ReplayCreditRepo) ConsumeOneCredit(ctx context.Context, customerID string) (*domain.ReplayCredit, error) {
+func (r *ReplayCreditRepo) ConsumeOneCredit(ctx context.Context, customerID string, maxEventCount int) (*domain.ReplayCredit, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -115,10 +115,11 @@ func (r *ReplayCreditRepo) ConsumeOneCredit(ctx context.Context, customerID stri
 		FROM replay_credits
 		WHERE customer_id = $1
 		  AND (total_replays = -1 OR used_replays < total_replays)
+		  AND (max_events_per_replay = 0 OR max_events_per_replay >= $2)
 		  AND expires_at > NOW()
 		ORDER BY expires_at ASC
 		LIMIT 1
-		FOR UPDATE SKIP LOCKED`, customerID).Scan(
+		FOR UPDATE SKIP LOCKED`, customerID, maxEventCount).Scan(
 		&credit.ID, &credit.CustomerID, &credit.PurchaseID, &credit.PackType,
 		&credit.TotalReplays, &credit.UsedReplays, &credit.MaxEventsPerReplay,
 		&credit.ExpiresAt, &credit.CreatedAt,

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
@@ -31,8 +32,9 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 	r.Use(middleware.Logger(logger))
 	r.Use(middleware.CORS(cfg.CORSAllowedOrigins))
 	r.Use(chimiddleware.Compress(5))
+	r.Use(middleware.MaxBodySize(1 << 20)) // 1 MB request body limit
 
-	// Token encryption (optional)
+	// Token encryption (optional in dev, required in production)
 	var encryptor *crypto.TokenEncryptor
 	if cfg.TokenEncryptionKey != "" {
 		keyBytes, err := hex.DecodeString(cfg.TokenEncryptionKey)
@@ -47,6 +49,10 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 				logger.Info("token encryption enabled")
 			}
 		}
+	}
+	if encryptor == nil && cfg.Env == "production" {
+		logger.Error("TOKEN_ENCRYPTION_KEY is required in production")
+		os.Exit(1)
 	}
 
 	// Repositories
@@ -68,7 +74,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 
 	// Services
 	authService := service.NewAuthService(customerRepo, refreshTokenRepo, cfg)
-	billingService := service.NewBillingService(purchaseRepo, creditRepo, subRepo, customerRepo, webhookEventRepo, cfg)
+	billingService := service.NewBillingService(purchaseRepo, creditRepo, subRepo, customerRepo, webhookEventRepo, pool, cfg)
 	quotaService := service.NewQuotaService(creditRepo, subRepo, usageRepo, pixelRepo, salePageRepo, customerRepo)
 	pixelService := service.NewPixelService(pixelRepo, capiClient, logger, quotaService)
 	eventService := service.NewEventService(eventRepo, pixelRepo, capiClient, logger, quotaService)

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stripe/stripe-go/v82"
 	portalsession "github.com/stripe/stripe-go/v82/billingportal/session"
 	checkoutsession "github.com/stripe/stripe-go/v82/checkout/session"
@@ -53,10 +54,16 @@ type BillingService struct {
 	subRepo       repository.SubscriptionRepository
 	customerRepo  repository.CustomerRepository
 	webhookRepo   repository.WebhookEventRepository
+	pool          Pool
 	cfg           *config.Config
 	packConfigs   map[string]PackConfig
 	addonPriceIDs map[string]string // addon type -> Stripe price ID
 	planPriceIDs  map[string]string // plan sub type -> Stripe price ID
+}
+
+// Pool is the subset of pgxpool.Pool used by BillingService for transactions.
+type Pool interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
 }
 
 func NewBillingService(
@@ -65,6 +72,7 @@ func NewBillingService(
 	subRepo repository.SubscriptionRepository,
 	customerRepo repository.CustomerRepository,
 	webhookRepo repository.WebhookEventRepository,
+	pool Pool,
 	cfg *config.Config,
 ) *BillingService {
 	s := &BillingService{
@@ -73,6 +81,7 @@ func NewBillingService(
 		subRepo:      subRepo,
 		customerRepo: customerRepo,
 		webhookRepo:  webhookRepo,
+		pool:         pool,
 		cfg:          cfg,
 	}
 
@@ -382,6 +391,8 @@ func (s *BillingService) ProcessWebhookEvent(ctx context.Context, stripeEventID,
 }
 
 // HandleCheckoutCompleted processes a completed Stripe Checkout session.
+// It wraps purchase status update + credit creation in a database transaction
+// when a pool is available, ensuring atomicity.
 func (s *BillingService) HandleCheckoutCompleted(ctx context.Context, sess *stripe.CheckoutSession) error {
 	purchaseID, ok := sess.Metadata["purchase_id"]
 	if !ok || purchaseID == "" {
@@ -397,16 +408,59 @@ func (s *BillingService) HandleCheckoutCompleted(ctx context.Context, sess *stri
 		return fmt.Errorf("purchase not found: %s", purchaseID)
 	}
 
-	// Update purchase status
-	now := time.Now()
-	if err := s.purchaseRepo.UpdateStatus(ctx, purchase.ID, domain.PurchaseStatusCompleted, &now); err != nil {
-		return fmt.Errorf("update purchase status: %w", err)
-	}
-
-	// Create replay credit
 	packCfg, ok := s.packConfigs[purchase.PackType]
 	if !ok {
 		return fmt.Errorf("unknown pack type: %s", purchase.PackType)
+	}
+
+	now := time.Now()
+
+	// Use a transaction if pool is available to ensure atomicity
+	if s.pool != nil {
+		tx, err := s.pool.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		// Update purchase status within transaction
+		_, err = tx.Exec(ctx,
+			`UPDATE purchases SET status = $1, completed_at = $2 WHERE id = $3`,
+			domain.PurchaseStatusCompleted, &now, purchase.ID,
+		)
+		if err != nil {
+			return fmt.Errorf("update purchase status: %w", err)
+		}
+
+		// Create replay credit within transaction
+		credit := &domain.ReplayCredit{
+			CustomerID:         purchase.CustomerID,
+			PurchaseID:         &purchase.ID,
+			PackType:           purchase.PackType,
+			TotalReplays:       packCfg.TotalReplays,
+			UsedReplays:        0,
+			MaxEventsPerReplay: packCfg.MaxEventsPerReplay,
+			ExpiresAt:          now.AddDate(0, 0, packCfg.ExpiryDays),
+		}
+
+		err = tx.QueryRow(ctx,
+			`INSERT INTO replay_credits (customer_id, purchase_id, pack_type,
+				total_replays, used_replays, max_events_per_replay, expires_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)
+			 RETURNING id, created_at`,
+			credit.CustomerID, credit.PurchaseID, credit.PackType,
+			credit.TotalReplays, credit.UsedReplays, credit.MaxEventsPerReplay, credit.ExpiresAt,
+		).Scan(&credit.ID, &credit.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("create replay credit: %w", err)
+		}
+
+		return tx.Commit(ctx)
+	}
+
+	// Fallback: no pool — execute without transaction
+	if err := s.purchaseRepo.UpdateStatus(ctx, purchase.ID, domain.PurchaseStatusCompleted, &now); err != nil {
+		return fmt.Errorf("update purchase status: %w", err)
 	}
 
 	credit := &domain.ReplayCredit{

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -47,7 +47,7 @@ func newTestBillingService() (
 		FrontendURL:                "http://localhost:5173",
 	}
 
-	svc := NewBillingService(purchaseRepo, creditRepo, subRepo, customerRepo, webhookRepo, cfg)
+	svc := NewBillingService(purchaseRepo, creditRepo, subRepo, customerRepo, webhookRepo, nil, cfg)
 	return svc, purchaseRepo, creditRepo, subRepo, customerRepo, webhookRepo
 }
 

--- a/backend/internal/service/cleanup_service.go
+++ b/backend/internal/service/cleanup_service.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
 )
 
@@ -73,11 +72,9 @@ func (s *CleanupService) run(ctx context.Context) {
 }
 
 func (s *CleanupService) cleanup(ctx context.Context) {
-	maxRetention := domain.PlanLimitsMap[domain.PlanVault].RetentionDays
-	before := time.Now().AddDate(0, 0, -maxRetention)
 	var totalDeleted int64
 
-	s.logger.Info("event cleanup started", "before", before.Format(time.RFC3339))
+	s.logger.Info("per-plan event cleanup started")
 
 	for {
 		if ctx.Err() != nil {
@@ -85,7 +82,7 @@ func (s *CleanupService) cleanup(ctx context.Context) {
 			return
 		}
 
-		deleted, err := s.eventRepo.DeleteOlderThan(ctx, before, cleanupBatchSize)
+		deleted, err := s.eventRepo.DeleteExpiredByPlan(ctx, cleanupBatchSize)
 		if err != nil {
 			s.logger.Error("event cleanup batch failed", "error", err, "deleted_so_far", totalDeleted)
 			return
@@ -109,5 +106,5 @@ func (s *CleanupService) cleanup(ctx context.Context) {
 		}
 	}
 
-	s.logger.Info("event cleanup completed", "total_deleted", totalDeleted)
+	s.logger.Info("per-plan event cleanup completed", "total_deleted", totalDeleted)
 }

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -22,6 +22,7 @@ type EventService struct {
 	capiClient   *facebook.CAPIClient
 	logger       *slog.Logger
 	quotaService *QuotaService
+	capiSem      chan struct{} // limits concurrent CAPI goroutines
 }
 
 func NewEventService(
@@ -37,6 +38,7 @@ func NewEventService(
 		capiClient:   capiClient,
 		logger:       logger,
 		quotaService: quotaService,
+		capiSem:      make(chan struct{}, 50),
 	}
 }
 
@@ -144,15 +146,31 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 			continue
 		}
 
-		// Forward to Facebook CAPI asynchronously
-		go s.forwardToCAPI(context.Background(), event, pixel, client)
+		// Forward to Facebook CAPI asynchronously (semaphore-limited)
+		go func(evt *domain.PixelEvent, px *domain.Pixel, cl ClientContext) {
+			s.capiSem <- struct{}{}
+			defer func() { <-s.capiSem }()
+			s.forwardToCAPI(context.Background(), evt, px, cl)
+		}(event, pixel, client)
 
-		// Fan-out to backup pixel (best-effort, 1 level only)
+		// Fan-out to backup pixel (best-effort, 1 level only, semaphore-limited)
 		if pixel.BackupPixelID != nil {
-			go s.forwardToBackupPixel(context.Background(), event, *pixel.BackupPixelID, client)
+			go func(evt *domain.PixelEvent, backupID string, cl ClientContext) {
+				s.capiSem <- struct{}{}
+				defer func() { <-s.capiSem }()
+				s.forwardToBackupPixel(context.Background(), evt, backupID, cl)
+			}(event, *pixel.BackupPixelID, client)
 		}
 
 		created++
+	}
+
+	// Refund quota for skipped events (duplicates, invalid pixels, etc.)
+	skipped := len(input.Events) - created
+	if skipped > 0 && s.quotaService != nil {
+		if err := s.quotaService.DecrementEventQuota(ctx, customerID, int64(skipped)); err != nil {
+			s.logger.Error("failed to refund skipped event quota", "error", err, "skipped", skipped)
+		}
 	}
 
 	return created, nil
@@ -303,11 +321,24 @@ func (s *EventService) ListRecent(ctx context.Context, customerID string, since 
 	return events, nil
 }
 
-func (s *EventService) GetByID(ctx context.Context, id string) (*domain.PixelEvent, error) {
+func (s *EventService) GetByID(ctx context.Context, customerID, id string) (*domain.PixelEvent, error) {
 	event, err := s.eventRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("get event: %w", err)
 	}
+	if event == nil {
+		return nil, nil
+	}
+
+	// Ownership check: verify the event's pixel belongs to the customer
+	pixel, err := s.pixelRepo.GetByID(ctx, event.PixelID)
+	if err != nil {
+		return nil, fmt.Errorf("get pixel for ownership check: %w", err)
+	}
+	if pixel == nil || pixel.CustomerID != customerID {
+		return nil, nil
+	}
+
 	return event, nil
 }
 

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -67,8 +67,8 @@ func (m *MockReplayCreditRepo) IncrementUsed(ctx context.Context, id string) err
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
-func (m *MockReplayCreditRepo) ConsumeOneCredit(ctx context.Context, customerID string) (*domain.ReplayCredit, error) {
-	args := m.Called(ctx, customerID)
+func (m *MockReplayCreditRepo) ConsumeOneCredit(ctx context.Context, customerID string, maxEventCount int) (*domain.ReplayCredit, error) {
+	args := m.Called(ctx, customerID, maxEventCount)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -116,6 +116,10 @@ func (m *MockSubscriptionRepo) ListByCustomerID(ctx context.Context, customerID 
 type MockEventUsageRepo struct{ mock.Mock }
 
 func (m *MockEventUsageRepo) IncrementCount(ctx context.Context, customerID string, count int64) error {
+	args := m.Called(ctx, customerID, count)
+	return args.Error(0)
+}
+func (m *MockEventUsageRepo) DecrementCount(ctx context.Context, customerID string, count int64) error {
 	args := m.Called(ctx, customerID, count)
 	return args.Error(0)
 }
@@ -385,6 +389,10 @@ func (m *MockEventRepo) ListRecentByCustomerID(ctx context.Context, customerID s
 }
 func (m *MockEventRepo) DeleteOlderThan(ctx context.Context, before time.Time, batchSize int) (int64, error) {
 	args := m.Called(ctx, before, batchSize)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockEventRepo) DeleteExpiredByPlan(ctx context.Context, batchSize int) (int64, error) {
+	args := m.Called(ctx, batchSize)
 	return args.Get(0).(int64), args.Error(1)
 }
 

--- a/backend/internal/service/quota_service.go
+++ b/backend/internal/service/quota_service.go
@@ -137,6 +137,11 @@ func (s *QuotaService) CheckAndIncrementEventQuota(ctx context.Context, customer
 	return nil
 }
 
+// DecrementEventQuota reduces the event usage counter to refund skipped events.
+func (s *QuotaService) DecrementEventQuota(ctx context.Context, customerID string, count int64) error {
+	return s.usageRepo.DecrementCount(ctx, customerID, count)
+}
+
 // CheckPixelCreationQuota checks if the customer can create another pixel.
 func (s *QuotaService) CheckPixelCreationQuota(ctx context.Context, customerID string) error {
 	quota, err := s.GetCustomerQuota(ctx, customerID)
@@ -171,6 +176,37 @@ func (s *QuotaService) CheckSalePageCreationQuota(ctx context.Context, customerI
 		return ErrQuotaSalePagesExceeded
 	}
 	return nil
+}
+
+// CheckReplayEventCount verifies that at least one active credit can handle the given event count.
+// This is a pre-flight check to reject replays early before loading events into memory.
+func (s *QuotaService) CheckReplayEventCount(ctx context.Context, customerID string, eventCount int) error {
+	credits, err := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
+	if err != nil {
+		return fmt.Errorf("check active credits: %w", err)
+	}
+	if len(credits) == 0 {
+		return ErrQuotaReplayNotAllowed
+	}
+
+	for _, c := range credits {
+		if c.RemainingReplays() != 0 && (c.MaxEventsPerReplay == 0 || eventCount <= c.MaxEventsPerReplay) {
+			return nil
+		}
+	}
+
+	// Credits exist but none can handle the event count
+	hasRemaining := false
+	for _, c := range credits {
+		if c.RemainingReplays() != 0 {
+			hasRemaining = true
+			break
+		}
+	}
+	if !hasRemaining {
+		return ErrQuotaReplayNotAllowed
+	}
+	return ErrQuotaReplayEventsExceeded
 }
 
 // ConsumeReplayCredit atomically consumes one replay from the customer's active credits.
@@ -209,18 +245,20 @@ func (s *QuotaService) ConsumeReplayCredit(ctx context.Context, customerID strin
 		return nil, ErrQuotaReplayEventsExceeded
 	}
 
-	// Now atomically consume
-	credit, err := s.creditRepo.ConsumeOneCredit(ctx, customerID)
+	// Atomically consume a credit that can handle the event count
+	credit, err := s.creditRepo.ConsumeOneCredit(ctx, customerID, eventCount)
 	if err != nil {
 		return nil, fmt.Errorf("consume credit: %w", err)
 	}
 	if credit == nil {
-		return nil, ErrQuotaReplayNotAllowed
-	}
-
-	// Final check on consumed credit's actual MaxEventsPerReplay
-	if credit.MaxEventsPerReplay > 0 && eventCount > credit.MaxEventsPerReplay {
+		// Atomic consume failed — do read-only query to determine error type
+		readCredits, readErr := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
+		if readErr != nil || len(readCredits) == 0 {
+			return nil, ErrQuotaReplayNotAllowed
+		}
+		// Credits exist but none matched event count constraint
 		return nil, ErrQuotaReplayEventsExceeded
 	}
+
 	return credit, nil
 }

--- a/backend/internal/service/quota_service_test.go
+++ b/backend/internal/service/quota_service_test.go
@@ -290,7 +290,7 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 			MaxEventsPerReplay: domain.DefaultMaxEventsPerReplay,
 		}
 		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(activeCredit, nil)
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
 
@@ -337,7 +337,7 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 			MaxEventsPerReplay: 0,
 		}
 		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(activeCredit, nil)
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 999999)
 
@@ -355,7 +355,7 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 			UsedReplays:        0,
 			MaxEventsPerReplay: 0,
 		}}, nil)
-		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1").Return(nil, errors.New("db error"))
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(nil, errors.New("db error"))
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
 

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -179,7 +179,20 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		return nil, err
 	}
 
-	// Count events to replay
+	// Pre-check event count before loading all events into memory
+	eventCount, err := s.eventRepo.CountEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo)
+	if err != nil {
+		return nil, fmt.Errorf("count events for replay: %w", err)
+	}
+
+	// Early rejection if quota service is available and event count exceeds credit limits
+	if s.quotaService != nil && eventCount > 0 {
+		if err := s.quotaService.CheckReplayEventCount(ctx, customerID, eventCount); err != nil {
+			return nil, err
+		}
+	}
+
+	// Load events for replay
 	events, err := s.eventRepo.GetEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get events for replay: %w", err)

--- a/backend/internal/service/replay_service_test.go
+++ b/backend/internal/service/replay_service_test.go
@@ -61,6 +61,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
+				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(1, nil)
 				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
@@ -95,6 +96,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
+				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(1, nil)
 				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
@@ -129,6 +131,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
+				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(1, nil)
 				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-1 * time.Hour)},
@@ -162,6 +165,7 @@ func TestReplayService_Create(t *testing.T) {
 					FBPixelID:     "fb-2",
 					FBAccessToken: "token-2",
 				}, nil)
+				er.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(2, nil)
 				er.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 					Return([]*domain.PixelEvent{
 						{ID: "evt-1", EventName: "PageView", EventTime: time.Now().Add(-10 * 24 * time.Hour)},
@@ -954,6 +958,7 @@ func TestReplayService_Create_SemaphoreBlock(t *testing.T) {
 	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
 		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
 	}, nil)
+	eventRepo.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(1, nil)
 	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 		Return([]*domain.PixelEvent{
 			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},
@@ -998,6 +1003,7 @@ func TestReplayService_Create_ShutdownDuringSemWait(t *testing.T) {
 	pixelRepo.On("GetByID", mock.Anything, "pixel-2").Return(&domain.Pixel{
 		ID: "pixel-2", CustomerID: "cust-1", FBPixelID: "fb-2", FBAccessToken: "token-2",
 	}, nil)
+	eventRepo.On("CountEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(1, nil)
 	eventRepo.On("GetEventsForReplay", mock.Anything, "pixel-1", []string(nil), (*time.Time)(nil), (*time.Time)(nil), mock.AnythingOfType("*time.Time")).
 		Return([]*domain.PixelEvent{
 			{ID: "evt-1", EventName: "PageView", EventTime: time.Now()},


### PR DESCRIPTION
## Summary
- **B1** [BLOCKING]: Fix IDOR on GET /events/{id} — add ownership check via pixel.CustomerID
- **B2** [BLOCKING]: Fix replay credit TOCTOU race — move MaxEventsPerReplay check into SQL WHERE clause
- **B3** [BLOCKING]: Add request body size limit middleware (1MB) using http.MaxBytesReader
- **B4**: Refund quota for skipped events (duplicates, invalid pixels) in batch ingestion
- **B5**: Wrap webhook checkout (purchase status + credit creation) in database transaction
- **B6**: Enforce TOKEN_ENCRYPTION_KEY in production (os.Exit if missing)
- **B7**: Sanitize validator error messages — FormatValidationErrors prevents struct field name leakage
- **B8**: Add CAPI goroutine semaphore (cap 50) to prevent unbounded goroutine creation
- **B9**: Pre-check replay event count via CountEventsForReplay before loading into memory
- **B10**: Per-plan event cleanup retention (sandbox 7d, launch 60d, shield 180d, vault 365d)
- **B11**: Clarify rate limit IP resolution comment (RealIP runs before rate limiter)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all tests green)
- [x] New middleware: bodylimit_test.go (under/over limit)
- [x] Updated mocks for CountEventsForReplay, ConsumeOneCredit signature
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)