### PR TITLE
fix: add retry with exponential backoff to post-deploy-e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,21 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Verify backend before smoke tests
+        run: |
+          URL="${{ vars.BACKEND_PROD_URL }}/health"
+          echo "Re-checking backend health before E2E..."
+          for i in $(seq 1 5); do
+            STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "Backend healthy (HTTP 200)"
+              exit 0
+            fi
+            echo "Attempt $i/5: HTTP $STATUS — retrying in 10s..."
+            sleep 10
+          done
+          echo "::warning::Backend health check failed — global-setup retry will handle it"
+
       - name: Run smoke tests against production
         run: npx playwright test --grep @smoke
         env:

--- a/frontend/e2e/support/global-setup.ts
+++ b/frontend/e2e/support/global-setup.ts
@@ -5,6 +5,44 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  retries = 5
+): Promise<Response> {
+  const backoffMs = [3000, 6000, 12000, 24000, 48000]
+  let lastError: Error | null = null
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, options)
+
+      // Only retry on 5xx server errors
+      if (res.status >= 500 && attempt < retries) {
+        const delay = backoffMs[attempt] ?? 48000
+        console.log(
+          `[global-setup] ${url} returned ${res.status}, retrying in ${delay / 1000}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, delay))
+        continue
+      }
+
+      return res
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err))
+      if (attempt < retries) {
+        const delay = backoffMs[attempt] ?? 48000
+        console.log(
+          `[global-setup] ${url} fetch error: ${lastError.message}, retrying in ${delay / 1000}s (attempt ${attempt + 1}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, delay))
+      }
+    }
+  }
+
+  throw lastError ?? new Error(`fetchWithRetry failed after ${retries} retries`)
+}
+
 async function globalSetup() {
   const authDir = path.resolve(__dirname, '../.auth')
   if (!fs.existsSync(authDir)) {
@@ -19,7 +57,7 @@ async function globalSetup() {
 
   // Try to register via API (may fail if user already exists)
   try {
-    const res = await fetch(`${apiBase}/auth/register`, {
+    const res = await fetchWithRetry(`${apiBase}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -33,7 +71,7 @@ async function globalSetup() {
     tokens = body.data
   } catch {
     // Registration failed (user exists) — login instead
-    const res = await fetch(`${apiBase}/auth/login`, {
+    const res = await fetchWithRetry(`${apiBase}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- เพิ่ม `fetchWithRetry` helper ใน `global-setup.ts` — retry เฉพาะ 5xx errors ด้วย exponential backoff (3s→48s, ~90s max)
- เพิ่ม health re-check step ใน `post-deploy-e2e` CI job ก่อนรัน smoke tests
- แก้ปัญหา CI fail จาก transient 502 Bad Gateway ระหว่าง Railway deploy

## Test plan
- [ ] CI passes on this PR (e2e job runs global-setup successfully)
- [ ] ถ้า backend healthy → retry ไม่ trigger (ทำงานเหมือนเดิม)
- [ ] ถ้า backend flicker 502 → retry จัดการให้อัตโนมัติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)