### PR TITLE
chore: update 6 skills, create sale-page-editor, modernize CLAUDE.md

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -150,14 +150,31 @@ cd backend && go build ./...
 
 ## Database Schema Reference
 
-Current tables in the database:
-- `customers` — User accounts (id, email, password_hash, name, api_key, plan)
-- `pixels` — Facebook Pixel configs (id, customer_id, fb_pixel_id, fb_access_token, name, is_active, status)
-- `pixel_events` — Captured events (id, pixel_id, event_name, event_data, user_data, source_url, event_time)
+24 migrations (000001–000024). Current active tables:
+
+- `customers` — User accounts (id, email, name, google_id, api_key, plan, is_admin, suspended_at)
+- `pixels` — Facebook Pixel configs (id, customer_id, fb_pixel_id, fb_access_token, name, is_active, backup_pixel_id)
+- `pixel_events` — Captured events (id, pixel_id, event_name, event_data, user_data, source_url, event_time, event_id)
 - `event_rules` — Visual event setup rules (id, pixel_id, page_url, event_name, trigger_type, css_selector)
-- `replay_sessions` — Event replay jobs (id, customer_id, source_pixel_id, target_pixel_id, status)
+- `replay_sessions` — Event replay jobs (id, customer_id, source_pixel_id, target_pixel_id, status, events_replayed, events_failed)
 - `refresh_tokens` — JWT refresh tokens (id, customer_id, token_hash, expires_at)
-- `sale_pages` — Landing page builder (id, customer_id, pixel_id, name, slug, template_name, content)
+- `sale_pages` — Landing page builder (id, customer_id, name, slug, template_name, content, content_version)
+- `sale_page_pixels` — M:M join table (sale_page_id, pixel_id, position)
+- `notifications` — User notifications (id, customer_id, type, title, message, read)
+- `purchases` — Stripe checkout records (id, customer_id, stripe_session_id, pack_type, amount, status)
+- `replay_credits` — Credit packs for replays (id, customer_id, total_replays, used_replays, max_events_per_replay, expires_at)
+- `subscriptions` — Stripe subscriptions (id, customer_id, stripe_subscription_id, plan, status)
+- `event_usage` — Monthly event usage tracking (id, customer_id, month, event_count)
+- `stripe_webhook_events` — Webhook idempotency (event_id, event_type, processed_at)
+- `admin_credit_grants` — Admin credit grant audit trail (id, admin_id, customer_id, pack_type, reason)
+- `admin_audit_logs` — Admin action audit logs (id, admin_id, action, target_type, target_id, details)
+
+**Dropped tables:** `custom_domains` (created 000003, dropped 000009)
+
+### Key Migration Patterns
+- All DDL uses `IF NOT EXISTS` / `IF EXISTS` for idempotency (server restarts re-run migrations)
+- M:M join tables use composite primary keys: `PRIMARY KEY (sale_page_id, pixel_id)`
+- Column additions use `ADD COLUMN IF NOT EXISTS` for safe re-runs
 
 ## Related
 

--- a/.claude/skills/deploy-check/SKILL.md
+++ b/.claude/skills/deploy-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-check
-description: Run pre-deployment verification checklist across all 3 packages (backend, frontend, SDK) before pushing to Railway
+description: Run pre-deployment verification checklist across backend and frontend packages before pushing to Railway
 ---
 
 # Deploy Check
@@ -43,15 +43,7 @@ cd frontend && npm run build
 
 This runs `tsc` + `vite build`. Must exit 0 with no TypeScript errors.
 
-### Step 3: SDK Build
-
-```bash
-cd sdk && npm run build
-```
-
-Must produce `sdk/dist/pixlinks.min.js` and `sdk/dist/pixlinks.esm.js`.
-
-### Step 4: Security Scan
+### Step 3: Security Scan
 
 Check for common security issues:
 
@@ -65,7 +57,7 @@ Must return empty.
 ```bash
 grep -rn --include='*.go' --include='*.ts' --include='*.tsx' --include='*.js' \
   -E '(password|secret|token|api_key)\s*[:=]\s*["\x27][^"\x27]{8,}' \
-  backend/internal/ frontend/src/ sdk/src/ || true
+  backend/internal/ frontend/src/ || true
 ```
 Review any matches — false positives are OK (like variable names), but actual hardcoded credentials must be flagged.
 
@@ -76,7 +68,7 @@ grep -rn --include='*.go' --include='*.ts' --include='*.tsx' \
   backend/ frontend/src/ || true
 ```
 
-### Step 5: Deployment Files
+### Step 4: Deployment Files
 
 Verify Railway configuration files exist:
 
@@ -92,7 +84,7 @@ Check that `backend/Dockerfile` and `frontend/Dockerfile` exist:
 ls backend/Dockerfile frontend/Dockerfile
 ```
 
-### Step 6: Output Summary
+### Step 5: Output Summary
 
 Print a summary table:
 
@@ -103,7 +95,6 @@ Pre-Deployment Check Results
 [PASS/FAIL] Backend lint      (go vet ./...)
 [PASS/FAIL] Backend tests     (go test ./...)
 [PASS/FAIL] Frontend build    (npm run build)
-[PASS/FAIL] SDK build         (npm run build)
 [PASS/FAIL] Security scan     (no secrets, no .env)
 [PASS/FAIL] Deploy configs    (railway.json + Dockerfiles)
 ============================

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: dev-workflow
-description: Keep-PX development workflow patterns extracted from 120 commits — file co-change maps, recurring pitfalls, and iteration shortcuts
-version: 1.1.0
+description: Keep-PX development workflow patterns extracted from 166 commits — file co-change maps, recurring pitfalls, and iteration shortcuts
+version: 1.2.0
 source: local-git-analysis
-analyzed_commits: 200
+analyzed_commits: 166
 ---
 
 # Keep-PX Development Workflow Patterns
@@ -18,11 +18,11 @@ type: short description (lowercase, no period, max 72 chars)
 
 | Type | Usage | Count |
 |------|-------|-------|
-| `fix:` | Bug fixes, CSP fixes, proxy fixes | 50 (46%) |
-| `feat:` | New features, new pages, new endpoints | 44 (40%) |
-| `chore:` | Config, env vars, cleanup | 7 (6%) |
-| `refactor:` | Code restructuring without behavior change | 6 (5%) |
-| `ci:` | GitHub Actions, hooks | 2 (2%) |
+| `fix:` | Bug fixes, CSP fixes, proxy fixes | 66 (40%) |
+| `feat:` | New features, new pages, new endpoints | 53 (32%) |
+| `merge:` | PR merges | 35 (21%) |
+| `chore:` | Config, env vars, cleanup | 12 (7%) |
+| `refactor:` | Code restructuring without behavior change | 7 (4%) |
 
 Branch naming: `feat/`, `fix/`, `chore/`, `refactor/`, `perf/`
 
@@ -44,9 +44,9 @@ When changing one file, you almost always need to change these others:
 9. backend/cmd/server/main.go             → Wire new dependencies (if new service)
 ```
 
-**router.go** changes 27/120 commits — it's the DI wiring hub.
-**interfaces.go** changes 21/120 — every new repo method touches it.
-**mocks_test.go** changes 18/120 — must update when interfaces change.
+**router.go** changes 27/166 commits — it's the DI wiring hub.
+**interfaces.go** changes 21/166 — every new repo method touches it.
+**mocks_test.go** changes 18/166 — must update when interfaces change.
 
 ### Frontend: Adding/Modifying a Page
 
@@ -58,9 +58,22 @@ When changing one file, you almost always need to change these others:
 5. frontend/src/components/layout/Sidebar.tsx → Add nav entry
 ```
 
-**types/index.ts** changes 19/120 — every API change touches it.
-**router.tsx** changes 13/120 — every new page.
-**Sidebar.tsx** changes 12/120 — every new page.
+**types/index.ts** changes 19/166 — every API change touches it.
+**router.tsx** changes 13/166 — every new page.
+**Sidebar.tsx** changes 12/166 — every new page.
+
+### Sale Page Co-Change Group (7 backend + 5 frontend files)
+
+```
+Backend:
+  domain/sale_page.go → repo/sale_page_repo.go → service/sale_page_service.go
+  → handler/sale_page_handler.go → router.go
+  → templates/blocks.html + simple.html + tracking.html (ALWAYS together)
+
+Frontend:
+  types/index.ts → hooks/use-sale-pages.ts → SalePageEditorPage.tsx
+  → BlockEditor.tsx → SalePagePreview.tsx
+```
 
 ### Full-Stack Feature (both sides)
 
@@ -72,25 +85,11 @@ All backend files above + all frontend files above + often:
 
 ### 1. Nginx CSP Headers (6+ fix rounds)
 
-**Pattern:** Every new external service (Google OAuth, Stripe, R2 CDN) needs CSP updates in **6 places** in `nginx.conf`:
-- Server-level (line ~25)
-- `/assets/` location
-- `/` location
-- `/p/` location (separate sale page CSP)
+**Pattern:** Every new external service (Google OAuth, Stripe, R2 CDN) needs CSP updates in **4 location blocks** in `nginx.conf`.
 
 **Pitfall:** Nginx drops parent `add_header` when child location has its own `add_header`. You must redeclare ALL headers in every location block.
 
-**Checklist for new external domains:**
-- [ ] `script-src` — if loading JS
-- [ ] `style-src` — if loading CSS
-- [ ] `connect-src` — if making API calls
-- [ ] `frame-src` — if embedding iframes
-- [ ] `img-src` — if loading images
-- [ ] All 4 location blocks updated
-
 ### 2. Nginx Proxy Configuration (5+ fix rounds)
-
-**Pattern:** `/p/` and `/api/` proxy to backend. Common mistakes:
 
 | Mistake | Symptom | Fix |
 |---------|---------|-----|
@@ -117,19 +116,31 @@ Change interfaces.go → Update mocks_test.go → Run tests
 
 **Pattern:** All migrations must use `IF NOT EXISTS` / `IF EXISTS` because they may run multiple times (server restarts, CI).
 
-```sql
--- GOOD
-CREATE TABLE IF NOT EXISTS ...
-CREATE INDEX IF NOT EXISTS ...
-ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...
-
--- BAD (will crash on re-run)
-CREATE TABLE ...
-```
-
 ### 6. Stripe Webhook → Event Type Matching
 
 **Pattern:** Stripe API version mismatches cause webhook handler to reject events. Always use `stripe.Event` parsing that tolerates version differences.
+
+### 7. Sale Page Template Co-Change
+
+**Pattern:** `blocks.html`, `simple.html`, and `tracking.html` ALWAYS need the same tracking changes. Forgetting one causes silent rendering or tracking failures.
+
+**Checklist:** When modifying sale page tracking:
+- [ ] `blocks.html` updated
+- [ ] `simple.html` updated
+- [ ] `tracking.html` updated
+- [ ] Changes are identical across all three
+
+### 8. E2E Strict Mode Violations (Duplicate Elements)
+
+**Pattern:** Responsive layouts that show different content on mobile vs desktop create duplicate DOM elements. Playwright's strict mode throws when multiple elements match a selector.
+
+**Fix:** Use `.first()`, `.nth(0)`, or scope locators with parent containers. Better: use unique `data-testid` attributes.
+
+### 9. Login Page Heading Hierarchy
+
+**Pattern:** E2E selectors for headings (`getByRole('heading', { name: ... })`) must match the actual HTML structure. Split-panel layouts with different headings per panel cause selector ambiguity.
+
+**Fix:** Ensure heading text matches what e2e page objects expect, or update page objects to use scoped locators.
 
 ## Hot Files (Change Frequency)
 
@@ -142,11 +153,14 @@ Files that change most often — review these carefully:
 | `types/index.ts` | 19 | Frontend type definitions |
 | `nginx.conf` | 19 | Proxy + CSP headers |
 | `mocks_test.go` | 18 | Test mocks |
+| `sale_page_service.go` | 15 | Sale page business logic |
 | `router.tsx` | 13 | Frontend routing |
 | `Sidebar.tsx` | 12 | Navigation menu |
 | `SalePageEditorPage.tsx` | 12 | Core feature page |
 | `replay_service.go` | 12 | Complex async logic |
 | `event_service.go` | 12 | Event pipeline |
+| `billing/` components | 10 | Billing UI (AccountStatusCard, etc.) |
+| `sale-pages.spec.ts` | 8 | Sale page E2E tests |
 
 ## Iteration Patterns
 

--- a/.claude/skills/e2e-debug/SKILL.md
+++ b/.claude/skills/e2e-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-debug
-description: Debug Playwright E2E test failures in CI — root cause analysis, Zod schema alignment, and dialog timing patterns
+description: Debug Playwright E2E test failures in CI — root cause analysis, strict mode violations, Thai text selectors, and dialog timing patterns (61 tests, 12 page objects)
 ---
 
 # E2E Debug
@@ -12,6 +12,12 @@ Activate this skill when the user says:
 - "Dialog won't close" / "Form not submitting in test"
 - "Playwright timeout" / "Strict mode violation"
 - "Fix flaky test" / "Debug CI failure"
+
+## Test Suite Overview
+
+- **61 tests** across 17 spec files
+- **12 page objects** (login, pixels, sale-pages, billing, admin, etc.)
+- Tests run in CI via GitHub Actions with Playwright
 
 ## Step 1: Read the CI Error
 
@@ -85,16 +91,49 @@ await expect(page.getByText('new value')).toBeVisible()
 - Between sequential dialogs → wait for previous to fully close first
 - After table update → wait for expected content to appear
 
+## Step 4: Wait Strategies for Rapid Operations
+
+For loops that perform rapid deletions or mutations:
+
+```typescript
+// Add small delay between rapid deletion loops
+for (const item of items) {
+  await item.deleteButton.click()
+  await page.waitForTimeout(500)  // Prevent race conditions
+  await confirmButton.click()
+  await expect(item.row).not.toBeVisible()
+}
+```
+
+For post-deploy auth with exponential backoff:
+
+```typescript
+// Auth retry with exponential backoff (3→6→12→24→48s)
+const delays = [3000, 6000, 12000, 24000, 48000]
+for (const delay of delays) {
+  try {
+    await loginAndVerify()
+    break
+  } catch {
+    await page.waitForTimeout(delay)
+  }
+}
+```
+
 ## Quick Reference: Common CI Failures
 
 | Symptom | Root Cause | Fix |
 |---------|-----------|-----|
 | Dialog stays open after submit | Zod validation failure | Fill ALL required schema fields |
 | Element not found after action | Animation/render delay | Add `toBeVisible()` / `not.toBeVisible()` wait |
-| Strict mode violation | Multiple matching elements | Scope locator: `.locator('form').getByRole(...)` |
+| Strict mode violation | Multiple matching elements | Use `.first()` or scope: `.locator('form').getByRole(...)` |
+| Strict mode on responsive layout | Duplicate elements for mobile/desktop | Use `data-testid` or `.first()` for the visible element |
 | Button click has no effect | Element obscured by overlay | Wait for previous dialog/overlay to close first |
 | Test passes locally, fails CI | CI slower than local | Add explicit waits, never rely on implicit timing |
 | Stale data after mutation | TanStack Query cache | Wait for updated content to appear in DOM |
+| Thai text selector fails | Text mismatch | Use exact Thai text: `getByRole('button', { name: 'บันทึก' })` |
+| Toast blocks click | Toast overlay on target | Dismiss toast before next action: `await toast.waitFor({ state: 'hidden' })` |
+| Serial test step fails | Previous step dependency | Use `test.skip()` when prerequisite step failed |
 
 ## Decision Tree
 
@@ -105,10 +144,14 @@ E2E test fails in CI
 │   ├── After clicking submit? → Check Zod schema (Step 2)
 │   └── On open/close? → Add timing waits (Step 3)
 ├── Strict mode violation?
-│   └── Scope locator with parent: .locator('form').getByRole(...)
+│   ├── Duplicate elements in responsive DOM? → Use .first() or data-testid
+│   └── Multiple forms/dialogs? → Scope locator with parent: .locator('form').getByRole(...)
 ├── Element not found?
 │   ├── After dialog close? → Wait for not.toBeVisible() first
-│   └── After navigation? → Wait for new page content
+│   ├── After navigation? → Wait for new page content
+│   └── Thai text mismatch? → Verify exact Thai string in component
+├── Toast blocking interaction?
+│   └── Wait for toast to disappear before next action
 └── Passes locally but fails CI?
     └── Add explicit waits — CI is always slower
 ```
@@ -130,3 +173,4 @@ git push && gh run watch
 
 - `frontend-feature` for creating new pages with testable structure
 - `deploy-check` for pre-deployment verification including E2E
+- `sale-page-editor` for sale page patterns that affect E2E tests

--- a/.claude/skills/event-pipeline/SKILL.md
+++ b/.claude/skills/event-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: event-pipeline
-description: Checklist and pitfalls for the Keep-PX event tracking pipeline — sale page templates, SDK endpoint sync, and Meta CAPI required fields
+description: Checklist and pitfalls for the Keep-PX event tracking pipeline — sale page templates, Meta CAPI forwarding, and template co-change rules
 ---
 
 # Event Pipeline
@@ -9,10 +9,22 @@ description: Checklist and pitfalls for the Keep-PX event tracking pipeline — 
 
 Activate this skill when the user says:
 - "Edit sale page" / "Add field to sale page" / "Change sale page template"
-- "Fix SDK endpoint" / "Events not showing" / "SDK not sending events"
+- "Events not showing" / "Events not appearing"
 - "Send event to Meta" / "Fix CAPI" / "Test pixel connection"
 - "Events not appearing in Meta Events Manager"
 - "Change event tracking" / "Update pixel integration"
+
+## Architecture
+
+```
+Sale page HTML (blocks.html / simple.html)
+    → tracking.html (injected via Go template)
+    → fetch POST /api/v1/events/ingest (API Key auth)
+    → backend event_service.go (store in DB)
+    → go s.forwardToCAPI() (async Meta CAPI forward)
+```
+
+Events flow from sale page templates directly to the backend ingest endpoint. There is no client-side SDK — all tracking is embedded in the sale page HTML templates.
 
 ## Part 1: Sale Page Co-Change Checklist
 
@@ -27,41 +39,18 @@ When modifying the Sale Page feature, a single change typically touches 8-15 fil
 6. `backend/internal/router/router.go` — New routes (if needed)
 7. `backend/internal/templates/sale_pages/blocks.html` — Block template
 8. `backend/internal/templates/sale_pages/simple.html` — Simple template
+9. `backend/internal/templates/sale_pages/tracking.html` — Tracking script (shared)
 
 ### Frontend (change after backend)
-9. `frontend/src/types/index.ts` — TypeScript types (must match domain struct)
-10. `frontend/src/hooks/use-sale-pages.ts` — TanStack Query hooks
-11. `frontend/src/pages/SalePageEditorPage.tsx` — Editor page
-12. `frontend/src/pages/BlockEditorPage.tsx` — Block editor
+10. `frontend/src/types/index.ts` — TypeScript types (must match domain struct)
+11. `frontend/src/hooks/use-sale-pages.ts` — TanStack Query hooks
+12. `frontend/src/pages/SalePageEditorPage.tsx` — Editor page
 13. `frontend/src/components/sale-pages/BlockEditor.tsx` — Block editor component
-14. `frontend/src/components/sale-pages/BlockPreview.tsx` — Block preview
-15. `frontend/src/components/sale-pages/SalePagePreview.tsx` — Page preview
+14. `frontend/src/components/sale-pages/SalePagePreview.tsx` — Page preview
 
-**Critical**: `blocks.html` and `simple.html` ALWAYS need the same changes. Forgetting one causes silent rendering failures.
+**Critical**: `blocks.html`, `simple.html`, and `tracking.html` ALWAYS need the same tracking changes. Forgetting one causes silent rendering or tracking failures.
 
-## Part 2: SDK Endpoint Three-Point Sync
-
-When changing the SDK endpoint, you MUST sync all three locations:
-
-```
-sdk/src/tracker.ts (DEFAULT_ENDPOINT)
-        ↕ must match
-backend/internal/templates/sale_pages/*.html (data-endpoint="...")
-        ↕ must match
-frontend/src/pages/PixelsPage.tsx ("Get Code" snippet)
-```
-
-If any one is out of sync, events silently fail — SDK sends to wrong URL, backend never receives POST, no CAPI forwarding.
-
-### Diagnostic: Events Not Appearing
-1. Check browser Network tab → POST `/api/v1/events/ingest`
-2. POST goes to wrong domain → SDK endpoint misconfigured
-3. No POST at all → `data-endpoint` missing from script tag
-4. Check backend logs for incoming event requests
-
-**Trap**: Browser pixel (fbq) works independently. Pixel Helper shows green, but server-side CAPI path may be broken.
-
-## Part 3: Meta CAPI Required Fields
+## Part 2: Meta CAPI Required Fields
 
 When sending events to Facebook Conversions API, ALL of these fields are required:
 
@@ -99,16 +88,28 @@ EventData{
 2. Response 400 → Missing `user_data` or `event_source_url`
 3. Events with `test_event_code` → only in Test Events tab, not Overview
 
+## Diagnostic: Events Not Appearing
+
+1. Check sale page HTML source → confirm tracking.html is injected
+2. Check browser Network tab → POST `/api/v1/events/ingest`
+3. No POST at all → `tracking.html` not rendering or API key missing
+4. POST returns 4xx → Check API key validity and request body format
+5. Check backend logs for received events and CAPI response
+
+**Trap**: Browser pixel (fbq) works independently. Pixel Helper shows green, but server-side CAPI path may be broken.
+
 ## Verification
 
 After changes to the event pipeline:
-1. Check SDK sends POST to correct backend URL (browser Network tab)
-2. Check backend logs for received events
-3. Check CAPI response status in backend logs (should be 200)
-4. Verify events appear in Meta Events Manager (allow 20 min)
+1. Check sale page renders tracking script (view page source at `/p/<slug>`)
+2. Check browser Network for POST to `/api/v1/events/ingest`
+3. Check backend logs for received events
+4. Check CAPI response status in backend logs (should be 200)
+5. Verify events appear in Meta Events Manager (allow 20 min)
 
 ## Related
 
+- `sale-page-editor` for sale page CRUD and template patterns
 - `go-service-scaffold` for creating new backend resources
 - `api-endpoint` for adding new endpoints
 - `deploy-check` for pre-deployment verification

--- a/.claude/skills/nginx-csp/SKILL.md
+++ b/.claude/skills/nginx-csp/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: nginx-csp
+description: Nginx CSP header management, security headers, and envsubst variable checklist for Keep-PX frontend deployment
+---
+
+# Nginx CSP
+
+## When to Activate
+
+Activate this skill when the user says:
+- "CSP error" / "Content Security Policy" / "blocked by CSP"
+- "Add external script/style/font/image" / "Add Google/Stripe/Facebook domain"
+- "Nginx config" / "Security headers"
+- "Image not loading" / "Script blocked" / "Font not loading"
+- "Google login broken in production" / "Stripe not loading"
+- "envsubst" / "nginx won't start" / "undefined variable in nginx"
+
+## Architecture
+
+Keep-PX nginx.conf has **4 location blocks** with separate CSP policies:
+
+```
+server {
+    # Global security headers (COOP, X-Frame-Options, etc.)
+
+    location /assets/ {
+        # Dashboard CSP (same as root)
+    }
+
+    location /p/ {
+        # Sale Pages CSP (more permissive img-src)
+        proxy_pass to backend
+    }
+
+    location / {
+        # Dashboard CSP
+        try_files SPA fallback
+    }
+}
+```
+
+**Critical**: Nginx does NOT inherit `add_header` into nested locations. Each location must redeclare ALL headers.
+
+## Current CSP Directives (Dashboard)
+
+```nginx
+add_header Content-Security-Policy "
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' js.stripe.com connect.facebook.net accounts.google.com;
+  style-src 'self' 'unsafe-inline' fonts.googleapis.com accounts.google.com;
+  connect-src 'self' ${BACKEND_URL} accounts.google.com js.stripe.com;
+  frame-src js.stripe.com accounts.google.com;
+  img-src 'self' data: *.googleusercontent.com *.r2.dev;
+  font-src 'self' data: fonts.gstatic.com;
+" always;
+```
+
+## Current CSP Directives (Sale Pages)
+
+```nginx
+add_header Content-Security-Policy "
+  default-src 'self';
+  script-src 'self' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+  connect-src 'self';
+  img-src * data:;
+  font-src 'self' data: fonts.gstatic.com;
+" always;
+```
+
+## Domain-to-Directive Reference
+
+When adding an external service, add its domains to the correct CSP directives:
+
+### Google Sign-In (accounts.google.com)
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| script-src | accounts.google.com | GSI JavaScript library |
+| style-src | accounts.google.com | GSI injects stylesheet |
+| connect-src | accounts.google.com | Token exchange XHR |
+| frame-src | accounts.google.com | Popup window/iframe |
+
+### Google Fonts
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| style-src | fonts.googleapis.com | CSS font-face declarations |
+| font-src | fonts.gstatic.com | Actual font files (.woff2) |
+
+### Stripe
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| script-src | js.stripe.com | Stripe.js SDK |
+| connect-src | js.stripe.com | Payment API calls |
+| frame-src | js.stripe.com | Checkout iframe |
+
+### Facebook Pixel
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| script-src | connect.facebook.net | fbevents.js SDK |
+
+### Cloudflare R2 (Image Storage)
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| img-src | *.r2.dev | Uploaded images from R2 bucket |
+
+### Backend API
+| Directive | Domain | Why |
+|-----------|--------|-----|
+| connect-src | ${BACKEND_URL} | API calls from different subdomain in production |
+
+## Checklist: Adding External Resource
+
+Before adding any external script, stylesheet, font, image, or API call:
+
+- [ ] Identify ALL resource types the service loads (script, style, font, image, XHR, iframe)
+- [ ] Add each domain to the correct CSP directive
+- [ ] Update ALL 3 dashboard CSP locations (server-level /assets/, root /)
+- [ ] If sale pages need it too, update the /p/ location CSP separately
+- [ ] If using envsubst variable, verify it exists in Railway environment
+- [ ] Test in production URL (not localhost — 'self' resolves differently)
+- [ ] Check browser DevTools Console for CSP violation errors
+
+## Checklist: Security Headers Sync
+
+When modifying any `add_header` in nginx.conf, update ALL locations:
+
+- [ ] Server-level block (before first location)
+- [ ] `location /assets/` block
+- [ ] `location /` block (root/SPA)
+- [ ] `location /p/` block (sale pages — may have different CSP)
+
+Headers that MUST be in all locations:
+```nginx
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+```
+
+**COOP Header**: `same-origin-allow-popups` is REQUIRED for Google Sign-In popup to postMessage back to the parent window. Do NOT change this to `same-origin`.
+
+## Environment Variables
+
+| Variable | Used In | Set By |
+|----------|---------|--------|
+| `${BACKEND_URL}` | connect-src | Railway env var (required) |
+
+**Rules:**
+- Only use envsubst variables that are GUARANTEED to exist in Railway
+- Prefer wildcards (`*.r2.dev`) over variables for static domain lists
+- Never add `${VAR}` to nginx.conf without verifying it's in Railway environment
+- Undefined variables cause nginx startup failure (envsubst leaves literal `${VAR}`)
+
+## Common Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Missing domain in one directive | Script loads but XHR blocked | Check ALL resource types the service uses |
+| Header not in nested location | Works on `/` but not `/assets/` | Redeclare headers in every location block |
+| Undefined envsubst variable | Nginx container crash loop | Only use vars defined in Railway env |
+| COOP header missing | Google Sign-In popup fails silently | Add `same-origin-allow-popups` to all locations |
+| 'self' mismatch in production | API calls blocked | Add `${BACKEND_URL}` to connect-src (different subdomain) |
+| Wildcard in wrong directive | Security gap | Use wildcards only in img-src, never in script-src |
+| Build-time vs runtime var | VITE_* not resolved | VITE_* = Docker build ARGs, BACKEND_URL = runtime envsubst |
+| R2 CDN wildcard scope | Images blocked elsewhere | `*.r2.dev` only valid in `img-src`, not `connect-src` |
+| COOP `same-origin` | Google Sign-In popup broken | Must be `same-origin-allow-popups` (Google needs postMessage) |
+
+## Sale Page CSP Note
+
+The `/p/` location intentionally does NOT include `X-Frame-Options: DENY` — this allows sale pages to be embedded in iframes on customer sites. The sale page CSP is more permissive on `img-src` (allows `*`) to support user-uploaded images from any source.
+
+## Verification Tips
+
+After deploy, check **Response** headers (not Request headers) in browser DevTools Network tab. Common mistake: checking Request headers which don't show server-set CSP.
+
+## Diagnostic: CSP Violation
+
+1. Open browser DevTools → Console tab
+2. Look for `Refused to load/execute...violates CSP directive`
+3. The error tells you exactly which directive and domain are missing
+4. Add the domain to the correct directive in ALL location blocks
+5. Rebuild and redeploy frontend
+
+## Verification
+
+After modifying nginx.conf:
+```bash
+# Check syntax locally (if nginx installed)
+nginx -t -c frontend/nginx.conf
+
+# Check no undefined envsubst variables
+grep -oP '\$\{[^}]+\}' frontend/nginx.conf | sort -u
+# Every variable listed must exist in Railway env
+
+# After deploy, check headers
+curl -sI https://your-domain.com | grep -i "content-security-policy\|cross-origin"
+```
+
+## Related
+
+- `railway-deploy` for nginx proxy patterns and deployment
+- `deploy-check` for pre-deployment verification
+- Built-in `security-review` for comprehensive security analysis

--- a/.claude/skills/sale-page-editor/SKILL.md
+++ b/.claude/skills/sale-page-editor/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: sale-page-editor
+description: Sale page CRUD, block editor, template rendering, pixel assignment patterns, and co-change checklist for Keep-PX
+---
+
+# Sale Page Editor
+
+## When to Activate
+
+Activate this skill when the user says:
+- "Create/edit/delete sale page"
+- "Add block type" / "New template"
+- "Sale page preview" / "Sale page not rendering"
+- "Assign pixel to sale page" / "Multi-pixel sale page"
+- "Slug collision" / "Sale page URL"
+- "Block editor" / "Content version"
+
+## Part 1: Architecture Overview
+
+```
+Frontend Editor (SalePageEditorPage.tsx)
+    → API: POST/PUT /api/v1/sale-pages
+    → Backend: sale_page_service.go (validates, generates slug)
+    → DB: sale_pages + sale_page_pixels (M:M join)
+    → Public: GET /p/:slug → sale_page_handler.go renders HTML template
+    → Template: blocks.html or simple.html + tracking.html injection
+```
+
+### Content Versions
+- **V1 (SimpleContent)**: Single-section page with title, description, image, CTA button
+- **V2 (BlocksContent)**: Multi-block page with ordered blocks (hero, text, image, cta, etc.)
+
+Content version is stored in `content_version` column. Handler peeks at the struct to determine which template to render. Falls back to `simple.html` with a warning log if version detection fails.
+
+### Template Map
+| Template | Purpose | File |
+|----------|---------|------|
+| `simple.html` | V1 simple pages | `backend/internal/templates/sale_pages/simple.html` |
+| `blocks.html` | V2 block-based pages | `backend/internal/templates/sale_pages/blocks.html` |
+| `tracking.html` | Shared pixel tracking script | `backend/internal/templates/sale_pages/tracking.html` |
+
+## Part 2: Co-Change Checklist
+
+When modifying the Sale Page feature, update all layers in order:
+
+### Backend (7 files)
+1. `backend/internal/domain/sale_page.go` — Domain struct, content types, validation
+2. `backend/internal/repository/postgres/sale_page_repo.go` — SQL queries
+3. `backend/internal/service/sale_page_service.go` — Business logic, slug generation
+4. `backend/internal/handler/sale_page_handler.go` — HTTP handler, template rendering
+5. `backend/internal/templates/sale_pages/blocks.html` — Block template
+6. `backend/internal/templates/sale_pages/simple.html` — Simple template
+7. `backend/internal/templates/sale_pages/tracking.html` — Tracking script
+
+### Frontend (5 files)
+8. `frontend/src/types/index.ts` — TypeScript types (must match domain struct)
+9. `frontend/src/hooks/use-sale-pages.ts` — TanStack Query hooks
+10. `frontend/src/components/sale-pages/BlockEditor.tsx` — Block editor component
+11. `frontend/src/components/sale-pages/SalePagePreview.tsx` — Page preview
+12. `frontend/src/pages/SalePageEditorPage.tsx` — Editor page
+
+**Rule**: `blocks.html` + `simple.html` + `tracking.html` ALWAYS change together when modifying tracking behavior.
+
+## Part 3: Key Patterns
+
+### Slug Generation
+```go
+// p-XXXXXXXX format with retry loop (5 attempts)
+func generateSlug() string {
+    return fmt.Sprintf("p-%s", randomHex(4)) // e.g., p-a1b2c3d4
+}
+```
+Service retries slug generation up to 5 times if uniqueness check fails (DB unique constraint on `slug`).
+
+### Pixel Ownership Validation
+```go
+// validatePixelOwnership checks ALL pixel_ids belong to the customer
+func (s *SalePageService) validatePixelOwnership(ctx, customerID, pixelIDs) error
+```
+Every pixel ID in the request must be owned by the requesting customer. This runs before any create/update operation that assigns pixels.
+
+### Transaction-Based Pixel Assignment
+```go
+// setPixels uses delete-all-then-reinsert within a transaction
+func (r *SalePageRepo) SetPixels(ctx, tx, salePageID, pixelIDs) error {
+    // DELETE FROM sale_page_pixels WHERE sale_page_id = $1
+    // INSERT INTO sale_page_pixels (sale_page_id, pixel_id, position) VALUES ...
+}
+```
+Position ordering is maintained — the order of `pixel_ids` in the request determines the `position` column value.
+
+### Cache Invalidation on Slug Rename
+When a sale page slug changes (update operation), both the old and new slugs must be invalidated:
+```go
+// Invalidate old slug cache entry
+// Invalidate new slug cache entry
+// This prevents stale cached pages from being served
+```
+
+### Content Version Detection
+Handler peeks at the content JSON to determine which template to use:
+```go
+// If content has "blocks" key → use blocks.html (V2)
+// Otherwise → use simple.html (V1)
+// Fallback: simple.html with warning log
+```
+
+## Part 4: Common Pitfalls
+
+1. **Template tracking sync**: `blocks.html` and `simple.html` must inject `tracking.html` identically. Forgetting one template means events are silently lost for pages using that template.
+
+2. **Pixel ownership validation**: MUST validate every `pixel_id` before saving. Skipping this allows users to attach other customers' pixels to their pages.
+
+3. **Slug validation**: Reserved words list + regex validation + DB uniqueness check. Slugs must be URL-safe and not conflict with route prefixes (`api`, `assets`, `auth`, etc.).
+
+4. **Cache invalidation on rename**: When slug changes, invalidate BOTH old slug and new slug. Missing old slug invalidation = stale page served. Missing new slug = 404 until cache expires.
+
+5. **Content version mismatch**: If handler can't detect content version, it falls back to `simple.html` and logs a warning. This is intentional — never crash on unknown content.
+
+6. **sale_page_pixels join table ordering**: The `position` column determines pixel order. Reordering pixels requires delete-all + re-insert (not individual updates).
+
+7. **Draft auto-save**: Frontend uses localStorage + debounce for unsaved changes. `useBlocker` hook warns users before navigating away from unsaved edits.
+
+## Part 5: Adding a New Block Type
+
+1. **Domain**: Add new block type constant in `domain/sale_page.go`
+2. **Validation**: Add validation rules for the new block type
+3. **Template**: Add `{{if eq .Type "new_type"}}` section in `blocks.html`
+4. **Frontend BlockEditor**: Add new block component in `BlockEditor.tsx`
+5. **Frontend Preview**: Add rendering logic in `SalePagePreview.tsx`
+
+## Part 6: Adding a New Template
+
+1. **HTML file**: Create `backend/internal/templates/sale_pages/new_template.html`
+2. **Handler**: Register template in the handler's template map
+3. **Validation**: Add `new_template` to allowed `template_name` values in service layer
+4. **Frontend**: Add template option to the editor's template selector
+5. **Tracking**: Include `tracking.html` injection in the new template
+
+## Verification
+
+After sale page changes:
+```bash
+cd backend && go vet ./... && go test -race ./...
+cd frontend && npm run lint && npm run build
+cd frontend && npx playwright test sale-pages.spec.ts
+```
+
+Check public page renders correctly:
+```bash
+curl -s http://localhost:8080/p/<slug> | head -50
+```
+
+## Related
+
+- `event-pipeline` for tracking script and CAPI integration
+- `db-migration` for schema changes to sale_pages/sale_page_pixels
+- `e2e-debug` for debugging sale-pages.spec.ts failures
+- `deploy-check` for pre-deployment verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Tell the user: what was done, PR link, deploy status, any follow-up needed.
 |-------|------|-------|
 | Entry | `cmd/server/main.go` | Config, pgxpool, router, graceful shutdown |
 | Config | `internal/config/` | `caarlos0/env`, loads `.env` via godotenv |
-| Domain | `internal/domain/` | Pure structs (Customer, Pixel, PixelEvent, ReplaySession) |
+| Domain | `internal/domain/` | Pure structs (Customer, Pixel, PixelEvent, SalePage, ReplaySession, Notification, Subscription, Purchase, ReplayCredit) |
 | Repository | `internal/repository/` | Interfaces in `interfaces.go`, pgx implementations in `postgres/` |
 | Service | `internal/service/` | Business logic, sentinel errors for handler error mapping |
 | Handler | `internal/handler/` | `go-playground/validator`, `handler.JSON()`/`handler.ErrorJSON()` |
@@ -94,32 +94,45 @@ Tell the user: what was done, PR link, deploy status, any follow-up needed.
 | CAPI | `internal/facebook/capi.go` | Facebook Conversions API client |
 
 ### Key Patterns
-- **Auth**: JWT (dashboard, `middleware.GetCustomerID(ctx)`) + API Key (sale pages, `X-API-Key`)
+- **Auth**: Google OAuth + JWT (dashboard, `middleware.GetCustomerID(ctx)`) + API Key (sale pages, `X-API-Key`)
 - **Ownership**: Services check `pixel.CustomerID == customerID` before operations
 - **CAPI**: Async forwarding via `go s.forwardToCAPI(...)`
 - **Replay**: Background goroutine, semaphore (5 workers), ~50 events/sec rate limit
+- **Billing**: Stripe checkout sessions → webhook → replay credits (pack system)
+- **Admin**: `is_admin` flag on customers table, admin middleware, audit logging
 - **Repository nil**: `GetByID` returns `(nil, nil)` when not found — callers check for nil
 
 ### Frontend
 - **State**: Zustand (auth) + TanStack Query (server)
-- **Routing**: react-router v7, `ProtectedRoute` wrapper
-- **API**: Axios with auto token refresh (`src/lib/api.ts`), `@/` = `src/`
+- **Routing**: react-router v7, `ProtectedRoute` wrapper, lazy-loaded admin routes
+- **API**: Axios with auto token refresh + mutex (`src/lib/api.ts`), `@/` = `src/`
 - **UI**: shadcn/ui in `src/components/ui/`, Vite proxy `/api` → `:8080`
+- **Admin**: Separate admin pages under `/admin/*`, requires `is_admin` flag
 
 ## API Routes
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| POST | `/api/v1/auth/register\|login\|refresh` | Public | Auth endpoints |
+| POST | `/api/v1/auth/google` | Public | Google OAuth login |
+| POST | `/api/v1/auth/refresh` | Public | Token refresh |
+| POST | `/api/v1/auth/logout` | JWT | Logout (revoke refresh token) |
 | POST | `/api/v1/events/ingest` | API Key | Batch event ingestion |
-| CRUD | `/api/v1/pixels/*` | JWT | Pixel management |
+| CRUD | `/api/v1/pixels/*` | JWT | Pixel management + test connection |
 | GET | `/api/v1/events` | JWT | Event log (paginated) |
+| CRUD | `/api/v1/sale-pages/*` | JWT | Sale page CRUD + pixel assignment |
+| GET | `/p/:slug` | Public | Public sale page rendering |
 | POST/GET | `/api/v1/replays/*` | JWT | Replay sessions |
 | GET | `/api/v1/analytics/*` | JWT | Dashboard analytics |
+| POST | `/api/v1/billing/checkout` | JWT | Stripe checkout session |
+| GET | `/api/v1/billing/status` | JWT | Billing status + credits |
+| POST | `/api/v1/billing/webhook` | Stripe sig | Stripe webhook handler |
+| GET | `/api/v1/notifications` | JWT | User notifications |
+| GET/PUT | `/api/v1/settings/*` | JWT | User settings + API key |
+| GET/PUT/POST | `/api/v1/admin/*` | JWT+Admin | Admin panel endpoints |
 
 ## Reference
 
-- **Database**: PostgreSQL on Neon. Tables: `customers`, `pixels`, `pixel_events`, `replay_sessions`, `refresh_tokens`. UUIDs, `TIMESTAMPTZ`.
+- **Database**: PostgreSQL on Neon. 16 active tables: `customers`, `pixels`, `pixel_events`, `event_rules`, `replay_sessions`, `refresh_tokens`, `sale_pages`, `sale_page_pixels`, `notifications`, `purchases`, `replay_credits`, `subscriptions`, `event_usage`, `stripe_webhook_events`, `admin_credit_grants`, `admin_audit_logs`. UUIDs, `TIMESTAMPTZ`. 24 migrations.
 - **Deploy**: Railway — Backend (Go/Alpine Dockerfile) + Frontend (Node→Nginx Dockerfile, needs `VITE_API_URL` build arg).
 - **Backend env** (`backend/.env.example`): `DATABASE_URL`, `JWT_SECRET` (required), `PORT`, `ENV`, `JWT_ACCESS_TTL`, `JWT_REFRESH_TTL`, `FB_GRAPH_API_URL`, `CORS_ALLOWED_ORIGINS`, `RATE_LIMIT_RPS`
 - **Frontend env**: `VITE_API_URL` (empty = Vite proxy)


### PR DESCRIPTION
## Summary
- Update 6 outdated skills: remove SDK references, add new failure patterns, update schema/stats
- Create new `sale-page-editor` skill with architecture, co-change checklist, and pitfalls
- Modernize root CLAUDE.md: API routes (6→16), domain structs, Google OAuth, billing, admin, database tables (5→16)
- Remove 33 empty subdirectory CLAUDE.md files (claude-mem context only, no instructions)

## Changes

| Skill | Change |
|-------|--------|
| deploy-check | Remove SDK build step, SDK grep path, SDK summary row |
| event-pipeline | Rewrite: remove SDK sync, add CAPI-only architecture diagram |
| dev-workflow | v1.2.0: 166 commits, sale page co-change group, pitfalls 7-9 |
| e2e-debug | Add strict mode, Thai text, toast, serial patterns (61 tests) |
| db-migration | Schema reference: 7 tables → 16 tables (24 migrations) |
| nginx-csp | Add build-time vs runtime vars, R2 scope, COOP pitfalls |
| sale-page-editor | **New**: architecture, co-change checklist, key patterns |
| CLAUDE.md | Update all outdated sections to match current codebase |

## Test plan
- [x] No SDK references remain in updated skills
- [x] No "3 packages" or "tracker.ts" references
- [x] Table list matches actual migrations
- [x] Sale-page-editor covers all co-change files

🤖 Generated with [Claude Code](https://claude.com/claude-code)