### PR TITLE
fix: make post-deploy-e2e smoke tests state-agnostic

### DIFF
--- a/.claude/skills/e2e-write/SKILL.md
+++ b/.claude/skills/e2e-write/SKILL.md
@@ -182,6 +182,38 @@ Forms use Zod validation with `zodResolver`. If a required field is empty, `hand
 
 ---
 
+## Rule 10: Production Smoke Tests Must Be State-Agnostic
+
+`post-deploy-e2e` runs `@smoke` tests against **production** — the test user's data changes over time. Never assume a specific state.
+
+**Bad:**
+```typescript
+// Hardcodes "no credits" — breaks when user has credits
+await expect(page.getByText('ยังไม่มีเครดิตรีเพลย์')).toBeVisible()
+```
+
+**Good:**
+```typescript
+// State-agnostic: accept either state
+const hasCredits = await page.getByText('เครดิตที่มีอยู่').isVisible().catch(() => false)
+if (hasCredits) {
+  await expect(page.getByText('เครดิตที่มีอยู่')).toBeVisible()
+} else {
+  await expect(page.getByText('ยังไม่มีเครดิตรีเพลย์')).toBeVisible()
+}
+```
+
+**Principles:**
+1. Assert **structure** (sections exist, buttons present) — not **specific content state**
+2. Use conditional checks when UI depends on user data (credits, subscriptions, list items)
+3. Add generous `timeout` for `toHaveURL` after save/redirect — production is slower:
+   ```typescript
+   await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
+   ```
+4. Distinguish: PR CI tests (predictable state) vs smoke tests (unpredictable state)
+
+---
+
 ## Conventions
 
 | Convention | Rule |
@@ -209,6 +241,8 @@ Before pushing E2E test code, verify:
 - [ ] Responsive nav locators use `.first()` or scope
 - [ ] Resource creation tests handle quota limits
 - [ ] `waitForLoadState('networkidle')` in page object `goto()`
+- [ ] `@smoke` tests are state-agnostic — no hardcoded assumptions about user data
+- [ ] `toHaveURL` after save/redirect uses `{ timeout: 15000 }` for production
 
 ---
 

--- a/frontend/e2e/tests/billing.spec.ts
+++ b/frontend/e2e/tests/billing.spec.ts
@@ -40,8 +40,13 @@ test.describe('Billing @smoke', () => {
     await expect(page.getByText('฿299')).toBeVisible()
     await expect(page.getByText('฿1,990')).toBeVisible()
 
-    // No credits message for free user
-    await expect(page.getByText('ยังไม่มีเครดิตรีเพลย์')).toBeVisible()
+    // Credits section: either active credits or "no credits" message (state-agnostic)
+    const hasCredits = await page.getByText('เครดิตที่มีอยู่').isVisible().catch(() => false)
+    if (hasCredits) {
+      await expect(page.getByText('เครดิตที่มีอยู่')).toBeVisible()
+    } else {
+      await expect(page.getByText('ยังไม่มีเครดิตรีเพลย์')).toBeVisible()
+    }
   })
 
   test('purchase history section is visible', async ({ page }) => {

--- a/frontend/e2e/tests/sale-pages.spec.ts
+++ b/frontend/e2e/tests/sale-pages.spec.ts
@@ -55,7 +55,7 @@ test.describe('Sale Pages @smoke', () => {
     await editor.saveDraft()
 
     // Should redirect back to list
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
 
     // Status should be draft
@@ -78,7 +78,7 @@ test.describe('Sale Pages @smoke', () => {
     await editor.goBackButton.click()
 
     // Should be back on list with published status
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
 
     const statusBadge = salePagesPage.getRow(spName)
@@ -95,12 +95,12 @@ test.describe('Sale Pages @smoke', () => {
     const originalName = `${TEST_PREFIX} Edit ${Date.now()}`
     await editor.fillMinimum(originalName)
     await editor.saveDraft()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(originalName)).toBeVisible()
 
     // Click edit
     await salePagesPage.clickEditOnRow(originalName)
-    await expect(page).toHaveURL(/\/sale-pages\/.*\/edit-blocks/)
+    await expect(page).toHaveURL(/\/sale-pages\/.*\/edit-blocks/, { timeout: 15000 })
 
     // Open settings collapsible (closed by default in edit mode)
     await page.getByText('ตั้งค่าหน้าเพจ').click()
@@ -113,7 +113,7 @@ test.describe('Sale Pages @smoke', () => {
     await editor.saveDraftButton.click()
 
     // Should be back on list with updated name
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(updatedName)).toBeVisible()
   })
 
@@ -127,7 +127,7 @@ test.describe('Sale Pages @smoke', () => {
     const spName = `${TEST_PREFIX} Delete ${Date.now()}`
     await editor.fillMinimum(spName)
     await editor.saveDraft()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
 
     // Click delete
@@ -159,7 +159,7 @@ test.describe('Sale Pages @smoke', () => {
       return
     }
     await editor.goBackButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
 
     // Click delete
@@ -208,7 +208,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.publishedUrlCode).toContainText(`/p/${customSlug}`)
 
     await editor.goBackButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
 
     // Verify slug appears in the list
     const row = page.locator('tr', { hasText: spName })
@@ -229,7 +229,7 @@ test.describe('Sale Page Editor Details', () => {
     await editor.heroImageUrlInput.fill('https://example.com/test-image.jpg')
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -246,7 +246,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.descriptionTextarea).toHaveValue('This is a test description for the sale page')
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -289,7 +289,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(featureInputs).toHaveCount(2)
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -308,7 +308,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.ctaButtonLinkInput).toHaveValue('https://example.com/buy')
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -337,7 +337,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.trackingCurrencySelect).toHaveValue('USD')
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -377,7 +377,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.contactWebsiteUrlInput).toHaveValue('https://example.com')
 
     await editor.saveDraftButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -414,7 +414,7 @@ test.describe('Sale Page Editor Details', () => {
     await expect(editor.copyUrlButton).toBeVisible()
 
     await editor.goBackButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
   })
 })
 
@@ -455,7 +455,7 @@ test.describe('Block Editor Flow', () => {
 
     // Save as draft
     await editor.saveDraft()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -487,7 +487,7 @@ test.describe('Block Editor Flow', () => {
 
     // Save
     await editor.saveDraft()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
     await expect(page.getByText(spName)).toBeVisible()
   })
 
@@ -575,7 +575,7 @@ test.describe('Sale Page Edge Cases', () => {
     await editor.leaveButton.click()
 
     // Should be on dashboard now
-    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 })
   })
 
   test('double-click publish prevention', async ({ page }) => {
@@ -606,7 +606,7 @@ test.describe('Sale Page Edge Cases', () => {
     }
 
     await editor.goBackButton.click()
-    await expect(page).toHaveURL(/\/sale-pages$/)
+    await expect(page).toHaveURL(/\/sale-pages$/, { timeout: 15000 })
 
     // Verify only one sale page was created (count rows matching the name)
     const matchingRows = page.locator('tr', { hasText: spName })


### PR DESCRIPTION
## Summary
- **billing.spec.ts**: Replace hardcoded "no credits" assertion with conditional check — accepts either "เครดิตที่มีอยู่" (has credits) or "ยังไม่มีเครดิตรีเพลย์" (no credits)
- **sale-pages.spec.ts**: Add `{ timeout: 15000 }` to all `toHaveURL` assertions — production redirects can exceed the default 5s timeout
- **e2e-write skill**: Add Rule 10 — production smoke tests must be state-agnostic + checklist items

## Root Cause
`post-deploy-e2e` runs against production where test user state changes over time. Tests that hardcode assumptions about user data (e.g., "user has no credits") fail when production state diverges.

## Test Plan
- [ ] PR CI passes (lint, unit tests, E2E against test DB)
- [ ] After merge: `post-deploy-e2e` smoke tests pass on production
- [ ] Billing smoke test works regardless of whether test user has credits or not
- [ ] Sale page redirect assertions no longer flaky on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)