### PR TITLE
fix: log malformed JSON in replay event construction

### DIFF
--- a/backend/internal/service/replay_service.go
+++ b/backend/internal/service/replay_service.go
@@ -416,13 +416,19 @@ func (s *ReplayService) executeReplay(ctx context.Context, session *domain.Repla
 
 			if evt.EventData != nil {
 				var cd map[string]interface{}
-				_ = json.Unmarshal(evt.EventData, &cd)
+				if err := json.Unmarshal(evt.EventData, &cd); err != nil {
+					s.logger.Warn("malformed event_data on replay event, skipping custom_data",
+						"error", err, "event_id", evt.ID)
+				}
 				capiEvt.CustomData = cd
 			}
 
 			userData := make(map[string]interface{})
 			if evt.UserData != nil {
-				_ = json.Unmarshal(evt.UserData, &userData)
+				if err := json.Unmarshal(evt.UserData, &userData); err != nil {
+					s.logger.Warn("malformed user_data on replay event, using empty map",
+						"error", err, "event_id", evt.ID)
+				}
 			}
 			if _, exists := userData["country"]; !exists {
 				userData["country"] = defaultCountry


### PR DESCRIPTION
## Summary
Per Go reviewer feedback on PR #199: silently discarded `json.Unmarshal` errors on `event_data` and `user_data` in replay path now log at warn level.

## Test plan
- [x] `go vet ./...` clean
- [x] 12/12 ExecuteReplay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)