### PR TITLE
fix: use same-origin login_uri for Google OAuth redirect

### DIFF
--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -169,7 +169,7 @@ export function LoginPage() {
                   onSuccess={() => {/* redirect mode — handled by backend callback */}}
                   ux_mode="redirect"
                   login_uri={
-                    (import.meta.env.VITE_API_URL || window.location.origin) + '/api/v1/auth/google/callback'
+                    window.location.origin + '/api/v1/auth/google/callback'
                   }
                   theme="filled_black"
                   size="large"


### PR DESCRIPTION
## Summary
- แก้ CSRF cookie ไม่ถูกส่งเพราะ login_uri ชี้ไปที่ `api.pixlinks.xyz` (คนละ subdomain กับ frontend `pixlinks.xyz`)
- เปลี่ยน login_uri ให้ใช้ `window.location.origin` เสมอ → POST ผ่าน nginx proxy → CSRF cookie อยู่บน same domain

## Root cause
```
Google ตั้ง g_csrf_token cookie บน pixlinks.xyz
แต่ form POST ไป api.pixlinks.xyz (cross-subdomain)
→ browser ไม่ส่ง cookie → CSRF validation fail → bounce back to login
```

## Fix
`login_uri = window.location.origin + '/api/v1/auth/google/callback'`
ไม่ใช้ `VITE_API_URL` เพราะมันชี้ไปคนละ subdomain

## Google Console redirect URI ต้องเปลี่ยนเป็น:
`https://pixlinks.xyz/api/v1/auth/google/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)