### PR TITLE
fix: audit sprint 3 — frontend UX quick wins

### DIFF
--- a/frontend/src/hooks/use-notifications.ts
+++ b/frontend/src/hooks/use-notifications.ts
@@ -16,7 +16,7 @@ export function useNotifications(enabled: boolean) {
       return data.data
     },
     enabled,
-    staleTime: 60_000,
+    staleTime: 15_000,
   })
 }
 
@@ -27,7 +27,7 @@ export function useUnreadCount() {
       const { data } = await api.get<{ data: { unread_count: number } }>('/notifications/unread-count')
       return data.data.unread_count
     },
-    refetchInterval: 60_000,
+    refetchInterval: 15_000,
   })
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,9 +11,12 @@ import {
   X,
   ArrowRight,
   Activity,
+  Plus,
+  FileText,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   useOverviewStats,
   useEventChart,
@@ -47,9 +50,10 @@ interface StatCardProps {
   icon: React.ReactNode
   trend?: { value: number; label: string } | null
   indicator?: 'green' | 'yellow' | 'red'
+  isLoading?: boolean
 }
 
-function StatCard({ title, value, subtitle, icon, trend, indicator }: StatCardProps) {
+function StatCard({ title, value, subtitle, icon, trend, indicator, isLoading }: StatCardProps) {
   return (
     <Card>
       <CardContent className="p-6">
@@ -57,7 +61,11 @@ function StatCard({ title, value, subtitle, icon, trend, indicator }: StatCardPr
           <div>
             <p className="text-sm font-medium text-muted-foreground">{title}</p>
             <div className="flex items-center gap-2 mt-1">
-              <p className="text-2xl font-bold text-foreground">{value}</p>
+              {isLoading ? (
+                <Skeleton className="h-8 w-20" />
+              ) : (
+                <p className="text-2xl font-bold text-foreground">{value}</p>
+              )}
               {indicator && (
                 <div
                   className={`h-2.5 w-2.5 rounded-full ${
@@ -432,9 +440,10 @@ function RecentReplays() {
 // --- Dashboard Page ---
 
 export function DashboardPage() {
-  const { data: stats, isError: statsError, error: statsErr, refetch: refetchStats } = useOverviewStats()
+  const { data: stats, isLoading: statsLoading, isError: statsError, error: statsErr, refetch: refetchStats } = useOverviewStats()
   const { data: recentEvents = [], isError: eventsError, error: eventsErr, refetch: refetchEvents } = useDashboardRecentEvents(15)
   const { data: quota } = useQuota()
+  const { data: pixels } = usePixels()
 
   const capiRate = stats && stats.total_events > 0
     ? Math.round((stats.forwarded_events / stats.total_events) * 100)
@@ -478,12 +487,14 @@ export function DashboardPage() {
           value={`${stats?.active_pixels ?? 0}/${stats?.total_pixels ?? 0}`}
           subtitle={`ทั้งหมด ${stats?.total_pixels ?? 0}`}
           icon={<Radio className="h-5 w-5" />}
+          isLoading={statsLoading}
         />
         <StatCard
           title="อีเวนต์วันนี้"
           value={(stats?.events_today ?? 0).toLocaleString()}
           trend={eventsTrend}
           icon={<Zap className="h-5 w-5" />}
+          isLoading={statsLoading}
         />
         <StatCard
           title="อัตรา CAPI"
@@ -491,19 +502,54 @@ export function DashboardPage() {
           subtitle="ส่งต่อไป Facebook แล้ว"
           indicator={stats ? capiIndicator : undefined}
           icon={<Send className="h-5 w-5" />}
+          isLoading={statsLoading}
         />
         <StatCard
           title="อีเวนต์สัปดาห์นี้"
           value={(stats?.events_this_week ?? 0).toLocaleString()}
           icon={<Activity className="h-5 w-5" />}
+          isLoading={statsLoading}
         />
         <StatCard
           title="รีเพลย์ที่ทำงาน"
           value={stats?.active_replays ?? 0}
           subtitle={`ทั้งหมด ${stats?.total_replays ?? 0}`}
           icon={<RotateCcw className="h-5 w-5" />}
+          isLoading={statsLoading}
         />
       </div>
+
+      {/* Quick-action cards for empty state (#117) */}
+      {pixels && pixels.length === 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <Link to="/pixels">
+            <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+              <CardContent className="p-6 flex items-center gap-4">
+                <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                  <Plus className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium text-foreground">สร้างพิกเซลแรกของคุณ</p>
+                  <p className="text-sm text-muted-foreground">เริ่มต้นใช้งานโดยเพิ่ม Facebook Pixel</p>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+          <Link to="/sale-pages">
+            <Card className="hover:border-primary/50 transition-colors cursor-pointer">
+              <CardContent className="p-6 flex items-center gap-4">
+                <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                  <FileText className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium text-foreground">สร้างเซลเพจ</p>
+                  <p className="text-sm text-muted-foreground">สร้างเซลเพจเพื่อเก็บอีเวนต์พิกเซล</p>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        </div>
+      )}
 
       {/* Event Usage */}
       {quota && (

--- a/frontend/src/pages/PixelsPage.tsx
+++ b/frontend/src/pages/PixelsPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { toast } from 'sonner'
 import { usePixels, useCreatePixel, useUpdatePixel, useDeletePixel, useTestPixel } from '@/hooks/use-pixels'
@@ -130,7 +131,32 @@ export function PixelsPage() {
       {isError && <QueryErrorAlert error={error} onRetry={refetch} className="mb-6" />}
 
       {isLoading ? (
-        <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted">
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">ชื่อ</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">Pixel ID</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">สถานะ</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">สำรอง</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">สร้างเมื่อ</th>
+                <th className="text-right text-sm font-medium text-muted-foreground px-4 py-3">การดำเนินการ</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i} className="border-b border-border last:border-0">
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-32" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-5 w-16" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-16" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton className="h-8 w-24 ml-auto" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : !pixels || pixels.length === 0 ? (
         isAtPixelLimit ? (
           <div className="text-center py-12 border border-dashed border-border rounded-lg">
@@ -149,6 +175,7 @@ export function PixelsPage() {
           </div>
         )
       ) : (
+        <div className="overflow-x-auto">
         <div className="border border-border rounded-lg overflow-hidden">
           <table className="w-full">
             <thead>
@@ -214,6 +241,7 @@ export function PixelsPage() {
             </tbody>
           </table>
         </div>
+        </div>
       )}
 
       {/* Create/Edit Dialog */}
@@ -232,6 +260,7 @@ export function PixelsPage() {
               <Label htmlFor="fb_pixel_id">Facebook Pixel ID</Label>
               <Input id="fb_pixel_id" placeholder="123456789012345" {...register('fb_pixel_id')} />
               {errors.fb_pixel_id && <p className="text-sm text-red-500">{errors.fb_pixel_id.message}</p>}
+              <p className="text-xs text-muted-foreground">Found in Facebook Events Manager &rarr; Data Sources</p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="fb_access_token">
@@ -239,6 +268,7 @@ export function PixelsPage() {
               </Label>
               <Input id="fb_access_token" type="password" placeholder="EAAxxxxxxx..." {...register('fb_access_token')} />
               {errors.fb_access_token && <p className="text-sm text-red-500">{errors.fb_access_token.message}</p>}
+              <p className="text-xs text-muted-foreground">Generate from Facebook Events Manager &rarr; Settings</p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="test_event_code">

--- a/frontend/src/pages/ReplayPage.tsx
+++ b/frontend/src/pages/ReplayPage.tsx
@@ -299,6 +299,10 @@ export function ReplayPage() {
                     <option value="original">ต้นฉบับ (ใช้เวลาเดิมของอีเวนต์)</option>
                     <option value="current">ปัจจุบัน (ใช้เวลาปัจจุบันสำหรับทุกอีเวนต์)</option>
                   </select>
+                  <div className="space-y-1 text-xs text-muted-foreground">
+                    <p><span className="font-medium text-foreground">Original:</span> Events will be sent with their original timestamps</p>
+                    <p><span className="font-medium text-foreground">Current:</span> Events will be sent with current timestamps (recommended for Facebook)</p>
+                  </div>
                   <p className="text-xs text-muted-foreground">ใช้ "ปัจจุบัน" หากอีเวนต์เก่ากว่า 7 วัน เพื่อป้องกัน Facebook ปฏิเสธ</p>
                 </div>
 

--- a/frontend/src/pages/SalePagesPage.tsx
+++ b/frontend/src/pages/SalePagesPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router'
 import { Plus, Pencil, Trash2, Eye } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { useSalePages, useDeleteSalePage } from '@/hooks/use-sale-pages'
 import { usePixels } from '@/hooks/use-pixels'
@@ -47,7 +48,32 @@ export function SalePagesPage() {
       {isPixelsError && <QueryErrorAlert error={pixelsError} onRetry={refetchPixels} className="mb-6" />}
 
       {isLoading ? (
-        <div className="text-center py-12 text-muted-foreground">กำลังโหลด...</div>
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted">
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">ชื่อ</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">URL</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">พิกเซล</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">เทมเพลต</th>
+                <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">สถานะ</th>
+                <th className="text-right text-sm font-medium text-muted-foreground px-4 py-3">การดำเนินการ</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i} className="border-b border-border last:border-0">
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-28" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-5 w-16" /></td>
+                  <td className="px-4 py-3"><Skeleton className="h-5 w-20" /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton className="h-8 w-24 ml-auto" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : !salePages || salePages.length === 0 ? (
         <div className="text-center py-12 border border-dashed border-border rounded-lg">
           <p className="text-muted-foreground mb-4">ยังไม่มีเซลเพจ</p>


### PR DESCRIPTION
## Summary
- Dashboard stat cards show `<Skeleton>` during loading instead of "0" (#112)
- Dashboard quick-action cards ("Create Your First Pixel", "Create a Sale Page") when user has 0 pixels (#117)
- Pixel form helper text for FB Pixel ID & Access Token fields (#118)
- Notification polling reduced from 60s to 15s (#120)
- Pixels table wrapped in `overflow-x-auto` for mobile horizontal scroll (#122)
- Skeleton table rows for Pixels & Sale Pages loading states (#125)
- Replay time_mode explanation text for Original/Current options (#127)

## Test Plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (106 tests)
- [x] `npm run build` passes

Closes #112, #117, #118, #120, #122, #125, #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)