### PR TITLE
fix: use enc: prefix for reliable token encryption detection

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -196,9 +196,15 @@ func migrateTokens(ctx context.Context, pool *pgxpool.Pool, encryptor *crypto.To
 			continue
 		}
 		if crypto.IsEncrypted(token) {
-			continue // already encrypted
+			continue // already has enc: prefix
 		}
-		encrypted, err := encryptor.Encrypt(token)
+		// Decrypt handles both legacy encrypted and plaintext tokens gracefully
+		plaintext, err := encryptor.Decrypt(token)
+		if err != nil {
+			logger.Error("token migration: failed to decrypt legacy token", "pixel_id", id, "error", err)
+			continue
+		}
+		encrypted, err := encryptor.Encrypt(plaintext)
 		if err != nil {
 			logger.Error("token migration: failed to encrypt", "pixel_id", id, "error", err)
 			continue
@@ -213,8 +219,8 @@ func migrateTokens(ctx context.Context, pool *pgxpool.Pool, encryptor *crypto.To
 		logger.Error("token migration: rows iteration error", "error", err)
 	}
 	if migrated > 0 {
-		logger.Info("token migration: encrypted plaintext tokens", "count", migrated)
+		logger.Info("token migration: upgraded tokens to enc: format", "count", migrated)
 	} else {
-		logger.Info("token migration: no plaintext tokens to migrate")
+		logger.Info("token migration: all tokens already in enc: format")
 	}
 }

--- a/backend/internal/crypto/token.go
+++ b/backend/internal/crypto/token.go
@@ -8,7 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
+
+// encPrefix marks tokens encrypted by this package.
+const encPrefix = "enc:"
 
 type TokenEncryptor struct {
 	gcm cipher.AEAD
@@ -38,20 +42,44 @@ func (e *TokenEncryptor) Encrypt(plaintext string) (string, error) {
 		return "", fmt.Errorf("generate nonce: %w", err)
 	}
 	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), nil)
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
+	return encPrefix + base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
 func (e *TokenEncryptor) Decrypt(encoded string) (string, error) {
 	if encoded == "" {
 		return "", nil
 	}
+
+	// New format: "enc:" prefix — strict decryption
+	if strings.HasPrefix(encoded, encPrefix) {
+		return e.decryptBase64(encoded[len(encPrefix):])
+	}
+
+	// Legacy format: try base64 + GCM, fallback to plaintext
 	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return encoded, nil // not valid base64: plaintext token
 	}
-	// AES-GCM: nonce (12) + ciphertext (>0) + tag (16) = min 29 bytes
 	if len(data) < e.gcm.NonceSize()+16 {
-		return encoded, nil // too short to be ciphertext: plaintext token
+		return encoded, nil // too short: plaintext token
+	}
+	nonce, ciphertext := data[:e.gcm.NonceSize()], data[e.gcm.NonceSize():]
+	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		// GCM failed: plaintext FB token that happens to be valid base64
+		return encoded, nil
+	}
+	return string(plaintext), nil
+}
+
+// decryptBase64 decodes base64 and decrypts AES-GCM. Errors are strict.
+func (e *TokenEncryptor) decryptBase64(b64 string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", fmt.Errorf("base64 decode: %w", err)
+	}
+	if len(data) < e.gcm.NonceSize()+16 {
+		return "", fmt.Errorf("ciphertext too short")
 	}
 	nonce, ciphertext := data[:e.gcm.NonceSize()], data[e.gcm.NonceSize():]
 	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
@@ -61,15 +89,7 @@ func (e *TokenEncryptor) Decrypt(encoded string) (string, error) {
 	return string(plaintext), nil
 }
 
-// IsEncrypted checks if a token looks like it's encrypted (base64 encoded, min length).
+// IsEncrypted checks if a token has the "enc:" prefix (encrypted by this package).
 func IsEncrypted(token string) bool {
-	if token == "" {
-		return false
-	}
-	data, err := base64.StdEncoding.DecodeString(token)
-	if err != nil {
-		return false
-	}
-	// AES-GCM: nonce (12) + ciphertext (>0) + tag (16) = min 29 bytes
-	return len(data) >= 29
+	return strings.HasPrefix(token, encPrefix)
 }

--- a/backend/internal/crypto/token_test.go
+++ b/backend/internal/crypto/token_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -18,6 +19,9 @@ func TestRoundTrip(t *testing.T) {
 	encrypted, err := enc.Encrypt(original)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
+	}
+	if !strings.HasPrefix(encrypted, "enc:") {
+		t.Fatalf("encrypted should have enc: prefix, got %q", encrypted)
 	}
 	if encrypted == original {
 		t.Fatal("encrypted should differ from original")
@@ -67,11 +71,11 @@ func TestTamperedCiphertext(t *testing.T) {
 		t.Fatalf("Encrypt: %v", err)
 	}
 
-	// Tamper with the encrypted string
+	// Tamper with the encrypted string (keep enc: prefix)
 	tampered := encrypted[:len(encrypted)-2] + "XX"
 	_, err = enc.Decrypt(tampered)
 	if err == nil {
-		t.Fatal("Decrypt tampered should return error")
+		t.Fatal("Decrypt tampered enc: token should return error")
 	}
 }
 
@@ -117,7 +121,7 @@ func TestDecryptPlaintext(t *testing.T) {
 		t.Fatalf("NewTokenEncryptor: %v", err)
 	}
 
-	// A plaintext FB token that's not base64 should be returned as-is
+	// A plaintext FB token should be returned as-is
 	plaintext := "EAABsbCS1iHgBO_plaintext_token"
 	decrypted, err := enc.Decrypt(plaintext)
 	if err != nil {
@@ -125,5 +129,23 @@ func TestDecryptPlaintext(t *testing.T) {
 	}
 	if decrypted != plaintext {
 		t.Fatalf("expected %q, got %q", plaintext, decrypted)
+	}
+}
+
+func TestDecryptLongBase64Plaintext(t *testing.T) {
+	enc, err := NewTokenEncryptor(testKey())
+	if err != nil {
+		t.Fatalf("NewTokenEncryptor: %v", err)
+	}
+
+	// FB access tokens are often long valid base64 strings (≥29 bytes decoded).
+	// These should be returned as-is (not error), since they're plaintext.
+	longToken := "EAABsbCS1iHgBOzBCxZAhJ1gZBYq5ZBrJ3xK7mz9ZC"
+	decrypted, err := enc.Decrypt(longToken)
+	if err != nil {
+		t.Fatalf("Decrypt long base64 plaintext should not error: %v", err)
+	}
+	if decrypted != longToken {
+		t.Fatalf("expected %q, got %q", longToken, decrypted)
 	}
 }


### PR DESCRIPTION
## Summary
- **Root cause**: FB access tokens (e.g., `EAAx...`) are valid base64 ≥29 bytes, causing `IsEncrypted()` to false-positive and `Decrypt()` to return error → 500 on `GET /api/v1/pixels`
- **Fix**: Use `enc:` prefix on encrypted tokens for unambiguous detection
  - `Encrypt`: prepends `enc:` to ciphertext
  - `Decrypt`: `enc:` prefix → strict decrypt; no prefix → legacy GCM with graceful fallback to plaintext
  - `IsEncrypted`: checks `enc:` prefix only (no base64 heuristic)
  - Migration: decrypts legacy tokens, re-encrypts with `enc:` prefix

## Test plan
- [x] All crypto unit tests pass (including new `TestDecryptLongBase64Plaintext`)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` pass
- [ ] After deploy: verify `GET /api/v1/pixels` returns 200 for all customers
- [ ] After deploy: verify token migration log shows `upgraded tokens to enc: format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)