### PR TITLE
chore: rename menu label หน้าขาย to เซลเพจ

### DIFF
--- a/frontend/e2e/pages/sidebar.page.ts
+++ b/frontend/e2e/pages/sidebar.page.ts
@@ -16,7 +16,7 @@ export class SidebarPage {
     this.brand = page.getByRole('heading', { name: 'Pixlinks' })
     this.dashboardLink = page.getByRole('link', { name: 'แดชบอร์ด' })
     this.pixelsLink = page.getByRole('link', { name: 'พิกเซล' })
-    this.salePagesLink = page.getByRole('link', { name: 'หน้าขาย' })
+    this.salePagesLink = page.getByRole('link', { name: 'เซลเพจ' })
     this.eventsLink = page.getByRole('link', { name: 'อีเวนต์' })
     this.replayCenterLink = page.getByRole('link', { name: 'รีเพลย์' })
     this.settingsLink = page.getByRole('link', { name: 'ตั้งค่า' })

--- a/frontend/e2e/tests/navigation.spec.ts
+++ b/frontend/e2e/tests/navigation.spec.ts
@@ -23,7 +23,7 @@ test.describe('Navigation @smoke', () => {
 
     const routes = [
       { name: 'พิกเซล', url: '/pixels' },
-      { name: 'หน้าขาย', url: '/sale-pages' },
+      { name: 'เซลเพจ', url: '/sale-pages' },
       { name: 'อีเวนต์', url: '/events' },
       { name: 'รีเพลย์', url: '/replay' },
       { name: 'ตั้งค่า', url: '/settings' },

--- a/frontend/src/components/admin/CustomerDetailDialog.tsx
+++ b/frontend/src/components/admin/CustomerDetailDialog.tsx
@@ -126,7 +126,7 @@ export function CustomerDetailDialog({ customerId, onClose }: CustomerDetailDial
                 {[
                   { label: 'พิกเซล', value: detail.pixel_count },
                   { label: 'อีเวนต์', value: detail.event_count.toLocaleString() },
-                  { label: 'หน้าขาย', value: detail.sale_page_count },
+                  { label: 'เซลเพจ', value: detail.sale_page_count },
                   { label: 'รีเพลย์', value: detail.replay_count },
                 ].map((s) => (
                   <div key={s.label} className="bg-muted rounded-lg p-3 text-center">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -25,7 +25,7 @@ import { NotificationBell } from './NotificationBell'
 const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'แดชบอร์ด' },
   { to: '/pixels', icon: Radio, label: 'พิกเซล' },
-  { to: '/sale-pages', icon: FileText, label: 'หน้าขาย' },
+  { to: '/sale-pages', icon: FileText, label: 'เซลเพจ' },
   { to: '/events', icon: Activity, label: 'อีเวนต์' },
   { to: '/replay', icon: RotateCcw, label: 'รีเพลย์' },
   { to: '/billing', icon: CreditCard, label: 'การเงิน' },

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -408,7 +408,7 @@ export function EventsPage() {
         <div className="text-center py-12 border border-dashed border-border rounded-lg">
           <p className="text-muted-foreground">ยังไม่มีอีเวนต์ที่บันทึก</p>
           <p className="text-sm text-muted-foreground mt-1">
-            อีเวนต์จะปรากฏที่นี่เมื่อหน้าขายของคุณเริ่มได้รับการเข้าชม
+            อีเวนต์จะปรากฏที่นี่เมื่อเซลเพจของคุณเริ่มได้รับการเข้าชม
           </p>
         </div>
       ) : (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ const features = [
     icon: FileText,
     title: 'Sale Pages',
     description:
-      'สร้างหน้าขายที่รองรับหลาย Pixel พร้อมติดตาม Event อัตโนมัติ',
+      'สร้างเซลเพจที่รองรับหลาย Pixel พร้อมติดตาม Event อัตโนมัติ',
   },
 ]
 
@@ -34,7 +34,7 @@ const steps = [
   {
     number: '2',
     title: 'เชื่อมต่อ Sale Page',
-    description: 'สร้างหน้าขายและเชื่อมต่อกับ Pixel',
+    description: 'สร้างเซลเพจและเชื่อมต่อกับ Pixel',
   },
   {
     number: '3',

--- a/frontend/src/pages/SalePagesPage.tsx
+++ b/frontend/src/pages/SalePagesPage.tsx
@@ -32,12 +32,12 @@ export function SalePagesPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">หน้าขาย</h1>
-          <p className="text-sm text-muted-foreground mt-1">สร้างและจัดการหน้าขายของคุณ</p>
+          <h1 className="text-2xl font-bold text-foreground">เซลเพจ</h1>
+          <p className="text-sm text-muted-foreground mt-1">สร้างและจัดการเซลเพจของคุณ</p>
         </div>
         <Button onClick={() => navigate('/sale-pages/new')}>
           <Plus className="h-4 w-4" />
-          สร้างหน้าขาย
+          สร้างเซลเพจ
         </Button>
       </div>
 
@@ -48,10 +48,10 @@ export function SalePagesPage() {
         <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
       ) : !salePages || salePages.length === 0 ? (
         <div className="text-center py-12 border border-dashed border-border rounded-lg">
-          <p className="text-muted-foreground mb-4">ยังไม่มีหน้าขาย</p>
+          <p className="text-muted-foreground mb-4">ยังไม่มีเซลเพจ</p>
           <Button variant="outline" onClick={() => navigate('/sale-pages/new')}>
             <Plus className="h-4 w-4" />
-            สร้างหน้าขายแรกของคุณ
+            สร้างเซลเพจแรกของคุณ
           </Button>
         </div>
       ) : (
@@ -135,10 +135,10 @@ export function SalePagesPage() {
       <Dialog open={!!deleteConfirm} onOpenChange={() => setDeleteConfirm(null)}>
         <DialogContent onClose={() => setDeleteConfirm(null)}>
           <DialogHeader>
-            <DialogTitle>ลบหน้าขาย</DialogTitle>
+            <DialogTitle>ลบเซลเพจ</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground mt-2">
-            คุณแน่ใจหรือไม่ว่าต้องการลบหน้าขายนี้? ไม่สามารถย้อนกลับได้
+            คุณแน่ใจหรือไม่ว่าต้องการลบเซลเพจนี้? ไม่สามารถย้อนกลับได้
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeleteConfirm(null)}>ยกเลิก</Button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -94,7 +94,7 @@ export function SettingsPage() {
             </div>
             <div className="flex items-center justify-between mt-3">
               <p className="text-xs text-muted-foreground">
-                คีย์นี้ใช้สำหรับเทมเพลตหน้าขายเพื่อส่งอีเวนต์ไปยังพิกเซลของคุณ
+                คีย์นี้ใช้สำหรับเทมเพลตเซลเพจเพื่อส่งอีเวนต์ไปยังพิกเซลของคุณ
               </p>
               <Button
                 variant="outline"


### PR DESCRIPTION
## Summary
- เปลี่ยนชื่อเมนู "หน้าขาย" เป็น "เซลเพจ" ทั้ง 8 ไฟล์ (sidebar, pages, admin, e2e tests)

## Test plan
- [x] Frontend lint passed
- [x] Frontend tests passed (13/13)
- [x] Frontend build passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)