### PR TITLE
feat(security): per-API-key rate limit for /events/ingest

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,10 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173
 # Rate Limiting
 RATE_LIMIT_RPS=100
 
+# Per-API-key rate limit for /events/ingest (requests per second / burst)
+RATE_LIMIT_API_KEY_RPS=100
+RATE_LIMIT_API_KEY_BURST=200
+
 # Public base URL
 BASE_URL=https://pixlinks.xyz
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -8,17 +8,17 @@ import (
 )
 
 type Config struct {
-	Port               int           `env:"PORT" envDefault:"8080"`
-	Env                string        `env:"ENV" envDefault:"production"`
-	DatabaseURL        string        `env:"DATABASE_URL,required"`
-	JWTSecret          string        `env:"JWT_SECRET,required"`
-	JWTAccessTTL       time.Duration `env:"JWT_ACCESS_TTL" envDefault:"15m"`
-	JWTRefreshTTL      time.Duration `env:"JWT_REFRESH_TTL" envDefault:"720h"`
-	FBGraphAPIURL      string        `env:"FB_GRAPH_API_URL" envDefault:"https://graph.facebook.com/v21.0"`
-	CORSAllowedOrigins []string      `env:"CORS_ALLOWED_ORIGINS" envSeparator:"," envDefault:"http://localhost:5173"`
-	RateLimitRPS       int           `env:"RATE_LIMIT_RPS" envDefault:"100"`
-	RateLimitAPIKeyRPS   int `env:"RATE_LIMIT_API_KEY_RPS" envDefault:"100"`
-	RateLimitAPIKeyBurst int `env:"RATE_LIMIT_API_KEY_BURST" envDefault:"200"`
+	Port                 int           `env:"PORT" envDefault:"8080"`
+	Env                  string        `env:"ENV" envDefault:"production"`
+	DatabaseURL          string        `env:"DATABASE_URL,required"`
+	JWTSecret            string        `env:"JWT_SECRET,required"`
+	JWTAccessTTL         time.Duration `env:"JWT_ACCESS_TTL" envDefault:"15m"`
+	JWTRefreshTTL        time.Duration `env:"JWT_REFRESH_TTL" envDefault:"720h"`
+	FBGraphAPIURL        string        `env:"FB_GRAPH_API_URL" envDefault:"https://graph.facebook.com/v21.0"`
+	CORSAllowedOrigins   []string      `env:"CORS_ALLOWED_ORIGINS" envSeparator:"," envDefault:"http://localhost:5173"`
+	RateLimitRPS         int           `env:"RATE_LIMIT_RPS" envDefault:"100"`
+	RateLimitAPIKeyRPS   int           `env:"RATE_LIMIT_API_KEY_RPS" envDefault:"100"`
+	RateLimitAPIKeyBurst int           `env:"RATE_LIMIT_API_KEY_BURST" envDefault:"200"`
 
 	// Public base URL for sale pages
 	BaseURL string `env:"BASE_URL" envDefault:"https://pixlinks.xyz"`
@@ -34,26 +34,26 @@ type Config struct {
 	S3PublicURL string `env:"S3_PUBLIC_URL"`
 
 	// Stripe
-	StripeSecretKey            string `env:"STRIPE_SECRET_KEY"`
-	StripeWebhookSecret        string `env:"STRIPE_WEBHOOK_SECRET"`
-	StripePublishableKey       string `env:"STRIPE_PUBLISHABLE_KEY"`
+	StripeSecretKey          string `env:"STRIPE_SECRET_KEY"`
+	StripeWebhookSecret      string `env:"STRIPE_WEBHOOK_SECRET"`
+	StripePublishableKey     string `env:"STRIPE_PUBLISHABLE_KEY"`
 	StripePricePixelSlot     string `env:"STRIPE_PRICE_PIXEL_SLOT"`
 	StripePriceReplaySingle  string `env:"STRIPE_PRICE_REPLAY_SINGLE"`
 	StripePriceReplayMonthly string `env:"STRIPE_PRICE_REPLAY_MONTHLY"`
-	FrontendURL                string `env:"FRONTEND_URL" envDefault:"http://localhost:5173"`
+	FrontendURL              string `env:"FRONTEND_URL" envDefault:"http://localhost:5173"`
 
 	// Token encryption (32-byte hex-encoded key, optional)
 	TokenEncryptionKey string `env:"TOKEN_ENCRYPTION_KEY"`
 
 	// Database pool tuning (defaults optimized for Neon serverless)
-	DBMaxConns         int32         `env:"DB_MAX_CONNS" envDefault:"20"`
-	DBMinConns         int32         `env:"DB_MIN_CONNS" envDefault:"3"`
-	DBMaxConnLifetime  time.Duration `env:"DB_MAX_CONN_LIFETIME" envDefault:"30m"`
-	DBMaxConnIdleTime  time.Duration `env:"DB_MAX_CONN_IDLE_TIME" envDefault:"5m"`
+	DBMaxConns          int32         `env:"DB_MAX_CONNS" envDefault:"20"`
+	DBMinConns          int32         `env:"DB_MIN_CONNS" envDefault:"3"`
+	DBMaxConnLifetime   time.Duration `env:"DB_MAX_CONN_LIFETIME" envDefault:"30m"`
+	DBMaxConnIdleTime   time.Duration `env:"DB_MAX_CONN_IDLE_TIME" envDefault:"5m"`
 	DBHealthCheckPeriod time.Duration `env:"DB_HEALTH_CHECK_PERIOD" envDefault:"15s"`
-	DBConnectTimeout   time.Duration `env:"DB_CONNECT_TIMEOUT" envDefault:"5s"`
-	DBQueryTimeout     time.Duration `env:"DB_QUERY_TIMEOUT" envDefault:"10s"`
-	SalePageCacheTTL   time.Duration `env:"SALE_PAGE_CACHE_TTL" envDefault:"60s"`
+	DBConnectTimeout    time.Duration `env:"DB_CONNECT_TIMEOUT" envDefault:"5s"`
+	DBQueryTimeout      time.Duration `env:"DB_QUERY_TIMEOUT" envDefault:"10s"`
+	SalePageCacheTTL    time.Duration `env:"SALE_PAGE_CACHE_TTL" envDefault:"60s"`
 }
 
 func Load() (*Config, error) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	FBGraphAPIURL      string        `env:"FB_GRAPH_API_URL" envDefault:"https://graph.facebook.com/v21.0"`
 	CORSAllowedOrigins []string      `env:"CORS_ALLOWED_ORIGINS" envSeparator:"," envDefault:"http://localhost:5173"`
 	RateLimitRPS       int           `env:"RATE_LIMIT_RPS" envDefault:"100"`
+	RateLimitAPIKeyRPS   int `env:"RATE_LIMIT_API_KEY_RPS" envDefault:"100"`
+	RateLimitAPIKeyBurst int `env:"RATE_LIMIT_API_KEY_BURST" envDefault:"200"`
 
 	// Public base URL for sale pages
 	BaseURL string `env:"BASE_URL" envDefault:"https://pixlinks.xyz"`

--- a/backend/internal/middleware/apikey.go
+++ b/backend/internal/middleware/apikey.go
@@ -51,6 +51,7 @@ func APIKeyAuthWithContext(ctx context.Context, customerRepo repository.Customer
 				entry := val.(apiKeyCacheEntry)
 				if time.Now().Before(entry.expiry) {
 					ctx := context.WithValue(r.Context(), CustomerIDKey, entry.customerID)
+					ctx = context.WithValue(ctx, apiKeyCtxKey{}, apiKey)
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
@@ -69,6 +70,7 @@ func APIKeyAuthWithContext(ctx context.Context, customerRepo repository.Customer
 			})
 
 			ctx := context.WithValue(r.Context(), CustomerIDKey, customer.ID)
+			ctx = context.WithValue(ctx, apiKeyCtxKey{}, apiKey)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/backend/internal/middleware/ratelimit_apikey.go
+++ b/backend/internal/middleware/ratelimit_apikey.go
@@ -77,7 +77,7 @@ func RateLimitByAPIKey(rps int, burst int) func(http.Handler) http.Handler {
 			}
 			if !store.get(key).Allow() {
 				w.Header().Set("Retry-After", "1")
-				http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
+				writeJSONError(w, http.StatusTooManyRequests, "rate limit exceeded")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/backend/internal/middleware/ratelimit_apikey.go
+++ b/backend/internal/middleware/ratelimit_apikey.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type apiKeyCtxKey struct{}
+
+const apiKeyLimiterTTL = 1 * time.Hour
+
+type apiKeyLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type apiKeyLimiterStore struct {
+	mu       sync.Mutex
+	limiters map[string]*apiKeyLimiter
+	rps      rate.Limit
+	burst    int
+}
+
+func newAPIKeyLimiterStore(rps int, burst int) *apiKeyLimiterStore {
+	s := &apiKeyLimiterStore{
+		limiters: make(map[string]*apiKeyLimiter),
+		rps:      rate.Limit(rps),
+		burst:    burst,
+	}
+	go s.gcLoop()
+	return s
+}
+
+func (s *apiKeyLimiterStore) get(key string) *rate.Limiter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.limiters[key]; ok {
+		l.lastSeen = time.Now()
+		return l.limiter
+	}
+	l := &apiKeyLimiter{
+		limiter:  rate.NewLimiter(s.rps, s.burst),
+		lastSeen: time.Now(),
+	}
+	s.limiters[key] = l
+	return l.limiter
+}
+
+func (s *apiKeyLimiterStore) gcLoop() {
+	t := time.NewTicker(10 * time.Minute)
+	defer t.Stop()
+	for range t.C {
+		s.mu.Lock()
+		cutoff := time.Now().Add(-apiKeyLimiterTTL)
+		for k, l := range s.limiters {
+			if l.lastSeen.Before(cutoff) {
+				delete(s.limiters, k)
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// RateLimitByAPIKey rate-limits by API key from request context.
+// Requests without an API key pass through unchanged.
+func RateLimitByAPIKey(rps int, burst int) func(http.Handler) http.Handler {
+	store := newAPIKeyLimiterStore(rps, burst)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key, ok := r.Context().Value(apiKeyCtxKey{}).(string)
+			if !ok || key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !store.get(key).Allow() {
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/middleware/ratelimit_apikey_test.go
+++ b/backend/internal/middleware/ratelimit_apikey_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimitByAPIKey_AllowsUnderLimit(t *testing.T) {
+	mw := RateLimitByAPIKey(5, 5)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, "key-a"))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: want 200, got %d", i, w.Code)
+		}
+	}
+}
+
+func TestRateLimitByAPIKey_BlocksWhenExceeded(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var blocked int
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, "key-b"))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			blocked++
+		}
+	}
+	if blocked == 0 {
+		t.Fatal("expected at least one 429, got none")
+	}
+}
+
+func TestRateLimitByAPIKey_SeparateBucketsPerKey(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, key := range []string{"key-c", "key-d"} {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, key))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("key %s: want 200, got %d", key, w.Code)
+		}
+	}
+}
+
+func TestRateLimitByAPIKey_PassthroughWhenNoKey(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("no key: want 200, got %d", w.Code)
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -144,7 +144,7 @@ func New(cfg *config.Config, logger *slog.Logger, pool *pgxpool.Pool, shutdownCt
 			// Event ingestion (API key auth)
 			r.Route("/events", func(r chi.Router) {
 				r.Use(middleware.APIKeyAuthWithContext(shutdownCtx, customerRepo))
-				r.Post("/ingest", eventHandler.Ingest)
+				r.With(middleware.RateLimitByAPIKey(cfg.RateLimitAPIKeyRPS, cfg.RateLimitAPIKeyBurst)).Post("/ingest", eventHandler.Ingest)
 			})
 
 			// Dashboard routes (JWT auth)


### PR DESCRIPTION
## Summary
- Add per-API-key token bucket rate limiter (defaults 100 rps / 200 burst)
- Inject API key into request context from APIKeyAuthWithContext middleware (both cache-hit and cache-miss paths)
- Mount limiter on `POST /events/ingest` after `APIKeyAuthWithContext` so context is populated before rate check
- Background GC every 10min removes idle limiters (1h TTL) to cap memory

## Test Plan
- [x] 4 new middleware unit tests pass (`AllowsUnderLimit`, `BlocksWhenExceeded`, `SeparateBucketsPerKey`, `PassthroughWhenNoKey`)
- [x] go vet + go test -race ./internal/middleware/... pass
- [ ] CI pipeline green
- [ ] Manual: hammer `/events/ingest` with one API key, observe 429 with `Retry-After: 1`
- [ ] Manual: two API keys in parallel each get full bucket independently

## Configuration
\`\`\`
RATE_LIMIT_API_KEY_RPS=100
RATE_LIMIT_API_KEY_BURST=200
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)