### PR TITLE
fix: resolve race conditions, add logout, JSON middleware, payload validation, and tests

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -120,6 +120,16 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 	JSON(w, http.StatusOK, APIResponse{Data: customer})
 }
 
+func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
+	customerID := middleware.GetCustomerID(r.Context())
+	if err := h.authService.Logout(r.Context(), customerID); err != nil {
+		h.logger.Error("logout failed", "error", err)
+		ErrorJSON(w, http.StatusInternalServerError, "logout failed")
+		return
+	}
+	JSON(w, http.StatusOK, APIResponse{Message: "logged out"})
+}
+
 func (h *AuthHandler) RegenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	customer, err := h.authService.RegenerateAPIKey(r.Context(), customerID)

--- a/backend/internal/middleware/admin.go
+++ b/backend/internal/middleware/admin.go
@@ -11,9 +11,7 @@ func AdminOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		isAdmin := GetIsAdmin(r.Context())
 		if !isAdmin {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte(`{"error":"forbidden"}`))
+			writeJSONError(w, http.StatusForbidden, "forbidden")
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/backend/internal/middleware/apikey.go
+++ b/backend/internal/middleware/apikey.go
@@ -42,7 +42,7 @@ func APIKeyAuthWithContext(ctx context.Context, customerRepo repository.Customer
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			apiKey := r.Header.Get("X-API-Key")
 			if apiKey == "" {
-				http.Error(w, `{"error":"missing API key"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "missing API key")
 				return
 			}
 
@@ -59,7 +59,7 @@ func APIKeyAuthWithContext(ctx context.Context, customerRepo repository.Customer
 
 			customer, err := customerRepo.GetByAPIKey(r.Context(), apiKey)
 			if err != nil || customer == nil {
-				http.Error(w, `{"error":"invalid API key"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "invalid API key")
 				return
 			}
 

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -19,13 +19,13 @@ func JWTAuth(secret string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
-				http.Error(w, `{"error":"missing authorization header"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "missing authorization header")
 				return
 			}
 
 			tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
 			if tokenStr == authHeader {
-				http.Error(w, `{"error":"invalid authorization format"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "invalid authorization format")
 				return
 			}
 
@@ -36,19 +36,19 @@ func JWTAuth(secret string) func(http.Handler) http.Handler {
 				return []byte(secret), nil
 			})
 			if err != nil || !token.Valid {
-				http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "invalid token")
 				return
 			}
 
 			claims, ok := token.Claims.(jwt.MapClaims)
 			if !ok {
-				http.Error(w, `{"error":"invalid claims"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "invalid claims")
 				return
 			}
 
 			customerID, ok := claims["sub"].(string)
 			if !ok {
-				http.Error(w, `{"error":"invalid subject"}`, http.StatusUnauthorized)
+				writeJSONError(w, http.StatusUnauthorized, "invalid subject")
 				return
 			}
 

--- a/backend/internal/middleware/errors.go
+++ b/backend/internal/middleware/errors.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	jsonMsg, _ := json.Marshal(msg)
+	fmt.Fprintf(w, `{"error":%s}`, jsonMsg)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -141,6 +141,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 
 			// Auth - get current user
 			r.Get("/auth/me", authHandler.Me)
+			r.Post("/auth/logout", authHandler.Logout)
 			r.Post("/auth/regenerate-api-key", authHandler.RegenerateAPIKey)
 
 			// Pixel routes - Phase 3

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -100,7 +100,7 @@ func (s *AuthService) Register(ctx context.Context, input RegisterInput) (*AuthT
 		PasswordHash: string(hashedPassword),
 		Name:         input.Name,
 		APIKey:       apiKey,
-		Plan:         "free",
+		Plan:         domain.PlanSandbox,
 	}
 
 	if err := s.customerRepo.Create(ctx, customer); err != nil {
@@ -196,6 +196,13 @@ func (s *AuthService) GoogleAuth(ctx context.Context, input GoogleAuthInput) (*A
 	}
 
 	return s.generateTokens(ctx, customer)
+}
+
+func (s *AuthService) Logout(ctx context.Context, customerID string) error {
+	if err := s.refreshTokenRepo.DeleteByCustomerID(ctx, customerID); err != nil {
+		return fmt.Errorf("delete refresh tokens: %w", err)
+	}
+	return nil
 }
 
 func (s *AuthService) RegenerateAPIKey(ctx context.Context, customerID string) (*domain.Customer, error) {

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -84,6 +85,7 @@ func TestAuthService_Register(t *testing.T) {
 				assert.NotEmpty(t, tokens.AccessToken)
 				assert.NotEmpty(t, tokens.RefreshToken)
 				assert.NotNil(t, tokens.Customer)
+				assert.Equal(t, domain.PlanSandbox, tokens.Customer.Plan)
 			}
 			customerRepo.AssertExpectations(t)
 			refreshTokenRepo.AssertExpectations(t)
@@ -227,6 +229,48 @@ func TestAuthService_RefreshTokens(t *testing.T) {
 				assert.NotEmpty(t, tokens.RefreshToken)
 			}
 			customerRepo.AssertExpectations(t)
+			refreshTokenRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthService_Logout(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID string
+		setup      func(*MockRefreshTokenRepo)
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			customerID: "cust-1",
+			setup: func(rt *MockRefreshTokenRepo) {
+				rt.On("DeleteByCustomerID", mock.Anything, "cust-1").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:       "repo error",
+			customerID: "cust-2",
+			setup: func(rt *MockRefreshTokenRepo) {
+				rt.On("DeleteByCustomerID", mock.Anything, "cust-2").Return(errors.New("db error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, refreshTokenRepo := newTestAuthService()
+			tt.setup(refreshTokenRepo)
+
+			err := svc.Logout(context.Background(), tt.customerID)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			refreshTokenRepo.AssertExpectations(t)
 		})
 	}

--- a/backend/internal/service/event_service.go
+++ b/backend/internal/service/event_service.go
@@ -100,6 +100,16 @@ func (s *EventService) Ingest(ctx context.Context, customerID string, input Inge
 			continue
 		}
 
+		// Skip events with oversized payloads
+		if len(eventInput.EventData) > maxEventDataSize || len(eventInput.UserData) > maxUserDataSize {
+			s.logger.Warn("event payload too large, skipping",
+				"pixel_id", eventInput.PixelID,
+				"event_data_size", len(eventInput.EventData),
+				"user_data_size", len(eventInput.UserData),
+			)
+			continue
+		}
+
 		eventTime := time.Now()
 		if eventInput.EventTime != "" {
 			if parsed, err := time.Parse(time.RFC3339, eventInput.EventTime); err == nil {
@@ -308,6 +318,8 @@ const (
 	maxFBCookieLen     = 500 // max length for _fbc/_fbp cookie values
 	maxFBClidLen       = 200 // max length for fbclid URL parameter
 	defaultCountry     = "th" // Pixlinks v1 operates in Thailand only
+	maxEventDataSize   = 64 * 1024 // 64 KB per event_data field
+	maxUserDataSize    = 16 * 1024 // 16 KB per user_data field
 )
 
 func (s *EventService) ListRecent(ctx context.Context, customerID string, since time.Time, pixelID string) ([]*domain.RealtimeEvent, error) {

--- a/backend/internal/service/event_service_test.go
+++ b/backend/internal/service/event_service_test.go
@@ -394,6 +394,119 @@ func TestEventService_Ingest_BackupPixelFanOut(t *testing.T) {
 	// The pixelRepo.GetByID("pixel-backup") call may or may not have completed by now.
 }
 
+func TestEventService_Ingest_OversizedPayload(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventData   json.RawMessage
+		userData    json.RawMessage
+		wantCreated int
+		expectCreate bool
+	}{
+		{
+			name:         "event_data exceeds 64KB limit",
+			eventData:    json.RawMessage(`{"data":"` + strings.Repeat("x", 64*1024) + `"}`),
+			userData:     json.RawMessage(`{}`),
+			wantCreated:  0,
+			expectCreate: false,
+		},
+		{
+			name:         "user_data exceeds 16KB limit",
+			eventData:    json.RawMessage(`{}`),
+			userData:     json.RawMessage(`{"data":"` + strings.Repeat("x", 16*1024) + `"}`),
+			wantCreated:  0,
+			expectCreate: false,
+		},
+		{
+			name:         "both fields oversized",
+			eventData:    json.RawMessage(`{"data":"` + strings.Repeat("x", 64*1024) + `"}`),
+			userData:     json.RawMessage(`{"data":"` + strings.Repeat("x", 16*1024) + `"}`),
+			wantCreated:  0,
+			expectCreate: false,
+		},
+		{
+			name:         "payloads within limits",
+			eventData:    json.RawMessage(`{"data":"` + strings.Repeat("x", 100) + `"}`),
+			userData:     json.RawMessage(`{"data":"` + strings.Repeat("x", 100) + `"}`),
+			wantCreated:  1,
+			expectCreate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, eventRepo, pixelRepo := newTestEventService()
+
+			pixelRepo.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
+				ID:         "pixel-1",
+				CustomerID: "cust-1",
+				IsActive:   true,
+			}}, nil)
+			if tt.expectCreate {
+				eventRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(true, nil)
+			}
+
+			input := IngestBatchInput{
+				Events: []IngestEventInput{
+					{
+						PixelID:   "pixel-1",
+						EventName: "PageView",
+						EventData: tt.eventData,
+						UserData:  tt.userData,
+					},
+				},
+			}
+
+			created, err := svc.Ingest(context.Background(), "cust-1", input, ClientContext{
+				IP:        "192.168.1.1",
+				UserAgent: "TestAgent/1.0",
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCreated, created)
+			eventRepo.AssertExpectations(t)
+			pixelRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEventService_Ingest_OversizedPayload_MixedBatch(t *testing.T) {
+	svc, eventRepo, pixelRepo := newTestEventService()
+
+	pixelRepo.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{{
+		ID:         "pixel-1",
+		CustomerID: "cust-1",
+		IsActive:   true,
+	}}, nil)
+	eventRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.PixelEvent")).Return(true, nil)
+
+	input := IngestBatchInput{
+		Events: []IngestEventInput{
+			{
+				PixelID:   "pixel-1",
+				EventName: "PageView",
+				EventData: json.RawMessage(`{"data":"` + strings.Repeat("x", 64*1024) + `"}`),
+				UserData:  json.RawMessage(`{}`),
+			},
+			{
+				PixelID:   "pixel-1",
+				EventName: "Purchase",
+				EventData: json.RawMessage(`{"value":"100"}`),
+				UserData:  json.RawMessage(`{"email":"test@example.com"}`),
+			},
+		},
+	}
+
+	created, err := svc.Ingest(context.Background(), "cust-1", input, ClientContext{
+		IP:        "192.168.1.1",
+		UserAgent: "TestAgent/1.0",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, created, "only the valid event should be created; oversized event should be skipped")
+	eventRepo.AssertExpectations(t)
+	pixelRepo.AssertExpectations(t)
+}
+
 func TestEventService_ListByCustomerID(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/backend/internal/service/quota_service.go
+++ b/backend/internal/service/quota_service.go
@@ -178,80 +178,19 @@ func (s *QuotaService) CheckSalePageCreationQuota(ctx context.Context, customerI
 	return nil
 }
 
-// CheckReplayEventCount verifies that at least one active credit can handle the given event count.
-// This is a pre-flight check to reject replays early before loading events into memory.
-func (s *QuotaService) CheckReplayEventCount(ctx context.Context, customerID string, eventCount int) error {
-	credits, err := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
-	if err != nil {
-		return fmt.Errorf("check active credits: %w", err)
-	}
-	if len(credits) == 0 {
-		return ErrQuotaReplayNotAllowed
-	}
-
-	for _, c := range credits {
-		if c.RemainingReplays() != 0 && (c.MaxEventsPerReplay == 0 || eventCount <= c.MaxEventsPerReplay) {
-			return nil
-		}
-	}
-
-	// Credits exist but none can handle the event count
-	hasRemaining := false
-	for _, c := range credits {
-		if c.RemainingReplays() != 0 {
-			hasRemaining = true
-			break
-		}
-	}
-	if !hasRemaining {
-		return ErrQuotaReplayNotAllowed
-	}
-	return ErrQuotaReplayEventsExceeded
-}
-
 // ConsumeReplayCredit atomically consumes one replay from the customer's active credits.
-// Pre-flight validation checks credit availability and event limits before consuming.
+// Uses SELECT ... FOR UPDATE SKIP LOCKED to prevent TOCTOU race conditions.
 // Returns the credit used so the caller can access MaxEventsPerReplay.
 func (s *QuotaService) ConsumeReplayCredit(ctx context.Context, customerID string, eventCount int) (*domain.ReplayCredit, error) {
-	// Pre-flight: check credits exist and event count is within limits before consuming
-	credits, err := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
-	if err != nil {
-		return nil, fmt.Errorf("check active credits: %w", err)
-	}
-	if len(credits) == 0 {
-		return nil, ErrQuotaReplayNotAllowed
-	}
-
-	// Verify at least one credit can handle the event count
-	hasValidCredit := false
-	for _, c := range credits {
-		if c.RemainingReplays() != 0 && (c.MaxEventsPerReplay == 0 || eventCount <= c.MaxEventsPerReplay) {
-			hasValidCredit = true
-			break
-		}
-	}
-	if !hasValidCredit {
-		// Check if it's an event limit issue vs no remaining replays
-		hasRemaining := false
-		for _, c := range credits {
-			if c.RemainingReplays() != 0 {
-				hasRemaining = true
-				break
-			}
-		}
-		if !hasRemaining {
-			return nil, ErrQuotaReplayNotAllowed
-		}
-		return nil, ErrQuotaReplayEventsExceeded
-	}
-
-	// Atomically consume a credit that can handle the event count
+	// Atomically consume a credit that can handle the event count.
+	// ConsumeOneCredit uses SELECT ... FOR UPDATE SKIP LOCKED to prevent
+	// concurrent requests from consuming the same credit.
 	credit, err := s.creditRepo.ConsumeOneCredit(ctx, customerID, eventCount)
 	if err != nil {
 		return nil, fmt.Errorf("consume credit: %w", err)
 	}
 	if credit == nil {
-		// Atomic consume failed — do read-only query to determine error type
+		// Atomic consume failed — do read-only query to classify the error
 		readCredits, readErr := s.creditRepo.GetActiveByCustomerID(ctx, customerID)
 		if readErr != nil || len(readCredits) == 0 {
 			return nil, ErrQuotaReplayNotAllowed

--- a/backend/internal/service/quota_service_test.go
+++ b/backend/internal/service/quota_service_test.go
@@ -289,7 +289,6 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 			UsedReplays:        1,
 			MaxEventsPerReplay: domain.DefaultMaxEventsPerReplay,
 		}
-		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
 		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
@@ -303,6 +302,9 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("no credits available", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _, _ := newTestQuotaService()
 
+		// ConsumeOneCredit returns nil when no credit is available
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(nil, nil)
+		// Fallback read-only query to classify error
 		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{}, nil)
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)
@@ -314,6 +316,9 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("exceeds max events per replay", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _, _ := newTestQuotaService()
 
+		// ConsumeOneCredit returns nil when event count exceeds limit
+		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(nil, nil)
+		// Fallback read-only query finds credits exist but none matched
 		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{{
 			ID:                 "credit-1",
 			TotalReplays:       3,
@@ -336,7 +341,6 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 			UsedReplays:        0,
 			MaxEventsPerReplay: 0,
 		}
-		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{activeCredit}, nil)
 		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(activeCredit, nil)
 
 		credit, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 999999)
@@ -349,12 +353,6 @@ func TestQuotaService_ConsumeReplayCredit(t *testing.T) {
 	t.Run("consume credit repo error", func(t *testing.T) {
 		svc, creditRepo, _, _, _, _, _ := newTestQuotaService()
 
-		creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{{
-			ID:                 "credit-1",
-			TotalReplays:       3,
-			UsedReplays:        0,
-			MaxEventsPerReplay: 0,
-		}}, nil)
 		creditRepo.On("ConsumeOneCredit", mock.Anything, "cust-1", mock.AnythingOfType("int")).Return(nil, errors.New("db error"))
 
 		_, err := svc.ConsumeReplayCredit(context.Background(), "cust-1", 500)

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -179,23 +179,31 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		return nil, err
 	}
 
-	// Pre-check event count before loading all events into memory
+	// Count events for replay
 	eventCount, err := s.eventRepo.CountEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo)
 	if err != nil {
 		return nil, fmt.Errorf("count events for replay: %w", err)
-	}
-
-	// Early rejection if quota service is available and event count exceeds credit limits
-	if s.quotaService != nil && eventCount > 0 {
-		if err := s.quotaService.CheckReplayEventCount(ctx, customerID, eventCount); err != nil {
-			return nil, err
-		}
 	}
 
 	// Load events for replay
 	events, err := s.eventRepo.GetEventsForReplay(ctx, input.SourcePixelID, input.EventTypes, dateFrom, dateTo, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get events for replay: %w", err)
+	}
+
+	// Atomically consume a replay credit BEFORE creating the session to prevent
+	// TOCTOU race conditions where concurrent requests both pass a pre-flight
+	// check and over-consume credits.
+	var credit *domain.ReplayCredit
+	if s.quotaService != nil && eventCount > 0 {
+		credit, err = s.quotaService.ConsumeReplayCredit(ctx, customerID, len(events))
+		if err != nil {
+			return nil, err
+		}
+		// Cap events to the credit's limit if applicable
+		if credit.MaxEventsPerReplay > 0 && len(events) > credit.MaxEventsPerReplay {
+			events = events[:credit.MaxEventsPerReplay]
+		}
 	}
 
 	// Default TimeMode to "original"
@@ -220,7 +228,7 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 		}
 	}
 
-	// Create session FIRST (before consuming credit) so we have a record
+	// Create session AFTER consuming credit (credit is the scarce resource)
 	session := &domain.ReplaySession{
 		CustomerID:    customerID,
 		SourcePixelID: input.SourcePixelID,
@@ -235,26 +243,6 @@ func (s *ReplayService) Create(ctx context.Context, customerID string, input Cre
 
 	if err := s.replayRepo.Create(ctx, session); err != nil {
 		return nil, fmt.Errorf("create replay session: %w", err)
-	}
-
-	// Consume a replay credit if quota service is available
-	if s.quotaService != nil {
-		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(events))
-		if err != nil {
-			// Mark session as failed since credit consumption failed
-			if updateErr := s.replayRepo.UpdateStatusWithError(ctx, session.ID, "failed", err.Error()); updateErr != nil {
-				s.logger.Error("failed to mark session failed after credit error", "error", updateErr, "session_id", session.ID)
-			}
-			return nil, err
-		}
-		// Cap events to the credit's limit if lower than the global max
-		if credit.MaxEventsPerReplay > 0 && len(events) > credit.MaxEventsPerReplay {
-			events = events[:credit.MaxEventsPerReplay]
-			session.TotalEvents = len(events)
-			if updateErr := s.replayRepo.UpdateTotalEvents(ctx, session.ID, len(events)); updateErr != nil {
-				s.logger.Warn("failed to update total events after cap", "error", updateErr, "session_id", session.ID)
-			}
-		}
 	}
 
 	// Start replay in background (semaphore-limited)
@@ -644,7 +632,20 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 		retryEvents = allEvents
 	}
 
-	// Create a NEW session FIRST (preserve history, before consuming credit)
+	// Atomically consume a replay credit BEFORE creating the session to prevent
+	// TOCTOU race conditions where concurrent requests over-consume credits.
+	if s.quotaService != nil {
+		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(retryEvents))
+		if err != nil {
+			return nil, err
+		}
+		// Cap events to the credit's limit if applicable
+		if credit.MaxEventsPerReplay > 0 && len(retryEvents) > credit.MaxEventsPerReplay {
+			retryEvents = retryEvents[:credit.MaxEventsPerReplay]
+		}
+	}
+
+	// Create a NEW session (preserve history)
 	newSession := &domain.ReplaySession{
 		CustomerID:    customerID,
 		SourcePixelID: session.SourcePixelID,
@@ -659,26 +660,6 @@ func (s *ReplayService) Retry(ctx context.Context, customerID, sessionID string)
 
 	if err := s.replayRepo.Create(ctx, newSession); err != nil {
 		return nil, fmt.Errorf("create retry replay session: %w", err)
-	}
-
-	// Consume a replay credit if quota service is available
-	if s.quotaService != nil {
-		credit, err := s.quotaService.ConsumeReplayCredit(ctx, customerID, len(retryEvents))
-		if err != nil {
-			// Mark session as failed since credit consumption failed
-			if updateErr := s.replayRepo.UpdateStatusWithError(ctx, newSession.ID, "failed", err.Error()); updateErr != nil {
-				s.logger.Error("failed to mark retry session failed after credit error", "error", updateErr, "session_id", newSession.ID)
-			}
-			return nil, err
-		}
-		// Cap events to the credit's limit if lower
-		if credit.MaxEventsPerReplay > 0 && len(retryEvents) > credit.MaxEventsPerReplay {
-			retryEvents = retryEvents[:credit.MaxEventsPerReplay]
-			newSession.TotalEvents = len(retryEvents)
-			if updateErr := s.replayRepo.UpdateTotalEvents(ctx, newSession.ID, len(retryEvents)); updateErr != nil {
-				s.logger.Warn("failed to update total events after cap", "error", updateErr, "session_id", newSession.ID)
-			}
-		}
 	}
 
 	// Start replay in background (semaphore-limited)

--- a/backend/internal/service/sale_page_service_test.go
+++ b/backend/internal/service/sale_page_service_test.go
@@ -1,0 +1,1357 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+)
+
+func newTestSalePageService() (*SalePageService, *MockSalePageRepo, *MockCustomerRepo, *MockPixelRepo) {
+	salePageRepo := new(MockSalePageRepo)
+	customerRepo := new(MockCustomerRepo)
+	pixelRepo := new(MockPixelRepo)
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = cancel
+	svc := NewSalePageService(ctx, salePageRepo, customerRepo, pixelRepo, nil)
+	return svc, salePageRepo, customerRepo, pixelRepo
+}
+
+type quotaMocks struct {
+	salePageRepo *MockSalePageRepo
+	customerRepo *MockCustomerRepo
+	pixelRepo    *MockPixelRepo
+	subRepo      *MockSubscriptionRepo
+	creditRepo   *MockReplayCreditRepo
+	usageRepo    *MockEventUsageRepo
+}
+
+func newTestSalePageServiceWithQuota() (*SalePageService, *quotaMocks) {
+	m := &quotaMocks{
+		salePageRepo: new(MockSalePageRepo),
+		customerRepo: new(MockCustomerRepo),
+		pixelRepo:    new(MockPixelRepo),
+		subRepo:      new(MockSubscriptionRepo),
+		creditRepo:   new(MockReplayCreditRepo),
+		usageRepo:    new(MockEventUsageRepo),
+	}
+
+	quotaService := NewQuotaService(m.creditRepo, m.subRepo, m.usageRepo, m.pixelRepo, m.salePageRepo, m.customerRepo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = cancel
+	svc := NewSalePageService(ctx, m.salePageRepo, m.customerRepo, m.pixelRepo, quotaService)
+	return svc, m
+}
+
+var validV1Content = json.RawMessage(`{"hero":{"title":"Test","subtitle":"Sub","image_url":""},"body":{"description":"Test page","features":[],"images":[]},"cta":{"button_text":"Buy","button_link":""},"contact":{},"tracking":{},"style":{}}`)
+var validV2Content = json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"text","text":"hello"}],"style":{},"tracking":{}}`)
+
+// ---------- Create ----------
+
+func TestSalePageService_Create(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CreateSalePageInput
+		setup   func(*MockSalePageRepo, *MockPixelRepo)
+		wantErr error
+		errMsg  string
+		check   func(*testing.T, *domain.SalePage)
+	}{
+		{
+			name: "success_with_auto_slug",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, mock.AnythingOfType("string")).Return(false, nil).Once()
+				sp.On("Create", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.NotEmpty(t, page.Slug)
+				assert.True(t, len(page.Slug) > 2, "auto-generated slug should have prefix + chars")
+				assert.Equal(t, "My Page", page.Name)
+				assert.Equal(t, "cust-1", page.CustomerID)
+			},
+		},
+		{
+			name: "success_with_custom_slug",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "my-page",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "my-page").Return(false, nil)
+				sp.On("Create", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, "my-page", page.Slug)
+			},
+		},
+		{
+			name: "success_with_pixels",
+			input: CreateSalePageInput{
+				Name:         "Page With Pixels",
+				Slug:         "pixel-page",
+				TemplateName: "default",
+				Content:      validV1Content,
+				PixelIDs:     []string{"pixel-1", "pixel-2"},
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "pixel-page").Return(false, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1", "pixel-2"}).Return([]*domain.Pixel{
+					{ID: "pixel-1", CustomerID: "cust-1"},
+					{ID: "pixel-2", CustomerID: "cust-1"},
+				}, nil)
+				sp.On("Create", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, []string{"pixel-1", "pixel-2"}, page.PixelIDs)
+			},
+		},
+		{
+			name: "success_with_v2_content",
+			input: CreateSalePageInput{
+				Name:         "V2 Page",
+				Slug:         "v2-page",
+				TemplateName: "blocks",
+				Content:      validV2Content,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "v2-page").Return(false, nil)
+				sp.On("Create", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, "v2-page", page.Slug)
+			},
+		},
+		{
+			name: "slug_taken",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "taken-slug",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "taken-slug").Return(true, nil)
+			},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name: "reserved_slug_admin",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "admin",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name: "reserved_slug_api",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "api",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name: "reserved_slug_login",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "login",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name: "invalid_slug_uppercase",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "MyPage",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidSlug,
+		},
+		{
+			name: "invalid_slug_spaces",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "my page",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidSlug,
+		},
+		{
+			name: "invalid_slug_leading_hyphen",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "-my-page",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidSlug,
+		},
+		{
+			name: "invalid_content_v1_malformed_json",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "good-slug",
+				TemplateName: "default",
+				Content:      json.RawMessage(`{not valid json`),
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidContent,
+		},
+		{
+			name: "invalid_content_v2_no_blocks",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "good-slug",
+				TemplateName: "blocks",
+				Content:      json.RawMessage(`{"version":2,"blocks":[],"style":{},"tracking":{}}`),
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidContent,
+		},
+		{
+			name: "invalid_content_v2_too_many_blocks",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "good-slug",
+				TemplateName: "blocks",
+				Content:      generateTooManyBlocksContent(101),
+			},
+			setup:   func(sp *MockSalePageRepo, pr *MockPixelRepo) {},
+			wantErr: ErrInvalidContent,
+		},
+		{
+			name: "pixel_not_found",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "good-slug",
+				TemplateName: "default",
+				Content:      validV1Content,
+				PixelIDs:     []string{"pixel-missing"},
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "good-slug").Return(false, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-missing"}).Return([]*domain.Pixel{}, nil)
+			},
+			wantErr: ErrPixelNotFound,
+		},
+		{
+			name: "pixel_not_owned",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "good-slug",
+				TemplateName: "default",
+				Content:      validV1Content,
+				PixelIDs:     []string{"pixel-other"},
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "good-slug").Return(false, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-other"}).Return([]*domain.Pixel{
+					{ID: "pixel-other", CustomerID: "cust-other"},
+				}, nil)
+			},
+			wantErr: ErrPixelNotOwned,
+		},
+		{
+			name: "db_unique_constraint",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "racy-slug",
+				TemplateName: "default",
+				Content:      validV1Content,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "racy-slug").Return(false, nil)
+				sp.On("Create", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(
+					&pgconn.PgError{Code: "23505"},
+				)
+			},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name: "nil_pixel_ids_becomes_empty_slice",
+			input: CreateSalePageInput{
+				Name:         "My Page",
+				Slug:         "no-pixels",
+				TemplateName: "default",
+				Content:      validV1Content,
+				PixelIDs:     nil,
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("SlugExists", mock.Anything, "no-pixels").Return(false, nil)
+				sp.On("Create", mock.Anything, mock.MatchedBy(func(p *domain.SalePage) bool {
+					return p.PixelIDs != nil && len(p.PixelIDs) == 0
+				})).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.NotNil(t, page.PixelIDs)
+				assert.Empty(t, page.PixelIDs)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, salePageRepo, _, pixelRepo := newTestSalePageService()
+			tt.setup(salePageRepo, pixelRepo)
+
+			page, err := svc.Create(context.Background(), "cust-1", tt.input)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, page)
+			} else if tt.errMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, page)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, page)
+				if tt.check != nil {
+					tt.check(t, page)
+				}
+			}
+			salePageRepo.AssertExpectations(t)
+			pixelRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSalePageService_Create_QuotaExceeded(t *testing.T) {
+	svc, m := newTestSalePageServiceWithQuota()
+
+	// Set up quota check: sandbox plan allows 1 sale page, customer already has 1
+	m.customerRepo.On("GetByID", mock.Anything, "cust-1").Return(&domain.Customer{
+		ID:   "cust-1",
+		Plan: domain.PlanSandbox,
+	}, nil)
+	m.subRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.Subscription{}, nil)
+	m.creditRepo.On("GetActiveByCustomerID", mock.Anything, "cust-1").Return([]*domain.ReplayCredit{}, nil)
+	m.salePageRepo.On("CountByCustomerID", mock.Anything, "cust-1").Return(1, nil)
+	m.usageRepo.On("GetCurrentMonth", mock.Anything, "cust-1").Return(nil, nil)
+
+	input := CreateSalePageInput{
+		Name:         "My Page",
+		Slug:         "my-page",
+		TemplateName: "default",
+		Content:      validV1Content,
+	}
+
+	page, err := svc.Create(context.Background(), "cust-1", input)
+
+	assert.ErrorIs(t, err, ErrQuotaSalePagesExceeded)
+	assert.Nil(t, page)
+	m.customerRepo.AssertExpectations(t)
+}
+
+// ---------- GetByID ----------
+
+func TestSalePageService_GetByID(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID string
+		pageID     string
+		setup      func(*MockSalePageRepo)
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Name:       "Test Page",
+				}, nil)
+			},
+		},
+		{
+			name:       "not_found",
+			customerID: "cust-1",
+			pageID:     "nonexistent",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+			},
+			wantErr: ErrSalePageNotFound,
+		},
+		{
+			name:       "not_owned",
+			customerID: "cust-2",
+			pageID:     "page-1",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+				}, nil)
+			},
+			wantErr: ErrSalePageNotOwned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, salePageRepo, _, _ := newTestSalePageService()
+			tt.setup(salePageRepo)
+
+			page, err := svc.GetByID(context.Background(), tt.customerID, tt.pageID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, page)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, page)
+			}
+			salePageRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------- List ----------
+
+func TestSalePageService_List(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		svc, salePageRepo, _, _ := newTestSalePageService()
+
+		salePageRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return([]*domain.SalePage{
+			{ID: "page-1", CustomerID: "cust-1", Name: "Page 1"},
+			{ID: "page-2", CustomerID: "cust-1", Name: "Page 2"},
+		}, nil)
+
+		pages, err := svc.List(context.Background(), "cust-1")
+
+		assert.NoError(t, err)
+		assert.Len(t, pages, 2)
+		salePageRepo.AssertExpectations(t)
+	})
+
+	t.Run("empty_returns_empty_slice", func(t *testing.T) {
+		svc, salePageRepo, _, _ := newTestSalePageService()
+
+		salePageRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return(nil, nil)
+
+		pages, err := svc.List(context.Background(), "cust-1")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, pages)
+		assert.Len(t, pages, 0)
+		salePageRepo.AssertExpectations(t)
+	})
+
+	t.Run("repo_error", func(t *testing.T) {
+		svc, salePageRepo, _, _ := newTestSalePageService()
+
+		salePageRepo.On("ListByCustomerID", mock.Anything, "cust-1").Return(nil, errors.New("db error"))
+
+		pages, err := svc.List(context.Background(), "cust-1")
+
+		assert.Error(t, err)
+		assert.Nil(t, pages)
+		salePageRepo.AssertExpectations(t)
+	})
+}
+
+// ---------- Update ----------
+
+func TestSalePageService_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID string
+		pageID     string
+		input      UpdateSalePageInput
+		setup      func(*MockSalePageRepo, *MockPixelRepo)
+		wantErr    error
+		check      func(*testing.T, *domain.SalePage)
+	}{
+		{
+			name:       "success_name",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Name: strPtr("Updated Name")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Name:       "Old Name",
+					Slug:       "old-slug",
+				}, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, "Updated Name", page.Name)
+			},
+		},
+		{
+			name:       "success_slug",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("new-slug")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Name:       "My Page",
+					Slug:       "old-slug",
+				}, nil)
+				sp.On("SlugExists", mock.Anything, "new-slug").Return(false, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, "new-slug", page.Slug)
+			},
+		},
+		{
+			name:       "success_same_slug_no_check",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("same-slug")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Name:       "My Page",
+					Slug:       "same-slug",
+				}, nil)
+				// SlugExists should NOT be called when slug is unchanged
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, "same-slug", page.Slug)
+			},
+		},
+		{
+			name:       "slug_taken",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("taken-slug")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "old-slug",
+				}, nil)
+				sp.On("SlugExists", mock.Anything, "taken-slug").Return(true, nil)
+			},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name:       "slug_reserved",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("admin")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "old-slug",
+				}, nil)
+			},
+			wantErr: ErrSlugTaken,
+		},
+		{
+			name:       "slug_invalid",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("Invalid Slug")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "old-slug",
+				}, nil)
+			},
+			wantErr: ErrInvalidSlug,
+		},
+		{
+			name:       "not_found",
+			customerID: "cust-1",
+			pageID:     "nonexistent",
+			input:      UpdateSalePageInput{Name: strPtr("Updated")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+			},
+			wantErr: ErrSalePageNotFound,
+		},
+		{
+			name:       "not_owned",
+			customerID: "cust-2",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Name: strPtr("Updated")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+				}, nil)
+			},
+			wantErr: ErrSalePageNotOwned,
+		},
+		{
+			name:       "pixel_ownership_check",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input: UpdateSalePageInput{
+				PixelIDs: &[]string{"pixel-1", "pixel-2"},
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "my-slug",
+				}, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-1", "pixel-2"}).Return([]*domain.Pixel{
+					{ID: "pixel-1", CustomerID: "cust-1"},
+					{ID: "pixel-2", CustomerID: "cust-1"},
+				}, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.Equal(t, []string{"pixel-1", "pixel-2"}, page.PixelIDs)
+			},
+		},
+		{
+			name:       "pixel_not_owned_on_update",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input: UpdateSalePageInput{
+				PixelIDs: &[]string{"pixel-other"},
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "my-slug",
+				}, nil)
+				pr.On("GetByIDs", mock.Anything, []string{"pixel-other"}).Return([]*domain.Pixel{
+					{ID: "pixel-other", CustomerID: "cust-other"},
+				}, nil)
+			},
+			wantErr: ErrPixelNotOwned,
+		},
+		{
+			name:       "update_content_valid",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input: UpdateSalePageInput{
+				Content: rawPtr(validV2Content),
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "my-slug",
+					Content:    validV1Content,
+				}, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.NotNil(t, page.Content)
+			},
+		},
+		{
+			name:       "update_content_invalid",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input: UpdateSalePageInput{
+				Content: rawPtr(json.RawMessage(`{not valid`)),
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "my-slug",
+				}, nil)
+			},
+			wantErr: ErrInvalidContent,
+		},
+		{
+			name:       "update_published",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input: UpdateSalePageInput{
+				IsPublished: boolPtr(true),
+			},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:          "page-1",
+					CustomerID:  "cust-1",
+					Slug:        "my-slug",
+					IsPublished: false,
+				}, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(nil)
+			},
+			check: func(t *testing.T, page *domain.SalePage) {
+				assert.True(t, page.IsPublished)
+			},
+		},
+		{
+			name:       "db_unique_constraint_on_update",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			input:      UpdateSalePageInput{Slug: strPtr("racy-slug")},
+			setup: func(sp *MockSalePageRepo, pr *MockPixelRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "old-slug",
+				}, nil)
+				sp.On("SlugExists", mock.Anything, "racy-slug").Return(false, nil)
+				sp.On("Update", mock.Anything, mock.AnythingOfType("*domain.SalePage")).Return(
+					&pgconn.PgError{Code: "23505"},
+				)
+			},
+			wantErr: ErrSlugTaken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, salePageRepo, _, pixelRepo := newTestSalePageService()
+			tt.setup(salePageRepo, pixelRepo)
+
+			page, err := svc.Update(context.Background(), tt.customerID, tt.pageID, tt.input)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, page)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, page)
+				if tt.check != nil {
+					tt.check(t, page)
+				}
+			}
+			salePageRepo.AssertExpectations(t)
+			pixelRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------- Delete ----------
+
+func TestSalePageService_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID string
+		pageID     string
+		setup      func(*MockSalePageRepo)
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			customerID: "cust-1",
+			pageID:     "page-1",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+					Slug:       "my-slug",
+				}, nil)
+				sp.On("Delete", mock.Anything, "page-1").Return(nil)
+			},
+		},
+		{
+			name:       "not_found",
+			customerID: "cust-1",
+			pageID:     "nonexistent",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+			},
+			wantErr: ErrSalePageNotFound,
+		},
+		{
+			name:       "not_owned",
+			customerID: "cust-2",
+			pageID:     "page-1",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetByID", mock.Anything, "page-1").Return(&domain.SalePage{
+					ID:         "page-1",
+					CustomerID: "cust-1",
+				}, nil)
+			},
+			wantErr: ErrSalePageNotOwned,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, salePageRepo, _, _ := newTestSalePageService()
+			tt.setup(salePageRepo)
+
+			err := svc.Delete(context.Background(), tt.customerID, tt.pageID)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			salePageRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------- GetBySlug ----------
+
+func TestSalePageService_GetBySlug(t *testing.T) {
+	tests := []struct {
+		name    string
+		slug    string
+		setup   func(*MockSalePageRepo)
+		wantErr error
+	}{
+		{
+			name: "published",
+			slug: "my-page",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetBySlug", mock.Anything, "my-page").Return(&domain.SalePage{
+					ID:          "page-1",
+					CustomerID:  "cust-1",
+					Slug:        "my-page",
+					IsPublished: true,
+				}, nil)
+			},
+		},
+		{
+			name: "not_published",
+			slug: "draft-page",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetBySlug", mock.Anything, "draft-page").Return(&domain.SalePage{
+					ID:          "page-1",
+					CustomerID:  "cust-1",
+					Slug:        "draft-page",
+					IsPublished: false,
+				}, nil)
+			},
+			wantErr: ErrSalePageNotFound,
+		},
+		{
+			name: "not_found",
+			slug: "nonexistent",
+			setup: func(sp *MockSalePageRepo) {
+				sp.On("GetBySlug", mock.Anything, "nonexistent").Return(nil, nil)
+			},
+			wantErr: ErrSalePageNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, salePageRepo, _, _ := newTestSalePageService()
+			tt.setup(salePageRepo)
+
+			page, err := svc.GetBySlug(context.Background(), tt.slug)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, page)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, page)
+				assert.True(t, page.IsPublished)
+			}
+			salePageRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// ---------- GetPublishData ----------
+
+func TestSalePageService_GetPublishData(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		svc, salePageRepo, customerRepo, pixelRepo := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "my-page").Return(&domain.SalePage{
+			ID:          "page-1",
+			CustomerID:  "cust-1",
+			Slug:        "my-page",
+			IsPublished: true,
+			PixelIDs:    []string{"pixel-1"},
+		}, nil)
+		customerRepo.On("GetByID", mock.Anything, "cust-1").Return(&domain.Customer{
+			ID:     "cust-1",
+			APIKey: "api-key-123",
+		}, nil)
+		pixelRepo.On("GetByIDs", mock.Anything, []string{"pixel-1"}).Return([]*domain.Pixel{
+			{ID: "pixel-1", FBPixelID: "fb-123"},
+		}, nil)
+
+		data, err := svc.GetPublishData(context.Background(), "my-page")
+
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Equal(t, "page-1", data.Page.ID)
+		assert.Equal(t, "api-key-123", data.APIKey)
+		assert.Len(t, data.Pixels, 1)
+		assert.Equal(t, "pixel-1", data.Pixels[0].PixelID)
+		assert.Equal(t, "fb-123", data.Pixels[0].FBPixelID)
+		salePageRepo.AssertExpectations(t)
+		customerRepo.AssertExpectations(t)
+		pixelRepo.AssertExpectations(t)
+	})
+
+	t.Run("success_no_pixels", func(t *testing.T) {
+		svc, salePageRepo, customerRepo, _ := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "no-pixel-page").Return(&domain.SalePage{
+			ID:          "page-2",
+			CustomerID:  "cust-1",
+			Slug:        "no-pixel-page",
+			IsPublished: true,
+			PixelIDs:    []string{},
+		}, nil)
+		customerRepo.On("GetByID", mock.Anything, "cust-1").Return(&domain.Customer{
+			ID:     "cust-1",
+			APIKey: "api-key-123",
+		}, nil)
+
+		data, err := svc.GetPublishData(context.Background(), "no-pixel-page")
+
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		assert.Nil(t, data.Pixels)
+		salePageRepo.AssertExpectations(t)
+		customerRepo.AssertExpectations(t)
+	})
+
+	t.Run("page_not_found", func(t *testing.T) {
+		svc, salePageRepo, _, _ := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "nonexistent").Return(nil, nil)
+
+		data, err := svc.GetPublishData(context.Background(), "nonexistent")
+
+		assert.ErrorIs(t, err, ErrSalePageNotFound)
+		assert.Nil(t, data)
+		salePageRepo.AssertExpectations(t)
+	})
+
+	t.Run("page_not_published", func(t *testing.T) {
+		svc, salePageRepo, _, _ := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "draft").Return(&domain.SalePage{
+			ID:          "page-1",
+			CustomerID:  "cust-1",
+			Slug:        "draft",
+			IsPublished: false,
+		}, nil)
+
+		data, err := svc.GetPublishData(context.Background(), "draft")
+
+		assert.ErrorIs(t, err, ErrSalePageNotFound)
+		assert.Nil(t, data)
+		salePageRepo.AssertExpectations(t)
+	})
+
+	t.Run("customer_not_found", func(t *testing.T) {
+		svc, salePageRepo, customerRepo, _ := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "orphan-page").Return(&domain.SalePage{
+			ID:          "page-1",
+			CustomerID:  "cust-deleted",
+			Slug:        "orphan-page",
+			IsPublished: true,
+		}, nil)
+		customerRepo.On("GetByID", mock.Anything, "cust-deleted").Return(nil, nil)
+
+		data, err := svc.GetPublishData(context.Background(), "orphan-page")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "customer not found")
+		assert.Nil(t, data)
+		salePageRepo.AssertExpectations(t)
+		customerRepo.AssertExpectations(t)
+	})
+
+	t.Run("cache_hit", func(t *testing.T) {
+		svc, salePageRepo, customerRepo, pixelRepo := newTestSalePageService()
+
+		salePageRepo.On("GetBySlug", mock.Anything, "cached-page").Return(&domain.SalePage{
+			ID:          "page-1",
+			CustomerID:  "cust-1",
+			Slug:        "cached-page",
+			IsPublished: true,
+			PixelIDs:    []string{},
+		}, nil)
+		customerRepo.On("GetByID", mock.Anything, "cust-1").Return(&domain.Customer{
+			ID:     "cust-1",
+			APIKey: "api-key-123",
+		}, nil)
+
+		// First call: populates cache
+		data1, err := svc.GetPublishData(context.Background(), "cached-page")
+		require.NoError(t, err)
+		require.NotNil(t, data1)
+
+		// Second call: should use cache (repo not called again)
+		data2, err := svc.GetPublishData(context.Background(), "cached-page")
+		require.NoError(t, err)
+		require.NotNil(t, data2)
+
+		assert.Equal(t, data1, data2)
+
+		// GetBySlug should have been called exactly once
+		salePageRepo.AssertNumberOfCalls(t, "GetBySlug", 1)
+		customerRepo.AssertNumberOfCalls(t, "GetByID", 1)
+		_ = pixelRepo
+	})
+}
+
+// ---------- validateContent ----------
+
+func TestValidateContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content json.RawMessage
+		wantErr error
+		errMsg  string
+	}{
+		{
+			name:    "valid_v1",
+			content: validV1Content,
+		},
+		{
+			name:    "valid_v2_text_block",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"text","text":"hello world"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v2_image_block",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"image","image_url":"https://example.com/img.jpg"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v2_button_line",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"button","button_style":"line","button_text":"Add Line"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v2_button_website",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"button","button_style":"website","button_url":"https://example.com","button_text":"Visit"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v2_button_custom",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"button","button_style":"custom","button_url":"https://example.com","button_text":"Go"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v2_multiple_block_types",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"text","text":"Title"},{"id":"b2","type":"image","image_url":"https://example.com/img.jpg"},{"id":"b3","type":"button","button_style":"line","button_text":"Add Line"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "valid_v1_with_style",
+			content: json.RawMessage(`{"hero":{"title":"T"},"body":{"description":"D"},"cta":{},"contact":{},"tracking":{},"style":{"bg_color":"#ffffff","accent_color":"#667eea","text_color":"#1a1a2e"}}`),
+		},
+		{
+			name:    "malformed_json",
+			content: json.RawMessage(`{not valid`),
+			wantErr: ErrInvalidContent,
+		},
+		{
+			name:    "v2_empty_blocks",
+			content: json.RawMessage(`{"version":2,"blocks":[],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "at least one block",
+		},
+		{
+			name:    "v2_too_many_blocks",
+			content: generateTooManyBlocksContent(101),
+			wantErr: ErrInvalidContent,
+			errMsg:  "too many blocks",
+		},
+		{
+			name:    "v2_block_missing_id",
+			content: json.RawMessage(`{"version":2,"blocks":[{"type":"text","text":"hello"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "missing ID",
+		},
+		{
+			name:    "v2_unknown_block_type",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"video"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "unknown type",
+		},
+		{
+			name:    "v2_invalid_button_style",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"button","button_style":"fancy"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "invalid button_style",
+		},
+		{
+			name:    "invalid_hex_color_bg",
+			content: json.RawMessage(`{"hero":{},"body":{},"cta":{},"contact":{},"tracking":{},"style":{"bg_color":"red"}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "bg_color must be a valid hex color",
+		},
+		{
+			name:    "invalid_hex_color_accent",
+			content: json.RawMessage(`{"hero":{},"body":{},"cta":{},"contact":{},"tracking":{},"style":{"accent_color":"#xyz"}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "accent_color must be a valid hex color",
+		},
+		{
+			name:    "invalid_hex_color_text",
+			content: json.RawMessage(`{"hero":{},"body":{},"cta":{},"contact":{},"tracking":{},"style":{"text_color":"123456"}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "text_color must be a valid hex color",
+		},
+		{
+			name:    "javascript_url_rejected_in_image",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"image","image_url":"javascript:alert(1)"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "URL must use http or https scheme",
+		},
+		{
+			name:    "javascript_url_rejected_in_button",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"button","button_style":"website","button_url":"javascript:alert(1)"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "URL must use http or https scheme",
+		},
+		{
+			name:    "data_url_rejected",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"image","image_url":"data:text/html,<h1>evil</h1>"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "URL must use http or https scheme",
+		},
+		{
+			name:    "v2_image_block_with_valid_link",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"image","image_url":"https://example.com/img.jpg","link_url":"https://example.com"}],"style":{},"tracking":{}}`),
+		},
+		{
+			name:    "v2_image_block_javascript_link_rejected",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"image","image_url":"https://example.com/img.jpg","link_url":"javascript:void(0)"}],"style":{},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "URL must use http or https scheme",
+		},
+		{
+			name:    "bg_image_url_must_be_https",
+			content: json.RawMessage(`{"hero":{},"body":{},"cta":{},"contact":{},"tracking":{},"style":{"bg_image_url":"http://example.com/bg.jpg"}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "bg_image_url must start with https://",
+		},
+		{
+			name:    "v2_style_invalid_color",
+			content: json.RawMessage(`{"version":2,"blocks":[{"id":"b1","type":"text","text":"hi"}],"style":{"bg_color":"bad"},"tracking":{}}`),
+			wantErr: ErrInvalidContent,
+			errMsg:  "bg_color must be a valid hex color",
+		},
+		{
+			name:    "v2_exactly_100_blocks_valid",
+			content: generateTooManyBlocksContent(100),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContent(tt.content)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ---------- validateSlug ----------
+
+func TestValidateSlug(t *testing.T) {
+	tests := []struct {
+		name    string
+		slug    string
+		wantErr error
+	}{
+		{name: "valid_simple", slug: "hello"},
+		{name: "valid_with_hyphen", slug: "my-page"},
+		{name: "valid_with_numbers", slug: "test123"},
+		{name: "valid_numbers_and_hyphens", slug: "page-1-v2"},
+		{name: "valid_single_char", slug: "a"},
+		{name: "invalid_uppercase", slug: "Hello", wantErr: ErrInvalidSlug},
+		{name: "invalid_space", slug: "my page", wantErr: ErrInvalidSlug},
+		{name: "invalid_underscore", slug: "my_page", wantErr: ErrInvalidSlug},
+		{name: "invalid_leading_hyphen", slug: "-my-page", wantErr: ErrInvalidSlug},
+		{name: "invalid_trailing_hyphen", slug: "my-page-", wantErr: ErrInvalidSlug},
+		{name: "invalid_double_hyphen", slug: "my--page", wantErr: ErrInvalidSlug},
+		{name: "invalid_special_chars", slug: "my@page", wantErr: ErrInvalidSlug},
+		{name: "reserved_admin", slug: "admin", wantErr: ErrSlugTaken},
+		{name: "reserved_api", slug: "api", wantErr: ErrSlugTaken},
+		{name: "reserved_login", slug: "login", wantErr: ErrSlugTaken},
+		{name: "reserved_register", slug: "register", wantErr: ErrSlugTaken},
+		{name: "reserved_dashboard", slug: "dashboard", wantErr: ErrSlugTaken},
+		{name: "reserved_health", slug: "health", wantErr: ErrSlugTaken},
+		{name: "reserved_p", slug: "p", wantErr: ErrSlugTaken},
+		{name: "empty_string", slug: "", wantErr: ErrInvalidSlug},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSlug(tt.slug)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ---------- validateSafeURL ----------
+
+func TestValidateSafeURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "empty", url: ""},
+		{name: "https", url: "https://example.com"},
+		{name: "http", url: "http://example.com"},
+		{name: "relative", url: "/path/to/page"},
+		{name: "javascript", url: "javascript:alert(1)", wantErr: true, errMsg: "http or https"},
+		{name: "data", url: "data:text/html,hi", wantErr: true, errMsg: "http or https"},
+		{name: "ftp", url: "ftp://example.com/file", wantErr: true, errMsg: "http or https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSafeURL(tt.url)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ---------- validatePageStyle ----------
+
+func TestValidatePageStyle(t *testing.T) {
+	tests := []struct {
+		name    string
+		style   domain.PageStyle
+		wantErr bool
+	}{
+		{name: "empty_style", style: domain.PageStyle{}},
+		{name: "valid_colors", style: domain.PageStyle{BgColor: "#ffffff", AccentColor: "#667eea", TextColor: "#1a1a2e"}},
+		{name: "valid_bg_image", style: domain.PageStyle{BgImageURL: "https://example.com/bg.jpg"}},
+		{name: "invalid_bg_color", style: domain.PageStyle{BgColor: "red"}, wantErr: true},
+		{name: "invalid_accent_color", style: domain.PageStyle{AccentColor: "#gg0000"}, wantErr: true},
+		{name: "invalid_text_color", style: domain.PageStyle{TextColor: "000000"}, wantErr: true},
+		{name: "http_bg_image_rejected", style: domain.PageStyle{BgImageURL: "http://example.com/bg.jpg"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePageStyle(tt.style)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, ErrInvalidContent)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// ---------- generateRandomSlug ----------
+
+func TestGenerateRandomSlug(t *testing.T) {
+	slug, err := generateRandomSlug()
+	require.NoError(t, err)
+	assert.True(t, len(slug) == 10, "slug should be 'p-' + 8 chars = 10 chars, got %d: %s", len(slug), slug)
+	assert.Equal(t, "p-", slug[:2])
+	// Validate the generated slug passes validation
+	assert.NoError(t, validateSlug(slug))
+}
+
+func TestGenerateRandomSlug_Uniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		slug, err := generateRandomSlug()
+		require.NoError(t, err)
+		assert.False(t, seen[slug], "duplicate slug generated: %s", slug)
+		seen[slug] = true
+	}
+}
+
+// ---------- helpers ----------
+
+func rawPtr(r json.RawMessage) *json.RawMessage {
+	return &r
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// generateTooManyBlocksContent generates v2 content with the specified number of blocks.
+func generateTooManyBlocksContent(n int) json.RawMessage {
+	blocks := make([]domain.Block, n)
+	for i := 0; i < n; i++ {
+		blocks[i] = domain.Block{
+			ID:   "b" + json.Number(rune('0'+i%10)).String(),
+			Type: domain.BlockTypeText,
+			Text: "block",
+		}
+	}
+	// Use a simpler approach: build manually with proper unique IDs
+	var blocksJSON []byte
+	blocksJSON = append(blocksJSON, '[')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			blocksJSON = append(blocksJSON, ',')
+		}
+		id := "b" + intToStr(i)
+		blocksJSON = append(blocksJSON, []byte(`{"id":"`+id+`","type":"text","text":"block"}`)...)
+	}
+	blocksJSON = append(blocksJSON, ']')
+
+	return json.RawMessage(`{"version":2,"blocks":` + string(blocksJSON) + `,"style":{},"tracking":{}}`)
+}
+
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	result := ""
+	for n > 0 {
+		result = string(rune('0'+n%10)) + result
+		n /= 10
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- **Race condition fix**: Removed TOCTOU vulnerability in replay credit consumption — two concurrent replay requests can no longer over-consume credits. Reordered credit consumption before session creation to prevent orphaned sessions.
- **Logout endpoint**: Added `POST /api/v1/auth/logout` for server-side refresh token invalidation across all devices.
- **Plan consistency**: Fixed `Register()` using `"free"` instead of `domain.PlanSandbox` (matching `GoogleAuth()`).
- **Middleware JSON errors**: All auth/API key middleware errors now return `Content-Type: application/json` instead of plain text.
- **Payload validation**: Added per-field size limits for event ingestion (`event_data` 64KB, `user_data` 16KB) to prevent abuse.
- **Sale page service tests**: 66 new test cases covering Create, GetByID, List, Update, Delete, GetBySlug, GetPublishData, content/slug validation (previously 0% coverage).

## Files Changed (14 files, +1609 -135)

| Area | Files |
|------|-------|
| Race fix | `replay_service.go`, `quota_service.go`, `*_test.go` |
| Auth | `auth_service.go`, `auth_handler.go`, `router.go`, `auth_service_test.go` |
| Middleware | `auth.go`, `apikey.go`, `admin.go`, `errors.go` (new) |
| Event validation | `event_service.go`, `event_service_test.go` |
| Tests | `sale_page_service_test.go` (new, 66 cases) |

## Test plan

- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all packages)
- [x] Frontend build passes
- [x] Pre-push quality gates pass
- [ ] CI pipeline passes
- [ ] Post-deploy E2E smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)