### PR TITLE
fix: generate E2E auth tokens dynamically in post-deploy-e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,13 +289,27 @@ jobs:
           done
           echo "::warning::Backend health check failed — global-setup retry will handle it"
 
+      - name: Generate E2E auth tokens
+        run: |
+          E2E_USER_ID="00000000-0000-4000-a000-000000000e2e"
+          ACCESS_TOKEN=$(node -e "
+            const crypto = require('crypto');
+            const b64url = (b) => Buffer.from(b).toString('base64url');
+            const header = b64url(JSON.stringify({alg:'HS256',typ:'JWT'}));
+            const now = Math.floor(Date.now()/1000);
+            const payload = b64url(JSON.stringify({sub:'$E2E_USER_ID',email:'e2e-smoke@keep-px.internal',is_admin:false,iat:now,exp:now+3600}));
+            const sig = crypto.createHmac('sha256','${{ secrets.JWT_SECRET }}').update(header+'.'+payload).digest('base64url');
+            console.log(header+'.'+payload+'.'+sig);
+          ")
+          REFRESH_TOKEN=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+          echo "E2E_ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
+          echo "E2E_REFRESH_TOKEN=$REFRESH_TOKEN" >> "$GITHUB_ENV"
+
       - name: Run smoke tests against production
         run: npx playwright test --grep @smoke
         env:
           E2E_BASE_URL: ${{ vars.FRONTEND_PROD_URL }}
           E2E_API_URL: ${{ vars.BACKEND_PROD_URL }}
-          E2E_ACCESS_TOKEN: ${{ secrets.E2E_PROD_ACCESS_TOKEN }}
-          E2E_REFRESH_TOKEN: ${{ secrets.E2E_PROD_REFRESH_TOKEN }}
 
       - name: Upload smoke test results
         if: failure()


### PR DESCRIPTION
## Summary
- post-deploy-e2e job fails because static JWT secrets expire/rotate — replaced with dynamic token generation in CI
- Added "Generate E2E auth tokens" step that creates fresh JWT (1h TTL) using production `JWT_SECRET`
- Same pattern already used by local `e2e` job (lines 150-173)
- Created E2E test customer in production Neon DB (`e2e-smoke@keep-px.internal`, sandbox plan)

## Prerequisites (manual, one-time)
- [ ] Add GitHub secret `JWT_SECRET` (same value as Railway production env)
- [ ] Verify GitHub variables `FRONTEND_PROD_URL` and `BACKEND_PROD_URL` exist

## Test plan
- [ ] After adding `JWT_SECRET` secret, merge to `main` and verify `post-deploy-e2e` job passes
- [ ] All 15 smoke tests should pass (dashboard 2, navigation 2, billing 5, sale-pages 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)