### PR TITLE
feat: admin dashboard improvements - revenue chart, filters, confirmations, tests

### DIFF
--- a/backend/internal/service/admin_service_test.go
+++ b/backend/internal/service/admin_service_test.go
@@ -1,0 +1,350 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+	"github.com/jaochai/pixlinks/backend/internal/repository"
+)
+
+var errDBDown = errors.New("db down")
+
+func newTestAdminService() (*AdminService, *MockAdminRepo, *MockCustomerRepo, *MockReplayCreditRepo) {
+	adminRepo := new(MockAdminRepo)
+	customerRepo := new(MockCustomerRepo)
+	creditRepo := new(MockReplayCreditRepo)
+	svc := NewAdminService(adminRepo, customerRepo, creditRepo, nil)
+	return svc, adminRepo, customerRepo, creditRepo
+}
+
+func TestAdminService_ListCustomers(t *testing.T) {
+	tests := []struct {
+		name      string
+		search    string
+		plan      string
+		status    string
+		page      int
+		perPage   int
+		setup     func(*MockAdminRepo)
+		wantLen   int
+		wantTotal int
+		wantErr   error
+	}{
+		{
+			name:    "success with defaults",
+			search:  "",
+			plan:    "",
+			status:  "",
+			page:    0,
+			perPage: 0,
+			setup: func(ar *MockAdminRepo) {
+				ar.On("ListCustomers", mock.Anything, "", "", "", 20, 0).Return([]*domain.Customer{
+					{ID: "c1", Email: "a@b.com"},
+				}, 1, nil)
+			},
+			wantLen:   1,
+			wantTotal: 1,
+		},
+		{
+			name:    "invalid plan returns ErrInvalidPlan",
+			plan:    "nonexistent",
+			page:    1,
+			perPage: 20,
+			setup:   func(ar *MockAdminRepo) {},
+			wantErr: ErrInvalidPlan,
+		},
+		{
+			name:    "invalid status gets cleared",
+			status:  "bogus",
+			page:    1,
+			perPage: 10,
+			setup: func(ar *MockAdminRepo) {
+				ar.On("ListCustomers", mock.Anything, "", "", "", 10, 0).Return([]*domain.Customer{}, 0, nil)
+			},
+			wantLen:   0,
+			wantTotal: 0,
+		},
+		{
+			name:    "repo error propagates",
+			page:    1,
+			perPage: 20,
+			setup: func(ar *MockAdminRepo) {
+				ar.On("ListCustomers", mock.Anything, "", "", "", 20, 0).Return(nil, 0, errDBDown)
+			},
+			wantErr: errDBDown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			tt.setup(adminRepo)
+
+			customers, total, err := svc.ListCustomers(context.Background(), tt.search, tt.plan, tt.status, tt.page, tt.perPage)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Len(t, customers, tt.wantLen)
+			assert.Equal(t, tt.wantTotal, total)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_GetCustomerDetail(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		setup   func(*MockAdminRepo)
+		wantErr error
+	}{
+		{
+			name: "success",
+			id:   "c1",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("GetCustomerDetail", mock.Anything, "c1").Return(&domain.AdminCustomerDetail{
+					Customer: &domain.Customer{ID: "c1"},
+				}, nil)
+			},
+		},
+		{
+			name: "not found",
+			id:   "missing",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("GetCustomerDetail", mock.Anything, "missing").Return(nil, nil)
+			},
+			wantErr: ErrCustomerNotFound,
+		},
+		{
+			name: "repo error",
+			id:   "c1",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("GetCustomerDetail", mock.Anything, "c1").Return(nil, errDBDown)
+			},
+			wantErr: errDBDown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			tt.setup(adminRepo)
+
+			detail, err := svc.GetCustomerDetail(context.Background(), tt.id)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, detail)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_ChangePlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		custID  string
+		newPlan string
+		setup   func(*MockCustomerRepo)
+		wantErr error
+	}{
+		{
+			name:    "success",
+			custID:  "c1",
+			newPlan: domain.PlanLaunch,
+			setup: func(cr *MockCustomerRepo) {
+				cr.On("GetByID", mock.Anything, "c1").Return(&domain.Customer{ID: "c1"}, nil)
+				cr.On("UpdatePlan", mock.Anything, "c1", domain.PlanLaunch).Return(nil)
+			},
+		},
+		{
+			name:    "invalid plan",
+			custID:  "c1",
+			newPlan: "gold",
+			setup:   func(cr *MockCustomerRepo) {},
+			wantErr: ErrInvalidPlan,
+		},
+		{
+			name:    "customer not found",
+			custID:  "missing",
+			newPlan: domain.PlanShield,
+			setup: func(cr *MockCustomerRepo) {
+				cr.On("GetByID", mock.Anything, "missing").Return(nil, nil)
+			},
+			wantErr: ErrCustomerNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, customerRepo, _ := newTestAdminService()
+			tt.setup(customerRepo)
+
+			err := svc.ChangePlan(context.Background(), tt.custID, tt.newPlan)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			customerRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_SuspendCustomer(t *testing.T) {
+	tests := []struct {
+		name    string
+		adminID string
+		custID  string
+		setup   func(*MockAdminRepo)
+		wantErr error
+	}{
+		{
+			name:    "success",
+			adminID: "admin-1",
+			custID:  "c1",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("SuspendCustomer", mock.Anything, "c1").Return(nil)
+			},
+		},
+		{
+			name:    "self-suspend blocked",
+			adminID: "c1",
+			custID:  "c1",
+			setup:   func(ar *MockAdminRepo) {},
+			wantErr: ErrAdminSelfSuspend,
+		},
+		{
+			name:    "not found",
+			adminID: "admin-1",
+			custID:  "missing",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("SuspendCustomer", mock.Anything, "missing").Return(repository.ErrNotFound)
+			},
+			wantErr: ErrCustomerNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			tt.setup(adminRepo)
+
+			err := svc.SuspendCustomer(context.Background(), tt.adminID, tt.custID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_ActivateCustomer(t *testing.T) {
+	tests := []struct {
+		name    string
+		custID  string
+		setup   func(*MockAdminRepo)
+		wantErr error
+	}{
+		{
+			name:   "success",
+			custID: "c1",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("ActivateCustomer", mock.Anything, "c1").Return(nil)
+			},
+		},
+		{
+			name:   "not found",
+			custID: "missing",
+			setup: func(ar *MockAdminRepo) {
+				ar.On("ActivateCustomer", mock.Anything, "missing").Return(repository.ErrNotFound)
+			},
+			wantErr: ErrCustomerNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			tt.setup(adminRepo)
+
+			err := svc.ActivateCustomer(context.Background(), tt.custID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_GetRevenueChart(t *testing.T) {
+	tests := []struct {
+		name     string
+		days     int
+		wantDays int
+	}{
+		{"valid days", 30, 30},
+		{"zero defaults to 30", 0, 30},
+		{"over 365 defaults to 30", 400, 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			adminRepo.On("GetRevenueChart", mock.Anything, tt.wantDays).Return([]*domain.RevenueChartPoint{
+				{Date: "2026-03-01", AmountSatang: 100},
+			}, nil)
+
+			points, err := svc.GetRevenueChart(context.Background(), tt.days)
+
+			assert.NoError(t, err)
+			assert.Len(t, points, 1)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAdminService_GetGrowthChart(t *testing.T) {
+	tests := []struct {
+		name     string
+		days     int
+		wantDays int
+	}{
+		{"valid days", 30, 30},
+		{"zero defaults to 30", 0, 30},
+		{"over 365 defaults to 30", 400, 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, adminRepo, _, _ := newTestAdminService()
+			adminRepo.On("GetGrowthChart", mock.Anything, tt.wantDays).Return([]*domain.GrowthChartPoint{
+				{Date: "2026-03-01", NewCustomers: 5, TotalCustomers: 100},
+			}, nil)
+
+			points, err := svc.GetGrowthChart(context.Background(), tt.days)
+
+			assert.NoError(t, err)
+			assert.Len(t, points, 1)
+			adminRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/backend/internal/service/mocks_test.go
+++ b/backend/internal/service/mocks_test.go
@@ -479,3 +479,71 @@ func (m *MockNotificationRepo) MarkAllRead(ctx context.Context, customerID strin
 	args := m.Called(ctx, customerID)
 	return args.Error(0)
 }
+
+// MockAdminRepo
+type MockAdminRepo struct{ mock.Mock }
+
+func (m *MockAdminRepo) ListCustomers(ctx context.Context, search, plan, status string, limit, offset int) ([]*domain.Customer, int, error) {
+	args := m.Called(ctx, search, plan, status, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Int(1), args.Error(2)
+	}
+	return args.Get(0).([]*domain.Customer), args.Int(1), args.Error(2)
+}
+func (m *MockAdminRepo) GetCustomerDetail(ctx context.Context, id string) (*domain.AdminCustomerDetail, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.AdminCustomerDetail), args.Error(1)
+}
+func (m *MockAdminRepo) SuspendCustomer(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+func (m *MockAdminRepo) ActivateCustomer(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+func (m *MockAdminRepo) GetPlatformStats(ctx context.Context) (*domain.PlatformStats, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.PlatformStats), args.Error(1)
+}
+func (m *MockAdminRepo) GetRevenueChart(ctx context.Context, days int) ([]*domain.RevenueChartPoint, error) {
+	args := m.Called(ctx, days)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.RevenueChartPoint), args.Error(1)
+}
+func (m *MockAdminRepo) GetGrowthChart(ctx context.Context, days int) ([]*domain.GrowthChartPoint, error) {
+	args := m.Called(ctx, days)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.GrowthChartPoint), args.Error(1)
+}
+func (m *MockAdminRepo) ListAllPurchases(ctx context.Context, status string, limit, offset int) ([]*domain.AdminPurchase, int, error) {
+	args := m.Called(ctx, status, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Int(1), args.Error(2)
+	}
+	return args.Get(0).([]*domain.AdminPurchase), args.Int(1), args.Error(2)
+}
+func (m *MockAdminRepo) ListAllSubscriptions(ctx context.Context, status string, limit, offset int) ([]*domain.AdminSubscription, int, error) {
+	args := m.Called(ctx, status, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Int(1), args.Error(2)
+	}
+	return args.Get(0).([]*domain.AdminSubscription), args.Int(1), args.Error(2)
+}
+func (m *MockAdminRepo) ListCreditGrants(ctx context.Context, limit, offset int) ([]*domain.AdminCreditGrantWithCustomer, int, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Int(1), args.Error(2)
+	}
+	return args.Get(0).([]*domain.AdminCreditGrantWithCustomer), args.Int(1), args.Error(2)
+}

--- a/frontend/src/components/admin/CustomerDetailDialog.tsx
+++ b/frontend/src/components/admin/CustomerDetailDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -34,6 +35,8 @@ export function CustomerDetailDialog({ customerId, onClose }: CustomerDetailDial
   const grantCredits = useAdminGrantCredits()
 
   const [newPlan, setNewPlan] = useState('')
+  const [confirmSuspend, setConfirmSuspend] = useState(false)
+  const [confirmPlanChange, setConfirmPlanChange] = useState(false)
   const [creditForm, setCreditForm] = useState({
     total_replays: 1,
     max_events_per_replay: 5000,
@@ -45,7 +48,7 @@ export function CustomerDetailDialog({ customerId, onClose }: CustomerDetailDial
 
   const handlePlanChange = () => {
     if (!customer || !newPlan || newPlan === customer.plan) return
-    updatePlan.mutate({ customerId: customer.id, plan: newPlan })
+    setConfirmPlanChange(true)
   }
 
   const handleSuspendToggle = () => {
@@ -53,7 +56,7 @@ export function CustomerDetailDialog({ customerId, onClose }: CustomerDetailDial
     if (customer.suspended_at) {
       activate.mutate(customer.id)
     } else {
-      suspend.mutate(customer.id)
+      setConfirmSuspend(true)
     }
   }
 
@@ -271,6 +274,40 @@ export function CustomerDetailDialog({ customerId, onClose }: CustomerDetailDial
           </div>
         )}
       </DialogContent>
+
+      <Dialog open={confirmSuspend} onOpenChange={setConfirmSuspend}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>ยืนยันการระงับบัญชี</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            คุณต้องการระงับบัญชีของ <span className="font-medium text-foreground">{customer?.email}</span> ใช่หรือไม่? ผู้ใช้จะไม่สามารถเข้าใช้งานระบบได้
+          </p>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={() => setConfirmSuspend(false)}>ยกเลิก</Button>
+            <Button variant="destructive" size="sm" onClick={() => { if (!customer) return; suspend.mutate(customer.id); setConfirmSuspend(false) }} disabled={suspend.isPending}>
+              {suspend.isPending ? 'กำลังระงับ...' : 'ยืนยันระงับ'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={confirmPlanChange} onOpenChange={setConfirmPlanChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>ยืนยันการเปลี่ยนแผน</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            เปลี่ยนแผนจาก <Badge variant="secondary" className="text-xs">{PLAN_LABELS[customer?.plan ?? ''] ?? customer?.plan}</Badge> เป็น <Badge variant="secondary" className="text-xs">{PLAN_LABELS[newPlan] ?? newPlan}</Badge>
+          </p>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={() => setConfirmPlanChange(false)}>ยกเลิก</Button>
+            <Button size="sm" onClick={() => { if (!customer) return; updatePlan.mutate({ customerId: customer.id, plan: newPlan }); setConfirmPlanChange(false) }} disabled={updatePlan.isPending}>
+              {updatePlan.isPending ? 'กำลังบันทึก...' : 'ยืนยัน'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Dialog>
   )
 }

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -15,13 +15,14 @@ import type {
 
 // --- Queries ---
 
-export function useAdminCustomers(search: string, plan: string, page: number, perPage: number) {
+export function useAdminCustomers(search: string, plan: string, status: string, page: number, perPage: number) {
   return useQuery({
-    queryKey: ['admin', 'customers', { search, plan, page, perPage }],
+    queryKey: ['admin', 'customers', { search, plan, status, page, perPage }],
     queryFn: async () => {
       const params = new URLSearchParams()
       if (search) params.set('search', search)
       if (plan) params.set('plan', plan)
+      if (status) params.set('status', status)
       params.set('page', String(page))
       params.set('per_page', String(perPage))
       const { data } = await api.get<PaginatedResponse<AdminCustomer>>(`/admin/customers?${params}`)

--- a/frontend/src/pages/admin/AdminAnalyticsPage.tsx
+++ b/frontend/src/pages/admin/AdminAnalyticsPage.tsx
@@ -6,7 +6,7 @@ import {
   DollarSign,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { useAdminAnalytics, useAdminGrowthChart } from '@/hooks/use-admin'
+import { useAdminAnalytics, useAdminGrowthChart, useAdminRevenueChart } from '@/hooks/use-admin'
 import { formatBaht, PLAN_LABELS } from '@/lib/utils'
 import {
   AreaChart,
@@ -55,8 +55,10 @@ function StatCard({ title, value, subtitle, icon }: StatCardProps) {
 
 export function AdminAnalyticsPage() {
   const [days, setDays] = useState(30)
+  const [revenueDays, setRevenueDays] = useState(30)
   const { data: analytics } = useAdminAnalytics()
   const { data: growthData } = useAdminGrowthChart(days)
+  const { data: revenueData } = useAdminRevenueChart(revenueDays)
 
   const planDistribution = analytics
     ? Object.entries(analytics.customers_by_plan).map(([plan, count]) => ({
@@ -164,6 +166,85 @@ export function AdminAnalyticsPage() {
                   fillOpacity={1}
                   fill="url(#colorGrowth)"
                   name="ผู้ใช้ทั้งหมด"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="h-[300px] flex items-center justify-center text-muted-foreground">
+              ยังไม่มีข้อมูล
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Revenue Chart */}
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">รายได้</CardTitle>
+            <div className="flex rounded-lg border border-border p-0.5 bg-secondary">
+              {TIME_RANGES.map((range) => (
+                <button
+                  key={range.days}
+                  onClick={() => setRevenueDays(range.days)}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                    revenueDays === range.days
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {range.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {revenueData && revenueData.length > 0 ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <AreaChart data={revenueData}>
+                <defs>
+                  <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#16a34a" stopOpacity={0.1} />
+                    <stop offset="95%" stopColor="#16a34a" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#E4E4E7" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 12, fill: '#737373' }}
+                  tickFormatter={(val: string) => {
+                    const d = new Date(val)
+                    return `${d.getMonth() + 1}/${d.getDate()}`
+                  }}
+                />
+                <YAxis
+                  tick={{ fontSize: 12, fill: '#737373' }}
+                  tickFormatter={(val) => formatBaht(val)}
+                />
+                <Tooltip
+                  contentStyle={{
+                    borderRadius: '8px',
+                    border: '1px solid #e5e5e5',
+                    fontSize: '12px',
+                  }}
+                  labelFormatter={(val) => {
+                    const d = new Date(String(val))
+                    return d.toLocaleDateString('th-TH', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  }}
+                  formatter={(value) => [formatBaht(value as number), 'รายได้ (THB)']}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="amount_satang"
+                  stroke="#16a34a"
+                  fillOpacity={1}
+                  fill="url(#colorRevenue)"
+                  name="รายได้ (THB)"
                 />
               </AreaChart>
             </ResponsiveContainer>

--- a/frontend/src/pages/admin/AdminCustomersPage.tsx
+++ b/frontend/src/pages/admin/AdminCustomersPage.tsx
@@ -14,6 +14,7 @@ export function AdminCustomersPage() {
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [plan, setPlan] = useState('')
+  const [status, setStatus] = useState('')
   const [page, setPage] = useState(1)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const perPage = 20
@@ -27,7 +28,7 @@ export function AdminCustomersPage() {
     return () => clearTimeout(timer)
   }, [search])
 
-  const { data, isLoading } = useAdminCustomers(debouncedSearch, plan, page, perPage)
+  const { data, isLoading } = useAdminCustomers(debouncedSearch, plan, status, page, perPage)
 
   const planBadgeVariant = (p: string): 'default' | 'secondary' | 'success' | 'warning' => {
     switch (p) {
@@ -70,6 +71,15 @@ export function AdminCustomersPage() {
           {PLANS.filter(Boolean).map((p) => (
             <option key={p} value={p}>{PLAN_LABELS[p] ?? p}</option>
           ))}
+        </select>
+        <select
+          value={status}
+          onChange={(e) => { setStatus(e.target.value); setPage(1) }}
+          className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+        >
+          <option value="">ทุกสถานะ</option>
+          <option value="active">ใช้งาน</option>
+          <option value="suspended">ระงับ</option>
         </select>
       </div>
 


### PR DESCRIPTION
## Summary
- **Revenue Chart**: เพิ่ม AreaChart แสดงรายได้ (gradient สีเขียว) บน AdminAnalyticsPage พร้อม TIME_RANGES toggle
- **Status Filter**: เพิ่ม dropdown กรองสถานะลูกค้า (ใช้งาน/ระงับ) บน AdminCustomersPage
- **Confirmation Dialogs**: เพิ่ม dialog ยืนยันก่อนระงับบัญชีและเปลี่ยนแผน
- **Backend Tests**: เพิ่ม MockAdminRepo + 17 table-driven tests สำหรับ AdminService

## Files Changed
| File | Change |
|------|--------|
| `frontend/src/pages/admin/AdminAnalyticsPage.tsx` | Revenue AreaChart card |
| `frontend/src/hooks/use-admin.ts` | Added `status` param to `useAdminCustomers` |
| `frontend/src/pages/admin/AdminCustomersPage.tsx` | Status filter dropdown |
| `frontend/src/components/admin/CustomerDetailDialog.tsx` | Confirmation dialogs + null guards |
| `backend/internal/service/mocks_test.go` | MockAdminRepo (10 methods) |
| `backend/internal/service/admin_service_test.go` | 17 tests covering 7 service methods |

## Test Plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (17 admin tests)
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (13 tests)
- [x] `npm run build` passes
- [x] Pre-push hooks pass

## Known Pre-existing Issues (out of scope)
- `GrantCredits` raw SQL in service layer (needs repo refactor)
- `GetCustomerDetail` leaks `api_key` (needs handler fix)
- Status validation missing in `ListAllPurchases`/`ListAllSubscriptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)