### PR TITLE
fix: audit sprint 1 — security hardening and input validation

### DIFF
--- a/backend/internal/facebook/capi.go
+++ b/backend/internal/facebook/capi.go
@@ -90,7 +90,7 @@ func (c *CAPIClient) SendEvents(ctx context.Context, pixelID, accessToken, testE
 	if resp.StatusCode != http.StatusOK {
 		return nil, &CAPIError{
 			StatusCode: resp.StatusCode,
-			Message:    string(respBody),
+			Message:    parseFBErrorMessage(respBody),
 		}
 	}
 
@@ -118,6 +118,35 @@ func IsRateLimitError(err error) bool {
 		return capiErr.StatusCode == 429
 	}
 	return false
+}
+
+// parseFBErrorMessage extracts a sanitized error message from a Facebook API
+// error response. It parses the structured JSON to avoid leaking raw API internals
+// to client-facing surfaces. The raw (truncated) body may still appear in server logs.
+func parseFBErrorMessage(body []byte) string {
+	var fbErr struct {
+		Error struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &fbErr); err == nil && fbErr.Error.Message != "" {
+		msg := fmt.Sprintf("[%d] %s", fbErr.Error.Code, fbErr.Error.Message)
+		return truncateUTF8(msg, 500)
+	}
+	// Fallback: truncate raw body if JSON parsing fails
+	return truncateUTF8(string(body), 500)
+}
+
+// truncateUTF8 truncates a string to at most maxRunes runes, avoiding splitting
+// multi-byte UTF-8 characters.
+func truncateUTF8(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes])
 }
 
 func (c *CAPIClient) SendEvent(ctx context.Context, pixelID, accessToken, testEventCode string, event CAPIEvent) (*CAPIResponse, error) {

--- a/backend/internal/handler/admin_handler.go
+++ b/backend/internal/handler/admin_handler.go
@@ -34,7 +34,7 @@ func (h *AdminHandler) ListCustomers(w http.ResponseWriter, r *http.Request) {
 	plan := r.URL.Query().Get("plan")
 	status := r.URL.Query().Get("status")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	customers, total, err := h.adminService.ListCustomers(r.Context(), search, plan, status, page, perPage)
 	if err != nil {
@@ -215,7 +215,7 @@ func (h *AdminHandler) GetGrowthChart(w http.ResponseWriter, r *http.Request) {
 func (h *AdminHandler) ListPurchases(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	purchases, total, err := h.adminService.ListAllPurchases(r.Context(), status, page, perPage)
 	if err != nil {
@@ -240,7 +240,7 @@ func (h *AdminHandler) ListPurchases(w http.ResponseWriter, r *http.Request) {
 func (h *AdminHandler) ListSubscriptions(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	subs, total, err := h.adminService.ListAllSubscriptions(r.Context(), status, page, perPage)
 	if err != nil {
@@ -264,7 +264,7 @@ func (h *AdminHandler) ListSubscriptions(w http.ResponseWriter, r *http.Request)
 
 func (h *AdminHandler) ListCreditGrants(w http.ResponseWriter, r *http.Request) {
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	grants, total, err := h.adminService.ListCreditGrants(r.Context(), page, perPage)
 	if err != nil {
@@ -298,6 +298,15 @@ func queryInt(r *http.Request, key string, defaultVal int) int {
 	return i
 }
 
+// queryPerPage returns a clamped per_page value (1-100, default 20).
+func queryPerPage(r *http.Request) int {
+	perPage := queryInt(r, "per_page", 20)
+	if perPage > 100 {
+		perPage = 100
+	}
+	return perPage
+}
+
 func queryBool(r *http.Request, key string) *bool {
 	v := r.URL.Query().Get(key)
 	if v == "" {
@@ -328,7 +337,7 @@ func (h *AdminHandler) ListSalePages(w http.ResponseWriter, r *http.Request) {
 	customerID := r.URL.Query().Get("customer_id")
 	published := queryBool(r, "published")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	pages, total, err := h.adminService.ListAllSalePages(r.Context(), search, customerID, published, page, perPage)
 	if err != nil {
@@ -410,7 +419,7 @@ func (h *AdminHandler) ListPixels(w http.ResponseWriter, r *http.Request) {
 	customerID := r.URL.Query().Get("customer_id")
 	active := queryBool(r, "active")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	pixels, total, err := h.adminService.ListAllPixels(r.Context(), search, customerID, active, page, perPage)
 	if err != nil {
@@ -475,7 +484,7 @@ func (h *AdminHandler) ListReplays(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	customerID := r.URL.Query().Get("customer_id")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	sessions, total, err := h.adminService.ListAllReplaySessions(r.Context(), status, customerID, page, perPage)
 	if err != nil {
@@ -525,7 +534,7 @@ func (h *AdminHandler) ListEvents(w http.ResponseWriter, r *http.Request) {
 	pixelID := r.URL.Query().Get("pixel_id")
 	eventName := r.URL.Query().Get("event_name")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	events, total, err := h.adminService.ListAllEvents(r.Context(), customerID, pixelID, eventName, page, perPage)
 	if err != nil {
@@ -555,7 +564,7 @@ func (h *AdminHandler) ListAuditLog(w http.ResponseWriter, r *http.Request) {
 	action := r.URL.Query().Get("action")
 	targetCustomerID := r.URL.Query().Get("target_customer_id")
 	page := queryInt(r, "page", 1)
-	perPage := queryInt(r, "per_page", 20)
+	perPage := queryPerPage(r)
 
 	var from, to *time.Time
 	if v := r.URL.Query().Get("from"); v != "" {

--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -192,6 +192,11 @@ func (h *EventHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	eventID := chi.URLParam(r, "id")
 
+	if _, err := uuid.Parse(eventID); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "id must be a valid UUID")
+		return
+	}
+
 	event, err := h.eventService.GetByID(r.Context(), customerID, eventID)
 	if err != nil {
 		ErrorJSONWithLog(w, r, h.logger, http.StatusInternalServerError, "failed to get event", err)

--- a/backend/internal/handler/event_ingest_handler_test.go
+++ b/backend/internal/handler/event_ingest_handler_test.go
@@ -369,18 +369,33 @@ func TestEventHandler_GetByID(t *testing.T) {
 		assert.Equal(t, eventID, data["id"])
 	})
 
+	t.Run("invalid UUID returns 400", func(t *testing.T) {
+		eventRepo := &MockEventRepo{}
+		pixelRepo := &MockPixelRepo{}
+		eventSvc := newTestEventService(eventRepo, pixelRepo, nil)
+		h := NewEventHandler(eventSvc, testLogger())
+
+		r := eventRouter(h)
+		token := eventToken(eventTestCustomerID)
+
+		rr := doRequest(r, "GET", "/events/nonexistent", nil, token)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
 	t.Run("not found returns 404", func(t *testing.T) {
 		eventRepo := &MockEventRepo{}
 		pixelRepo := &MockPixelRepo{}
 		eventSvc := newTestEventService(eventRepo, pixelRepo, nil)
 		h := NewEventHandler(eventSvc, testLogger())
 
-		eventRepo.On("GetByID", mock.Anything, "nonexistent").Return(nil, nil)
+		missingID := uuid.New().String()
+		eventRepo.On("GetByID", mock.Anything, missingID).Return(nil, nil)
 
 		r := eventRouter(h)
 		token := eventToken(eventTestCustomerID)
 
-		rr := doRequest(r, "GET", "/events/nonexistent", nil, token)
+		rr := doRequest(r, "GET", "/events/"+missingID, nil, token)
 
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})

--- a/backend/internal/handler/pixel_handler.go
+++ b/backend/internal/handler/pixel_handler.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
@@ -99,7 +101,22 @@ func (h *PixelHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	JSON(w, http.StatusCreated, APIResponse{Data: pixel})
+
+	// Best-effort CAPI token validation — warn if token appears invalid.
+	// Bounded to 5s so a slow Facebook API doesn't block the response.
+	var warning string
+	if pixel.ID != "" {
+		testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, testErr := h.pixelService.TestConnection(testCtx, customerID, pixel.ID); testErr != nil {
+			if !errors.Is(testErr, service.ErrCAPINotConfigured) {
+				warning = "Pixel created successfully, but CAPI connection test failed. Please verify your access token."
+				h.logger.Warn("pixel created with failing CAPI token", "pixel_id", pixel.ID, "error", testErr)
+			}
+		}
+	}
+
+	JSON(w, http.StatusCreated, APIResponse{Data: pixel, Warning: warning})
 }
 
 func (h *PixelHandler) Update(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/response.go
+++ b/backend/internal/handler/response.go
@@ -12,6 +12,7 @@ type APIResponse struct {
 	Data    interface{} `json:"data,omitempty"`
 	Error   string      `json:"error,omitempty"`
 	Message string      `json:"message,omitempty"`
+	Warning string      `json:"warning,omitempty"`
 }
 
 type PaginatedResponse struct {

--- a/backend/internal/handler/sale_page_handler.go
+++ b/backend/internal/handler/sale_page_handler.go
@@ -9,12 +9,14 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/middleware"
@@ -27,7 +29,10 @@ const (
 	tmplBlocks = "blocks"
 )
 
-var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+var (
+	bufPool       = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+	cssHexColorRe = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+)
 
 type SalePageHandler struct {
 	salePageService *service.SalePageService
@@ -55,6 +60,22 @@ func NewSalePageHandler(salePageService *service.SalePageService, baseURL string
 		},
 		"hasPixels": func(pixels []service.PixelPublishInfo) bool {
 			return len(pixels) > 0
+		},
+		// safeColor validates a CSS hex color at render time (defense-in-depth).
+		// Returns the color if valid, otherwise the fallback default.
+		"safeColor": func(color, fallback string) string {
+			if color != "" && cssHexColorRe.MatchString(color) {
+				return color
+			}
+			return fallback
+		},
+		// safeBgImageURL validates a background image URL for CSS url() context.
+		// Only allows https:// URLs to prevent CSS injection via url() breakout.
+		"safeBgImageURL": func(u string) string {
+			if strings.HasPrefix(u, "https://") && !strings.ContainsAny(u, "(){};<>\"'") {
+				return u
+			}
+			return ""
 		},
 	}
 
@@ -166,6 +187,11 @@ func (h *SalePageHandler) Update(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pageID := chi.URLParam(r, "id")
 
+	if _, err := uuid.Parse(pageID); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "id must be a valid UUID")
+		return
+	}
+
 	var input service.UpdateSalePageInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		ErrorJSON(w, http.StatusBadRequest, "invalid request body")
@@ -212,6 +238,11 @@ func (h *SalePageHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pageID := chi.URLParam(r, "id")
 
+	if _, err := uuid.Parse(pageID); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "id must be a valid UUID")
+		return
+	}
+
 	err := h.salePageService.Delete(r.Context(), customerID, pageID)
 	if err != nil {
 		if errors.Is(err, service.ErrSalePageNotFound) {
@@ -252,6 +283,11 @@ func (h *SalePageHandler) Serve(w http.ResponseWriter, r *http.Request) {
 func (h *SalePageHandler) Preview(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pageID := chi.URLParam(r, "id")
+
+	if _, err := uuid.Parse(pageID); err != nil {
+		ErrorJSON(w, http.StatusBadRequest, "id must be a valid UUID")
+		return
+	}
 
 	page, err := h.salePageService.GetByID(r.Context(), customerID, pageID)
 	if err != nil {

--- a/backend/internal/handler/sale_page_handler_test.go
+++ b/backend/internal/handler/sale_page_handler_test.go
@@ -262,7 +262,7 @@ func TestSalePageHandler_Update(t *testing.T) {
 	t.Run("not found returns 404", func(t *testing.T) {
 		env := setupSalePageTest(t)
 		customerID := testCustomerID
-		pageID := "sp-nonexistent"
+		pageID := "a0000000-0000-0000-0000-000000000099"
 		token := testJWT(customerID, false)
 
 		env.salePageRepo.On("GetByID", mock.Anything, pageID).Return((*domain.SalePage)(nil), nil)
@@ -342,7 +342,7 @@ func TestSalePageHandler_Delete(t *testing.T) {
 	t.Run("not found returns 404", func(t *testing.T) {
 		env := setupSalePageTest(t)
 		customerID := testCustomerID
-		pageID := "sp-nonexistent"
+		pageID := "a0000000-0000-0000-0000-000000000099"
 		token := testJWT(customerID, false)
 
 		env.salePageRepo.On("GetByID", mock.Anything, pageID).Return((*domain.SalePage)(nil), nil)

--- a/backend/internal/handler/testhelpers_test.go
+++ b/backend/internal/handler/testhelpers_test.go
@@ -22,7 +22,7 @@ const (
 	testCustomerID   = "cust-1"
 	testPixelID      = "px-1"
 	testPixelMissing = "px-nonexistent"
-	testSalePageID   = "sp-1"
+	testSalePageID   = "a0000000-0000-0000-0000-000000000001"
 )
 
 // testJWT generates a valid JWT token for testing with the given customerID and admin flag.

--- a/backend/internal/service/pixel_service.go
+++ b/backend/internal/service/pixel_service.go
@@ -24,6 +24,7 @@ var (
 	ErrBackupPixelNotFound  = errors.New("backup pixel not found")
 	ErrBackupPixelNotOwned  = errors.New("backup pixel not owned by customer")
 	ErrInvalidFBPixelID     = errors.New("invalid Facebook Pixel ID format: must be 15-16 digits")
+	ErrCAPINotConfigured    = errors.New("CAPI client not configured")
 )
 
 type PixelService struct {
@@ -220,6 +221,10 @@ func (s *PixelService) TestConnection(ctx context.Context, customerID, pixelID s
 
 	if pixel.FBAccessToken == "" {
 		return nil, ErrPixelNoAccessToken
+	}
+
+	if s.capiClient == nil {
+		return nil, ErrCAPINotConfigured
 	}
 
 	event := facebook.CAPIEvent{

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -15,9 +15,9 @@
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;600;700&display=swap"></noscript>
     <style>
         :root {
-            --bg-color: {{if .Style.BgColor}}{{.Style.BgColor}}{{else}}#f8f9fa{{end}};
-            --accent-color: {{if .Style.AccentColor}}{{.Style.AccentColor}}{{else}}#4f46e5{{end}};
-            --text-color: {{if .Style.TextColor}}{{.Style.TextColor}}{{else}}#1a1a2e{{end}};
+            --bg-color: {{safeColor .Style.BgColor "#f8f9fa"}};
+            --accent-color: {{safeColor .Style.AccentColor "#4f46e5"}};
+            --text-color: {{safeColor .Style.TextColor "#1a1a2e"}};
         }
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
         body {
@@ -27,7 +27,7 @@
             background: var(--bg-color);
             min-height: 100vh;
             {{if .Style.BgImageURL}}
-            background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.45)), url({{.Style.BgImageURL}});
+            background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.45)), url({{safeBgImageURL .Style.BgImageURL}});
             background-size: cover;
             background-position: center;
             background-attachment: scroll;

--- a/backend/internal/templates/sale_pages/simple.html
+++ b/backend/internal/templates/sale_pages/simple.html
@@ -12,10 +12,10 @@
     <meta property="og:url" content="{{.BaseURL}}/p/{{.Page.Slug}}">
     <style>
         :root {
-            --bg-color: {{if .Style.BgColor}}{{.Style.BgColor}}{{else}}#f8f9fa{{end}};
-            --accent-color: {{if .Style.AccentColor}}{{.Style.AccentColor}}{{else}}#667eea{{end}};
-            --accent-color2: {{if .Style.AccentColor}}{{.Style.AccentColor}}{{else}}#764ba2{{end}};
-            --text-color: {{if .Style.TextColor}}{{.Style.TextColor}}{{else}}#1a1a2e{{end}};
+            --bg-color: {{safeColor .Style.BgColor "#f8f9fa"}};
+            --accent-color: {{safeColor .Style.AccentColor "#667eea"}};
+            --accent-color2: {{safeColor .Style.AccentColor "#764ba2"}};
+            --text-color: {{safeColor .Style.TextColor "#1a1a2e"}};
         }
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
         body {
@@ -25,7 +25,7 @@
             background: var(--bg-color);
             min-height: 100vh;
             {{if .Style.BgImageURL}}
-            background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.45)), url({{.Style.BgImageURL}});
+            background-image: linear-gradient(rgba(0,0,0,0.45), rgba(0,0,0,0.45)), url({{safeBgImageURL .Style.BgImageURL}});
             background-size: cover;
             background-position: center;
             background-attachment: scroll;


### PR DESCRIPTION
## Summary
- **CSS injection defense** (#110): `safeColor` + `safeBgImageURL` template functions validate values at render time, preventing CSS injection through color values and `url()` contexts
- **CAPI error leak** (#111): Parse structured Facebook JSON error responses instead of logging raw body; UTF-8 safe truncation at 500 runes
- **CAPI token validation** (#113): Auto-test connection on pixel create with 5s timeout; returns warning (not error) if token invalid
- **UUID validation** (#115): Validate UUID format on path params for event GetByID, sale page Update/Delete/Preview
- **Admin perPage clamping** (#128): `queryPerPage()` helper caps all admin list endpoints at 100 rows max

## Test Plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` all green (handler, service, facebook packages)
- [x] Pre-push quality gates pass
- [x] Updated tests for UUID validation (event, sale page handlers)
- [x] Code review findings addressed (gofmt, BgImageURL, timeout, sentinel, UTF-8)

Closes #110, #111, #113, #115, #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)