### PR TITLE
feat(sale-pages): add video and divider blocks to BlockEditor

### DIFF
--- a/backend/internal/domain/sale_page.go
+++ b/backend/internal/domain/sale_page.go
@@ -69,21 +69,26 @@ type ContactInfo struct {
 type BlockType string
 
 const (
-	BlockTypeImage  BlockType = "image"
-	BlockTypeText   BlockType = "text"
-	BlockTypeButton BlockType = "button"
+	BlockTypeImage   BlockType = "image"
+	BlockTypeText    BlockType = "text"
+	BlockTypeButton  BlockType = "button"
+	BlockTypeVideo   BlockType = "video"
+	BlockTypeDivider BlockType = "divider"
 )
 
 type Block struct {
-	ID          string    `json:"id"`
-	Type        BlockType `json:"type"`
-	ImageURL    string    `json:"image_url,omitempty"`
-	LinkURL     string    `json:"link_url,omitempty"`
-	Text        string    `json:"text,omitempty"`
-	ButtonStyle string    `json:"button_style,omitempty"`
-	ButtonText  string    `json:"button_text,omitempty"`
-	ButtonURL   string    `json:"button_url,omitempty"`
-	ButtonValue string    `json:"button_value,omitempty"`
+	ID               string    `json:"id"`
+	Type             BlockType `json:"type"`
+	ImageURL         string    `json:"image_url,omitempty"`
+	LinkURL          string    `json:"link_url,omitempty"`
+	Text             string    `json:"text,omitempty"`
+	ButtonStyle      string    `json:"button_style,omitempty"`
+	ButtonText       string    `json:"button_text,omitempty"`
+	ButtonURL        string    `json:"button_url,omitempty"`
+	ButtonValue      string    `json:"button_value,omitempty"`
+	VideoURL         string    `json:"video_url,omitempty"`
+	DividerStyle     string    `json:"divider_style,omitempty"`
+	DividerThickness int       `json:"divider_thickness,omitempty"`
 }
 
 type BlocksContent struct {

--- a/backend/internal/templates/sale_pages/blocks.html
+++ b/backend/internal/templates/sale_pages/blocks.html
@@ -100,6 +100,23 @@
             fill: currentColor;
             flex-shrink: 0;
         }
+        .block-video {
+            width: 100%;
+            margin: 0;
+            display: block;
+        }
+        .block-video video {
+            width: 100%;
+            height: auto;
+            display: block;
+        }
+        .block-divider {
+            margin: 1rem 1.5rem;
+            border: 0;
+            border-top-style: solid;
+            border-top-width: 1px;
+            border-top-color: rgba(0,0,0,0.15);
+        }
         .footer {
             padding: 1rem 1.5rem;
             text-align: center;
@@ -147,6 +164,16 @@
                     {{.ButtonText}}
                 </a>
                 {{end}}
+            {{end}}
+
+            {{if eq .Type "video"}}
+            <div class="block-video">
+                <video src="{{.VideoURL}}" controls preload="metadata" playsinline></video>
+            </div>
+            {{end}}
+
+            {{if eq .Type "divider"}}
+            <hr class="block-divider" style="border-top-style: {{if .DividerStyle}}{{.DividerStyle}}{{else}}solid{{end}}; border-top-width: {{if .DividerThickness}}{{.DividerThickness}}{{else}}1{{end}}px;">
             {{end}}
         {{end}}
 

--- a/frontend/src/components/sale-pages/BlockEditor.tsx
+++ b/frontend/src/components/sale-pages/BlockEditor.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { ChevronUp, ChevronDown, Trash2, Image, Type, MessageCircle, Globe, Link, Upload, Loader2 } from 'lucide-react'
+import { ChevronUp, ChevronDown, Trash2, Image, Type, MessageCircle, Globe, Link, Upload, Loader2, Film, Minus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -69,12 +69,21 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
     button_url: '',
     button_value: '',
   })
+  const addVideoBlock = () => addBlock({ id: crypto.randomUUID(), type: 'video', video_url: '' })
+  const addDividerBlock = () => addBlock({
+    id: crypto.randomUUID(),
+    type: 'divider',
+    divider_style: 'solid',
+    divider_thickness: 1,
+  })
 
   const getTypeBadge = (type: string) => {
     switch (type) {
       case 'image': return <Badge variant="secondary">รูปภาพ</Badge>
       case 'text': return <Badge variant="secondary">ข้อความ</Badge>
       case 'button': return <Badge variant="secondary">ปุ่ม</Badge>
+      case 'video': return <Badge variant="secondary">วิดีโอ</Badge>
+      case 'divider': return <Badge variant="secondary">เส้นคั่น</Badge>
       default: return null
     }
   }
@@ -208,6 +217,45 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
               )}
             </div>
           )}
+
+          {block.type === 'video' && (
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">URL วิดีโอ (mp4)</Label>
+              <Input
+                type="url"
+                placeholder="https://example.com/video.mp4"
+                value={block.video_url ?? ''}
+                onChange={(e) => updateBlock(index, { video_url: e.target.value })}
+              />
+            </div>
+          )}
+
+          {block.type === 'divider' && (
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label className="text-xs text-muted-foreground">รูปแบบเส้น</Label>
+                <select
+                  className="w-full mt-1 border border-input rounded-md px-3 py-2 text-sm bg-background"
+                  value={block.divider_style ?? 'solid'}
+                  onChange={(e) => updateBlock(index, { divider_style: e.target.value as 'solid' | 'dashed' | 'dotted' })}
+                >
+                  <option value="solid">เส้นทึบ</option>
+                  <option value="dashed">เส้นประ</option>
+                  <option value="dotted">จุด</option>
+                </select>
+              </div>
+              <div>
+                <Label className="text-xs text-muted-foreground">ความหนา (px)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={block.divider_thickness ?? 1}
+                  onChange={(e) => updateBlock(index, { divider_thickness: Number(e.target.value) })}
+                />
+              </div>
+            </div>
+          )}
         </div>
       ))}
 
@@ -241,6 +289,14 @@ export function BlockEditor({ blocks, onChange }: BlockEditorProps) {
           <Button type="button" variant="outline" size="sm" onClick={() => addButtonBlock('custom')}>
             <Link className="h-3.5 w-3.5" />
             ปุ่มลิงก์
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={addVideoBlock}>
+            <Film className="h-3.5 w-3.5" />
+            วิดีโอ
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={addDividerBlock}>
+            <Minus className="h-3.5 w-3.5" />
+            เส้นคั่น
           </Button>
         </div>
       </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,8 +105,9 @@ export interface SalePageContent {
 }
 
 // Block-based content (v2)
-export type BlockType = 'image' | 'text' | 'button'
+export type BlockType = 'image' | 'text' | 'button' | 'video' | 'divider'
 export type ButtonStyle = 'line' | 'website' | 'custom'
+export type DividerStyle = 'solid' | 'dashed' | 'dotted'
 
 export interface Block {
   id: string
@@ -118,6 +119,9 @@ export interface Block {
   button_text?: string
   button_url?: string
   button_value?: string
+  video_url?: string
+  divider_style?: DividerStyle
+  divider_thickness?: number
 }
 
 export interface TrackingConfig {


### PR DESCRIPTION
## Summary
- Add two new block types: \`video\` (mp4 URL) and \`divider\` (customizable style + thickness)
- Frontend: extend \`Block\` interface and \`BlockType\` union, add editor controls + toolbar buttons (\`Film\`, \`Minus\` icons)
- Backend: extend \`Block\` struct with \`VideoURL\`, \`DividerStyle\`, \`DividerThickness\` fields + new \`BlockType\` consts
- Template: only \`blocks.html\` renders blocks — added CSS rules and \`{{if eq .Type ...}}\` branches for both new types

## Implementation Notes
- \`simple.html\` and \`tracking.html\` don't render blocks — only \`blocks.html\` was modified (verified by grep)
- Backwards compatible: existing image/text/button blocks unchanged; new JSON fields are \`omitempty\`
- Video uses external mp4 URL only (no upload — leverages existing image-upload-only infra)
- Divider defaults: \`solid\`, 1px thickness, light gray (\`rgba(0,0,0,0.15)\`)

## Test Plan
- [x] \`go build ./...\` passes
- [x] \`go test\` passes  
- [x] \`npx tsc -b --noEmit\` passes
- [x] \`npm run lint\` passes
- [ ] Manual: create a sale page, add a video block with sample mp4 URL, save, open public \`/p/<slug>\` → video renders with controls
- [ ] Manual: add divider block with \`dashed\` style + 3px thickness, verify on public page
- [ ] Manual: existing sale pages still render correctly (no migration needed — \`omitempty\` keeps old payloads valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)