### PR TITLE
fix: use IsEncrypted guard and propagate decryptToken errors

### DIFF
--- a/backend/internal/crypto/token.go
+++ b/backend/internal/crypto/token.go
@@ -47,16 +47,16 @@ func (e *TokenEncryptor) Decrypt(encoded string) (string, error) {
 	}
 	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return encoded, nil // not encrypted, return as-is
+		return encoded, nil // not valid base64: plaintext token
 	}
-	nonceSize := e.gcm.NonceSize()
-	if len(data) < nonceSize {
-		return encoded, nil // not encrypted, return as-is
+	// AES-GCM: nonce (12) + ciphertext (>0) + tag (16) = min 29 bytes
+	if len(data) < e.gcm.NonceSize()+16 {
+		return encoded, nil // too short to be ciphertext: plaintext token
 	}
-	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	nonce, ciphertext := data[:e.gcm.NonceSize()], data[e.gcm.NonceSize():]
 	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		return encoded, nil // decrypt failed, return as-is (graceful fallback)
+		return "", fmt.Errorf("decrypt token: %w", err)
 	}
 	return string(plaintext), nil
 }

--- a/backend/internal/crypto/token_test.go
+++ b/backend/internal/crypto/token_test.go
@@ -69,13 +69,9 @@ func TestTamperedCiphertext(t *testing.T) {
 
 	// Tamper with the encrypted string
 	tampered := encrypted[:len(encrypted)-2] + "XX"
-	decrypted, err := enc.Decrypt(tampered)
-	if err != nil {
-		t.Fatalf("Decrypt tampered should not error: %v", err)
-	}
-	// Should return as-is since decrypt fails gracefully
-	if decrypted != tampered {
-		t.Fatalf("expected tampered string returned as-is, got %q", decrypted)
+	_, err = enc.Decrypt(tampered)
+	if err == nil {
+		t.Fatal("Decrypt tampered should return error")
 	}
 }
 

--- a/backend/internal/repository/postgres/pixel_repo.go
+++ b/backend/internal/repository/postgres/pixel_repo.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -18,30 +20,25 @@ func NewPixelRepo(pool *pgxpool.Pool, encryptor *crypto.TokenEncryptor) *PixelRe
 	return &PixelRepo{pool: pool, encryptor: encryptor}
 }
 
-func (r *PixelRepo) encryptToken(token string) string {
+func (r *PixelRepo) encryptToken(token string) (string, error) {
 	if r.encryptor == nil || token == "" {
-		return token
+		return token, nil
 	}
-	encrypted, err := r.encryptor.Encrypt(token)
-	if err != nil {
-		return token // fallback to plaintext on error
-	}
-	return encrypted
+	return r.encryptor.Encrypt(token)
 }
 
-func (r *PixelRepo) decryptToken(token string) string {
+func (r *PixelRepo) decryptToken(token string) (string, error) {
 	if r.encryptor == nil || token == "" {
-		return token
+		return token, nil
 	}
-	decrypted, err := r.encryptor.Decrypt(token)
-	if err != nil {
-		return token // fallback to as-is on error
-	}
-	return decrypted
+	return r.encryptor.Decrypt(token)
 }
 
 func (r *PixelRepo) Create(ctx context.Context, p *domain.Pixel) error {
-	encToken := r.encryptToken(p.FBAccessToken)
+	encToken, err := r.encryptToken(p.FBAccessToken)
+	if err != nil {
+		return fmt.Errorf("encrypt token: %w", err)
+	}
 	return r.pool.QueryRow(ctx,
 		`INSERT INTO pixels (customer_id, fb_pixel_id, fb_access_token, name, backup_pixel_id, test_event_code)
 		 VALUES ($1, $2, $3, $4, $5, $6)
@@ -56,13 +53,17 @@ func (r *PixelRepo) GetByID(ctx context.Context, id string) (*domain.Pixel, erro
 		`SELECT id, customer_id, fb_pixel_id, fb_access_token, name, is_active, status, backup_pixel_id, test_event_code, created_at, updated_at
 		 FROM pixels WHERE id = $1`, id,
 	).Scan(&p.ID, &p.CustomerID, &p.FBPixelID, &p.FBAccessToken, &p.Name, &p.IsActive, &p.Status, &p.BackupPixelID, &p.TestEventCode, &p.CreatedAt, &p.UpdatedAt)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	p.FBAccessToken = r.decryptToken(p.FBAccessToken)
+	dec, err := r.decryptToken(p.FBAccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt token for pixel %s: %w", p.ID, err)
+	}
+	p.FBAccessToken = dec
 	return p, nil
 }
 
@@ -85,7 +86,11 @@ func (r *PixelRepo) GetByIDs(ctx context.Context, ids []string) ([]*domain.Pixel
 		if err := rows.Scan(&p.ID, &p.CustomerID, &p.FBPixelID, &p.FBAccessToken, &p.Name, &p.IsActive, &p.Status, &p.BackupPixelID, &p.TestEventCode, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, err
 		}
-		p.FBAccessToken = r.decryptToken(p.FBAccessToken)
+		dec, err := r.decryptToken(p.FBAccessToken)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt token for pixel %s: %w", p.ID, err)
+		}
+		p.FBAccessToken = dec
 		pixels = append(pixels, p)
 	}
 	return pixels, rows.Err()
@@ -115,15 +120,22 @@ func (r *PixelRepo) ListByCustomerID(ctx context.Context, customerID string) ([]
 		if err := rows.Scan(&p.ID, &p.CustomerID, &p.FBPixelID, &p.FBAccessToken, &p.Name, &p.IsActive, &p.Status, &p.BackupPixelID, &p.TestEventCode, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, err
 		}
-		p.FBAccessToken = r.decryptToken(p.FBAccessToken)
+		dec, err := r.decryptToken(p.FBAccessToken)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt token for pixel %s: %w", p.ID, err)
+		}
+		p.FBAccessToken = dec
 		pixels = append(pixels, p)
 	}
 	return pixels, rows.Err()
 }
 
 func (r *PixelRepo) Update(ctx context.Context, p *domain.Pixel) error {
-	encToken := r.encryptToken(p.FBAccessToken)
-	_, err := r.pool.Exec(ctx,
+	encToken, err := r.encryptToken(p.FBAccessToken)
+	if err != nil {
+		return fmt.Errorf("encrypt token: %w", err)
+	}
+	_, err = r.pool.Exec(ctx,
 		`UPDATE pixels SET fb_pixel_id = $2, fb_access_token = $3, name = $4, is_active = $5, status = $6, backup_pixel_id = $7, test_event_code = $8, updated_at = NOW()
 		 WHERE id = $1`,
 		p.ID, p.FBPixelID, encToken, p.Name, p.IsActive, p.Status, p.BackupPixelID, p.TestEventCode,

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -236,7 +236,11 @@ func (s *EventService) forwardToCAPI(ctx context.Context, event *domain.PixelEve
 
 func (s *EventService) forwardToBackupPixel(ctx context.Context, event *domain.PixelEvent, backupPixelID string, client ClientContext) {
 	backupPixel, err := s.pixelRepo.GetByID(ctx, backupPixelID)
-	if err != nil || backupPixel == nil || !backupPixel.IsActive {
+	if err != nil {
+		s.logger.Error("get backup pixel failed", "backup_pixel_id", backupPixelID, "error", err)
+		return
+	}
+	if backupPixel == nil || !backupPixel.IsActive {
 		s.logger.Warn("backup pixel not available", "backup_pixel_id", backupPixelID)
 		return
 	}

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -150,13 +150,19 @@ func parseDateFilter(s string) (*time.Time, error) {
 func (s *ReplayService) Create(ctx context.Context, customerID string, input CreateReplayInput) (*CreateReplayResult, error) {
 	// Verify source pixel
 	sourcePixel, err := s.pixelRepo.GetByID(ctx, input.SourcePixelID)
-	if err != nil || sourcePixel == nil || sourcePixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get source pixel: %w", err)
+	}
+	if sourcePixel == nil || sourcePixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 
 	// Verify target pixel
 	targetPixel, err := s.pixelRepo.GetByID(ctx, input.TargetPixelID)
-	if err != nil || targetPixel == nil || targetPixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get target pixel: %w", err)
+	}
+	if targetPixel == nil || targetPixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 
@@ -488,13 +494,19 @@ const MaxReplayEvents = 100000
 func (s *ReplayService) Preview(ctx context.Context, customerID string, input CreateReplayInput) (*PreviewReplayResult, error) {
 	// Verify source pixel
 	sourcePixel, err := s.pixelRepo.GetByID(ctx, input.SourcePixelID)
-	if err != nil || sourcePixel == nil || sourcePixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get source pixel: %w", err)
+	}
+	if sourcePixel == nil || sourcePixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 
 	// Verify target pixel
 	targetPixel, err := s.pixelRepo.GetByID(ctx, input.TargetPixelID)
-	if err != nil || targetPixel == nil || targetPixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get target pixel: %w", err)
+	}
+	if targetPixel == nil || targetPixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 
@@ -578,7 +590,10 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 
 	// Verify target pixel still exists and is owned
 	targetPixel, err := s.pixelRepo.GetByID(ctx, session.TargetPixelID)
-	if err != nil || targetPixel == nil || targetPixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get target pixel: %w", err)
+	}
+	if targetPixel == nil || targetPixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 
@@ -679,7 +694,10 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 
 func (s *ReplayService) GetEventTypes(ctx context.Context, customerID, pixelID string) ([]string, error) {
 	pixel, err := s.pixelRepo.GetByID(ctx, pixelID)
-	if err != nil || pixel == nil || pixel.CustomerID != customerID {
+	if err != nil {
+		return nil, fmt.Errorf("get pixel: %w", err)
+	}
+	if pixel == nil || pixel.CustomerID != customerID {
 		return nil, ErrPixelNotFound
 	}
 	types, err := s.eventRepo.GetDistinctEventTypes(ctx, pixelID)


### PR DESCRIPTION
## Summary
Completes Fix #6 from the Production Readiness Plan — strict token encrypt/decrypt error handling.

**Changes:**
- `Decrypt()` — single base64 decode pass (eliminates double-decode), returns error on tampered ciphertext instead of silent fallback
- `decryptToken()` → `(string, error)` — callers (`GetByID`, `GetByIDs`, `ListByCustomerID`) propagate with pixel ID context
- `encryptToken()` → `(string, error)` — `Create`/`Update` propagate encrypt failures (no more silent plaintext writes)
- `errors.Is(err, pgx.ErrNoRows)` instead of `==` for idiomatic Go error comparison
- `replay_service.go` — separate DB errors from ownership checks (decrypt error no longer masked as `ErrPixelNotFound`)
- `event_service.go` — `forwardToBackupPixel` logs decrypt errors distinctly from missing/inactive pixels

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all packages)
- [x] Pre-push hook passes
- [x] Go code review — all CRITICAL/HIGH issues resolved
- [x] Security review — no information leakage in error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)