### PR TITLE
fix: resolve post-deploy E2E 502 by routing auth through backend directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
         run: npx playwright test --grep @smoke
         env:
           E2E_BASE_URL: ${{ vars.FRONTEND_PROD_URL }}
+          E2E_API_URL: ${{ vars.BACKEND_PROD_URL }}
           E2E_USER_EMAIL: ${{ secrets.E2E_PROD_USER_EMAIL }}
           E2E_USER_PASSWORD: ${{ secrets.E2E_PROD_USER_PASSWORD }}
 

--- a/frontend/e2e/support/global-setup.ts
+++ b/frontend/e2e/support/global-setup.ts
@@ -50,7 +50,9 @@ async function globalSetup() {
   }
 
   const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
-  const apiBase = `${baseURL}/api/v1`
+  const apiBase = process.env.E2E_API_URL
+    ? `${process.env.E2E_API_URL}/api/v1`
+    : `${baseURL}/api/v1`
   const storagePath = path.resolve(authDir, 'user.json')
 
   let tokens: { access_token: string; refresh_token: string }


### PR DESCRIPTION
## Summary
- **Railway `BACKEND_PROXY_URL`** changed from public URL to internal domain (`http://pixlinks-api.railway.internal:8080`) — fixes Nginx `/api/` and `/p/` proxy 502 errors
- **E2E global-setup** now supports `E2E_API_URL` env var to call backend directly, bypassing Nginx (matches how real app works via `VITE_API_URL`)
- **CI `post-deploy-e2e`** passes `BACKEND_PROD_URL` as `E2E_API_URL` so smoke tests authenticate directly against the backend

## Root Cause
Nginx proxy was configured with the public backend URL as `BACKEND_PROXY_URL`, causing the container to route API calls through the public internet instead of Railway's internal network — resulting in 502 Bad Gateway.

## Test Plan
- [ ] Railway redeploy completes → `curl https://pixlinks.xyz/api/v1/health` returns 200
- [ ] Sale pages (`/p/...`) load correctly
- [ ] CI `e2e` job passes (local flow unchanged)
- [ ] Merge to main → `post-deploy-e2e` passes with direct backend auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)