### PR TITLE
chore: production hygiene cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,17 +196,26 @@ jobs:
           echo "::warning::Backend health check failed — global-setup retry will handle it"
 
       - name: Generate E2E auth tokens
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          E2E_USER_ID: "00000000-0000-4000-a000-000000000e2e"
         run: |
-          E2E_USER_ID="00000000-0000-4000-a000-000000000e2e"
-          ACCESS_TOKEN=$(node -e "
-            const crypto = require('crypto');
-            const b64url = (b) => Buffer.from(b).toString('base64url');
-            const header = b64url(JSON.stringify({alg:'HS256',typ:'JWT'}));
+          if [ -z "$JWT_SECRET" ]; then
+            echo "JWT_SECRET missing" >&2
+            exit 1
+          fi
+          ACCESS_TOKEN=$(node -e '
+            const crypto = require("crypto");
+            const secret = process.env.JWT_SECRET;
+            const userId = process.env.E2E_USER_ID;
+            if (!secret) { console.error("JWT_SECRET missing"); process.exit(1); }
+            const b64url = (b) => Buffer.from(b).toString("base64url");
+            const header = b64url(JSON.stringify({alg:"HS256",typ:"JWT"}));
             const now = Math.floor(Date.now()/1000);
-            const payload = b64url(JSON.stringify({sub:'$E2E_USER_ID',email:'e2e-smoke@keep-px.internal',is_admin:false,iat:now,exp:now+3600}));
-            const sig = crypto.createHmac('sha256','${{ secrets.JWT_SECRET }}').update(header+'.'+payload).digest('base64url');
-            console.log(header+'.'+payload+'.'+sig);
-          ")
+            const payload = b64url(JSON.stringify({sub:userId,email:"e2e-smoke@keep-px.internal",is_admin:false,iat:now,exp:now+3600}));
+            const sig = crypto.createHmac("sha256", secret).update(header+"."+payload).digest("base64url");
+            console.log(header+"."+payload+"."+sig);
+          ')
           REFRESH_TOKEN=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
           echo "E2E_ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
           echo "E2E_REFRESH_TOKEN=$REFRESH_TOKEN" >> "$GITHUB_ENV"

--- a/backend/internal/facebook/capi.go
+++ b/backend/internal/facebook/capi.go
@@ -70,15 +70,6 @@ func (c *CAPIClient) SendEvents(ctx context.Context, pixelID, accessToken, testE
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// Debug: log first 500 bytes of request body for troubleshooting CAPI errors
-	if len(body) > 0 {
-		logBody := string(body)
-		if len(logBody) > 500 {
-			logBody = logBody[:500] + "..."
-		}
-		fmt.Printf("[DEBUG-CAPI] POST %s body=%s\n", url, logBody)
-	}
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -67,3 +67,11 @@ func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 		Pool:   pool,
 	})
 }
+
+// Ready is a lightweight liveness check that does not touch the DB.
+// Use this for Railway/Kubernetes liveness probes; use /health for readiness with DB ping.
+func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ready"}` + "\n"))
+}

--- a/backend/internal/handler/health_test.go
+++ b/backend/internal/handler/health_test.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReady_ReturnsOK(t *testing.T) {
+	h := &HealthHandler{pool: nil}
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	w := httptest.NewRecorder()
+
+	h.Ready(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != `{"status":"ready"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("want Content-Type application/json, got %q", ct)
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -105,6 +105,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 
 	// Health check
 	r.Get("/health", healthHandler.Health)
+	r.Get("/ready", healthHandler.Ready)
 
 	// Rate limiter with context for proper goroutine cleanup
 	rateLimiter := middleware.RateLimitWithContext(shutdownCtx, cfg.RateLimitRPS)


### PR DESCRIPTION
## Summary
- Remove temporary CAPI debug log left over from PR #201 (`backend/internal/facebook/capi.go`)
- Add `/ready` liveness endpoint (does not touch DB) — separate from `/health` which pings DB
- Move `JWT_SECRET` out of inline GitHub Actions interpolation into `env:` block with fail-fast guard

## Test Plan
- [x] `go vet ./...` clean
- [x] `go test ./internal/handler/... ./internal/router/... ./internal/facebook/...` pass
- [x] Frontend pre-push gates pass (104 tests)
- [ ] CI workflow runs green
- [ ] After merge: `curl https://api.../ready` returns `{"status":"ready"}` 200
- [ ] Check Railway/production logs no longer contain `[DEBUG-CAPI]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)