### PR TITLE
fix: stabilize flaky E2E smoke tests

### DIFF
--- a/frontend/e2e/pages/billing.page.ts
+++ b/frontend/e2e/pages/billing.page.ts
@@ -57,6 +57,7 @@ export class BillingPage {
   }
 
   async goto() {
-    await this.page.goto('/billing')
+    await this.page.goto('/billing', { waitUntil: 'networkidle' })
+    await this.heading.waitFor({ state: 'visible', timeout: 15000 })
   }
 }

--- a/frontend/e2e/pages/sale-pages.page.ts
+++ b/frontend/e2e/pages/sale-pages.page.ts
@@ -26,7 +26,8 @@ export class SalePagesPage {
   }
 
   async goto() {
-    await this.page.goto('/sale-pages')
+    await this.page.goto('/sale-pages', { waitUntil: 'networkidle' })
+    await this.heading.waitFor({ state: 'visible', timeout: 15000 })
   }
 
   /** Click trash icon on a row matching the given text */

--- a/frontend/e2e/pages/sidebar.page.ts
+++ b/frontend/e2e/pages/sidebar.page.ts
@@ -32,5 +32,6 @@ export class SidebarPage {
 
   async navigateTo(linkName: string) {
     await this.nav.getByRole('link', { name: linkName }).click()
+    await this.page.waitForLoadState('networkidle')
   }
 }


### PR DESCRIPTION
## Summary
- Add `waitUntil: 'networkidle'` + heading `waitFor` to sale-pages and billing page objects
- Add `waitForLoadState('networkidle')` after sidebar navigation clicks
- Fixes 4 flaky tests and 1 hard failure in post-deploy-e2e

## Test plan
- [ ] post-deploy-e2e job passes with 0 flaky tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)