### PR TITLE
fix: audit sprint 4 + backlog — backend reliability and performance

### DIFF
--- a/backend/db/migrations/000026_event_list_indexes.down.sql
+++ b/backend/db/migrations/000026_event_list_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pixel_events_created_asc;
+DROP INDEX IF EXISTS idx_pixel_events_pixel_event_time;

--- a/backend/db/migrations/000026_event_list_indexes.up.sql
+++ b/backend/db/migrations/000026_event_list_indexes.up.sql
@@ -1,0 +1,13 @@
+-- Composite indexes to speed up the event list page queries (#138).
+-- ListByCustomerID JOINs pixels→pixel_events and filters by event_name + event_time.
+-- The existing idx_pixel_events_pixel_time covers (pixel_id, event_time DESC) but not event_name.
+-- This index covers filtered-by-event-name queries via the JOIN path.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pixel_events_pixel_event_time
+    ON pixel_events (pixel_id, event_name, event_time DESC);
+
+-- ListRecentByCustomerID filters on created_at > $since with an optional pixel_id filter.
+-- The existing idx_pixel_events_pixel_created covers (pixel_id, created_at ASC) but
+-- the query's leading filter is created_at, not pixel_id.
+-- This index supports the polling query pattern: created_at > ? ORDER BY created_at ASC.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pixel_events_created_asc
+    ON pixel_events (created_at ASC);

--- a/backend/internal/handler/event_handler.go
+++ b/backend/internal/handler/event_handler.go
@@ -154,9 +154,15 @@ func (h *EventHandler) ListRecent(w http.ResponseWriter, r *http.Request) {
 
 	sinceStr := r.URL.Query().Get("since")
 
-	// Initial load mode: no since parameter — service owns limit clamping
+	// Initial load mode: no since parameter — clamp limit in handler
 	if sinceStr == "" {
 		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		if limit < 1 {
+			limit = 100
+		}
+		if limit > 200 {
+			limit = 200
+		}
 		events, err := h.eventService.ListLatest(r.Context(), customerID, pixelID, limit)
 		if err != nil {
 			ErrorJSONWithLog(w, r, h.logger, http.StatusInternalServerError, "failed to fetch latest events", err)

--- a/backend/internal/handler/sale_page_handler.go
+++ b/backend/internal/handler/sale_page_handler.go
@@ -280,6 +280,10 @@ func (h *SalePageHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	h.renderTemplate(w, r, data.Page, data.APIKey, data.Pixels)
 }
 
+// Preview renders a sale page preview for the owner. This handler requires JWT
+// authentication and verifies that the requesting customer owns the page via
+// salePageService.GetByID (which checks CustomerID == callerID). Unauthenticated
+// or non-owner requests are rejected before any rendering occurs.
 func (h *SalePageHandler) Preview(w http.ResponseWriter, r *http.Request) {
 	customerID := middleware.GetCustomerID(r.Context())
 	pageID := chi.URLParam(r, "id")
@@ -381,6 +385,7 @@ func (h *SalePageHandler) renderTemplate(w http.ResponseWriter, r *http.Request,
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=30, s-maxage=60")
+	w.Header().Set("Vary", "Accept-Encoding")
 	w.Header().Set("ETag", etag)
 
 	if match := r.Header.Get("If-None-Match"); match == etag {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -6,12 +6,38 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jaochai/pixlinks/backend/internal/domain"
 	"github.com/jaochai/pixlinks/backend/internal/repository"
 )
+
+const platformStatsCacheTTL = 5 * time.Minute
+
+// platformStatsCache is a simple TTL cache for GetPlatformOverview results.
+type platformStatsCache struct {
+	mu        sync.RWMutex
+	stats     *domain.PlatformStats
+	expiresAt time.Time
+}
+
+func (c *platformStatsCache) get() (*domain.PlatformStats, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.stats != nil && time.Now().Before(c.expiresAt) {
+		return c.stats, true
+	}
+	return nil, false
+}
+
+func (c *platformStatsCache) set(stats *domain.PlatformStats) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stats = stats
+	c.expiresAt = time.Now().Add(platformStatsCacheTTL)
+}
 
 var (
 	ErrAdminSelfSuspend = errors.New("cannot suspend your own account")
@@ -25,6 +51,7 @@ type AdminService struct {
 	replaySessionRepo repository.ReplaySessionRepository
 	pool              *pgxpool.Pool
 	logger            *slog.Logger
+	statsCache        platformStatsCache
 }
 
 func NewAdminService(
@@ -205,7 +232,15 @@ func (s *AdminService) GrantCredits(ctx context.Context, adminID, customerID str
 }
 
 func (s *AdminService) GetPlatformOverview(ctx context.Context) (*domain.PlatformStats, error) {
-	return s.adminRepo.GetPlatformStats(ctx)
+	if cached, ok := s.statsCache.get(); ok {
+		return cached, nil
+	}
+	stats, err := s.adminRepo.GetPlatformStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.statsCache.set(stats)
+	return stats, nil
 }
 
 func (s *AdminService) GetRevenueChart(ctx context.Context, days int) ([]*domain.RevenueChartPoint, error) {

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -123,6 +123,14 @@ func (s *BillingService) EnsureStripeCustomer(ctx context.Context, customer *dom
 	}
 
 	if err := s.customerRepo.UpdateStripeCustomerID(ctx, customer.ID, sc.ID); err != nil {
+		// Compensating action: delete the orphaned Stripe customer (#144)
+		if _, delErr := stripecustomer.Del(sc.ID, nil); delErr != nil {
+			slog.Warn("failed to clean up orphaned Stripe customer",
+				"stripe_customer_id", sc.ID,
+				"customer_id", customer.ID,
+				"cleanup_error", delErr.Error(),
+			)
+		}
 		return "", fmt.Errorf("save stripe customer id: %w", err)
 	}
 

--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -309,6 +309,34 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 	const revalidateInterval = 10 // re-check target pixel every N batches
 
 	for i := 0; i < len(events); i += batchSize {
+		// Check for server shutdown before each batch (#139)
+		select {
+		case <-ctx.Done():
+			s.logger.Warn("replay interrupted by server shutdown, saving progress",
+				"session_id", session.ID, "replayed", replayed, "failed", failed)
+			// Save progress and failed batch ranges before exiting
+			writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if len(failedBatchRanges) > 0 {
+				if rangesJSON, err := json.Marshal(failedBatchRanges); err == nil {
+					if err := s.replayRepo.UpdateFailedBatches(writeCtx, session.ID, rangesJSON); err != nil {
+						s.logger.Warn("failed to save failed batch ranges on shutdown", "error", err, "session_id", session.ID)
+					}
+				}
+			}
+			if err := s.replayRepo.UpdateProgress(writeCtx, session.ID, int(replayed), int(failed)); err != nil {
+				s.logger.Warn("failed to update progress on shutdown", "error", err, "session_id", session.ID)
+			}
+			if err := s.replayRepo.UpdateStatusWithError(writeCtx, session.ID, domain.ReplayStatusFailed, "server shutdown during replay"); err != nil {
+				s.logger.Error("failed to mark session failed on shutdown", "error", err, "session_id", session.ID)
+			}
+			s.createReplayNotification(session, domain.NotificationTypeReplayFailed,
+				"Replay interrupted",
+				fmt.Sprintf("Server shut down during replay. %d events replayed, %d failed. You can retry.", replayed, failed))
+			return
+		default:
+		}
+
 		// Periodically re-validate target pixel still exists (#119)
 		batchNum := i / batchSize
 		if batchNum > 0 && batchNum%revalidateInterval == 0 {
@@ -427,6 +455,27 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 			select {
 			case <-time.After(delay):
 			case <-ctx.Done():
+				// Shutdown during batch delay — save progress (#139)
+				s.logger.Warn("replay interrupted by server shutdown during batch delay",
+					"session_id", session.ID, "replayed", replayed, "failed", failed)
+				writeCtx, writeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer writeCancel()
+				if len(failedBatchRanges) > 0 {
+					if rangesJSON, err := json.Marshal(failedBatchRanges); err == nil {
+						if err := s.replayRepo.UpdateFailedBatches(writeCtx, session.ID, rangesJSON); err != nil {
+							s.logger.Warn("failed to save failed batch ranges on shutdown", "error", err, "session_id", session.ID)
+						}
+					}
+				}
+				if err := s.replayRepo.UpdateProgress(writeCtx, session.ID, int(replayed), int(failed)); err != nil {
+					s.logger.Warn("failed to update progress on shutdown", "error", err, "session_id", session.ID)
+				}
+				if err := s.replayRepo.UpdateStatusWithError(writeCtx, session.ID, domain.ReplayStatusFailed, "server shutdown during replay"); err != nil {
+					s.logger.Error("failed to mark session failed on shutdown", "error", err, "session_id", session.ID)
+				}
+				s.createReplayNotification(session, domain.NotificationTypeReplayFailed,
+					"Replay interrupted",
+					fmt.Sprintf("Server shut down during replay. %d events replayed, %d failed. You can retry.", replayed, failed))
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
- Vary: Accept-Encoding header on sale pages for CDN correctness (#135, #136)
- Composite indexes for event list queries (pixel_id+event_name+event_time, created_at ASC) (#138)
- Replay graceful shutdown with progress save — checks ctx.Done() before each batch (#139)
- Admin aggregate 5min TTL cache using sync.RWMutex (#140)
- ListRecent limit clamping in handler (1-200, default 100) (#141)
- Preview handler ownership documented (#142)
- Stripe customer orphan cleanup via compensating delete on DB save failure (#144)

## Test Plan
- [x] go vet ./... passes
- [x] go test -race ./... passes

Closes #135, #136, #138, #139, #140, #141, #142, #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)