### PR TITLE
test(repo): add integration tests for pixel/event/replay_credit repos (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,20 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: pixlinks
+          POSTGRES_PASSWORD: pixlinks_dev
+          POSTGRES_DB: pixlinks
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pixlinks"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -56,6 +70,11 @@ jobs:
 
       - name: go test
         run: go test -race -count=1 ./...
+
+      - name: Run integration tests
+        env:
+          TEST_DATABASE_URL: postgres://pixlinks:pixlinks_dev@localhost:5432/pixlinks?sslmode=disable
+        run: go test -race -tags=integration ./internal/repository/postgres/... -v
 
       - name: go build
         run: go build -o /dev/null ./cmd/server

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,27 @@
+# Keep-PX Backend
+
+## Running Integration Tests
+
+Integration tests ในโฟลเดอร์ `internal/repository/postgres/` ใช้ Postgres จริง เพื่อ verify SQL queries และ token encryption
+
+### Local
+
+```bash
+# 1. รัน Postgres ผ่าน docker compose
+docker compose up -d postgres
+
+# 2. รัน integration tests (build tag จำเป็น)
+cd backend
+TEST_DATABASE_URL="postgres://pixlinks:pixlinks_dev@localhost:5432/pixlinks?sslmode=disable" \
+  go test -race -tags=integration -v ./internal/repository/postgres/...
+```
+
+### CI
+
+GitHub Actions รันอัตโนมัติผ่าน Postgres service container — ไม่ต้อง config เพิ่ม
+
+### ข้อควรรู้
+
+- ทุก test จะ `TRUNCATE` ตารางก่อน → state isolated
+- ถ้า DB ไม่ตอบ test จะถูก `t.Skip` แทนที่จะ fail
+- Build tag `//go:build integration` แยก integration test ออกจาก unit test เดิม

--- a/backend/internal/repository/postgres/event_repo_integration_test.go
+++ b/backend/internal/repository/postgres/event_repo_integration_test.go
@@ -1,0 +1,428 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+	"github.com/jaochai/pixlinks/backend/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCtx(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 10*time.Second)
+}
+
+func TestEventRepo_Create_NewEvent(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	e := &domain.PixelEvent{
+		PixelID:   pixel.ID,
+		EventName: "Purchase",
+		EventData: json.RawMessage(`{"value":250,"currency":"THB"}`),
+		UserData:  json.RawMessage(`{"em":["abc"]}`),
+		SourceURL: "https://example.com/checkout",
+		EventTime: time.Now(),
+		EventID:   "evt_new_1",
+	}
+
+	inserted, err := repo.Create(ctx, e)
+	require.NoError(t, err)
+	assert.True(t, inserted, "first insert should return true")
+	assert.NotEmpty(t, e.ID, "ID should be populated after insert")
+	assert.False(t, e.ForwardedToCAPI, "new event must default to forwarded=false")
+	assert.False(t, e.CreatedAt.IsZero(), "CreatedAt should be populated")
+}
+
+func TestEventRepo_Create_DuplicateEventID(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	first := &domain.PixelEvent{
+		PixelID:   pixel.ID,
+		EventName: "Purchase",
+		EventData: json.RawMessage(`{}`),
+		UserData:  json.RawMessage(`{}`),
+		SourceURL: "https://example.com",
+		EventTime: time.Now(),
+		EventID:   "evt_dup",
+	}
+	inserted, err := repo.Create(ctx, first)
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	dup := &domain.PixelEvent{
+		PixelID:   pixel.ID,
+		EventName: "Purchase",
+		EventData: json.RawMessage(`{}`),
+		UserData:  json.RawMessage(`{}`),
+		SourceURL: "https://example.com",
+		EventTime: time.Now(),
+		EventID:   "evt_dup",
+	}
+	inserted2, err := repo.Create(ctx, dup)
+	require.NoError(t, err)
+	assert.False(t, inserted2, "second insert with same (pixel_id, event_id) must return false")
+}
+
+func TestEventRepo_Create_EmptyEventID_BypassesDedup(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	// Production behavior note: EventRepo.Create passes e.EventID (Go string) directly,
+	// so an empty value is stored as '' (empty string), NOT NULL. The partial unique
+	// index `WHERE event_id IS NOT NULL` therefore still applies to ''. This is a
+	// latent behavior — clients that omit event_id will collide with each other.
+	// This test pins the current behavior so any future change is intentional.
+	first := &domain.PixelEvent{
+		PixelID: pixel.ID, EventName: "PageView",
+		EventData: json.RawMessage(`{}`), UserData: json.RawMessage(`{}`),
+		SourceURL: "https://example.com", EventTime: time.Now(),
+	}
+	inserted, err := repo.Create(ctx, first)
+	require.NoError(t, err)
+	assert.True(t, inserted, "first insert with empty event_id succeeds")
+
+	second := &domain.PixelEvent{
+		PixelID: pixel.ID, EventName: "PageView",
+		EventData: json.RawMessage(`{}`), UserData: json.RawMessage(`{}`),
+		SourceURL: "https://example.com", EventTime: time.Now(),
+	}
+	inserted, err = repo.Create(ctx, second)
+	require.NoError(t, err)
+	assert.False(t, inserted, "second insert with same empty event_id collides — '' is treated as a dedup key")
+
+	_, total, err := repo.ListByPixelID(ctx, pixel.ID, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "only first insert persists due to '' dedup collision")
+}
+
+func TestEventRepo_GetByID_Found(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+	created := testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) {
+		e.EventID = "evt_lookup"
+		e.ClientIP = "1.2.3.4"
+		e.ClientUserAgent = "ua-test"
+	})
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	got, err := repo.GetByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, pixel.ID, got.PixelID)
+	assert.Equal(t, "Purchase", got.EventName)
+	assert.Equal(t, "evt_lookup", got.EventID)
+	assert.Equal(t, "1.2.3.4", got.ClientIP)
+	assert.Equal(t, "ua-test", got.ClientUserAgent)
+}
+
+func TestEventRepo_GetByID_NotFound(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	got, err := repo.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
+	require.NoError(t, err)
+	assert.Nil(t, got, "missing id must return (nil, nil)")
+}
+
+func TestEventRepo_ListByPixelID_PaginationAndOrder(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	// insert 5 events with increasing event_time
+	base := time.Now().Add(-5 * time.Hour)
+	for i := 0; i < 5; i++ {
+		i := i
+		testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) {
+			e.EventTime = base.Add(time.Duration(i) * time.Hour)
+			e.EventName = "Purchase"
+		})
+	}
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	// page 1: limit 2 → newest 2 first
+	page1, total, err := repo.ListByPixelID(ctx, pixel.ID, 2, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+	require.Len(t, page1, 2)
+	assert.True(t, page1[0].EventTime.After(page1[1].EventTime) || page1[0].EventTime.Equal(page1[1].EventTime),
+		"results must be ordered by event_time DESC")
+
+	// page 2: offset 2 limit 2
+	page2, _, err := repo.ListByPixelID(ctx, pixel.ID, 2, 2)
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	assert.True(t, page1[1].EventTime.After(page2[0].EventTime) || page1[1].EventTime.Equal(page2[0].EventTime),
+		"page2 must be older than end of page1")
+
+	// page 3: offset 4 limit 2 → only 1 left
+	page3, _, err := repo.ListByPixelID(ctx, pixel.ID, 2, 4)
+	require.NoError(t, err)
+	assert.Len(t, page3, 1)
+}
+
+func TestEventRepo_ListByCustomerID_Filters(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixelA := testutil.CreateTestPixel(t, pool, customer.ID)
+	pixelB := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	now := time.Now()
+	// pixelA: 2 Purchase (in range), 1 PageView (in range), 1 Purchase (out of range)
+	testutil.CreateTestEvent(t, pool, pixelA.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-1 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixelA.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-2 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixelA.ID, func(e *domain.PixelEvent) { e.EventName = "PageView"; e.EventTime = now.Add(-3 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixelA.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-48 * time.Hour) })
+	// pixelB: 1 Purchase in range
+	testutil.CreateTestEvent(t, pool, pixelB.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-1 * time.Hour) })
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	// no filters → 5 events total
+	_, total, err := repo.ListByCustomerID(ctx, customer.ID, "", "", nil, nil, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	// filter by pixelID
+	_, total, err = repo.ListByCustomerID(ctx, customer.ID, pixelB.ID, "", nil, nil, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+
+	// filter by event name
+	_, total, err = repo.ListByCustomerID(ctx, customer.ID, "", "Purchase", nil, nil, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+
+	// filter by date range (last 24h) → exclude the -48h event
+	from := now.Add(-24 * time.Hour)
+	to := now
+	events, total, err := repo.ListByCustomerID(ctx, customer.ID, "", "", &from, &to, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, total)
+	assert.Len(t, events, 4)
+
+	// combined: pixelA + Purchase + last 24h → 2
+	_, total, err = repo.ListByCustomerID(ctx, customer.ID, pixelA.ID, "Purchase", &from, &to, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+}
+
+func TestEventRepo_MarkForwarded(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+	created := testutil.CreateTestEvent(t, pool, pixel.ID)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	err := repo.MarkForwarded(ctx, created.ID, 200, 1)
+	require.NoError(t, err)
+
+	got, err := repo.GetByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.ForwardedToCAPI, "forwarded_to_capi must be true")
+	require.NotNil(t, got.CAPIResponseCode)
+	assert.Equal(t, 200, *got.CAPIResponseCode)
+	require.NotNil(t, got.CAPIEventsReceived)
+	assert.Equal(t, 1, *got.CAPIEventsReceived)
+}
+
+func TestEventRepo_GetEventsForReplay_Filters(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	now := time.Now()
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-1 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "PageView"; e.EventTime = now.Add(-2 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase"; e.EventTime = now.Add(-3 * time.Hour) })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "Lead"; e.EventTime = now.Add(-48 * time.Hour) })
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	// filter by event types
+	events, err := repo.GetEventsForReplay(ctx, pixel.ID, []string{"Purchase"}, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
+	for _, e := range events {
+		assert.Equal(t, "Purchase", e.EventName)
+	}
+
+	// filter by date range (last 24h)
+	from := now.Add(-24 * time.Hour)
+	to := now
+	events, err = repo.GetEventsForReplay(ctx, pixel.ID, nil, &from, &to, nil)
+	require.NoError(t, err)
+	assert.Len(t, events, 3, "should exclude the -48h Lead event")
+
+	// ordering ASC
+	if len(events) >= 2 {
+		assert.True(t, events[0].EventTime.Before(events[1].EventTime) || events[0].EventTime.Equal(events[1].EventTime),
+			"replay results must be ordered ASC by event_time")
+	}
+
+	// createdBefore in the past → exclude all (events were just created)
+	past := now.Add(-1 * time.Hour)
+	events, err = repo.GetEventsForReplay(ctx, pixel.ID, nil, nil, nil, &past)
+	require.NoError(t, err)
+	assert.Empty(t, events, "createdBefore in past should exclude freshly-inserted rows")
+}
+
+func TestEventRepo_GetDistinctEventTypes(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase" })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "Purchase" })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "PageView" })
+	testutil.CreateTestEvent(t, pool, pixel.ID, func(e *domain.PixelEvent) { e.EventName = "AddToCart" })
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	types, err := repo.GetDistinctEventTypes(ctx, pixel.ID)
+	require.NoError(t, err)
+	// ORDER BY event_name → AddToCart, PageView, Purchase
+	assert.Equal(t, []string{"AddToCart", "PageView", "Purchase"}, types)
+}
+
+func TestEventRepo_DeleteOlderThan(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	// Insert 4 events, then back-date 2 of them via raw UPDATE
+	old1 := testutil.CreateTestEvent(t, pool, pixel.ID)
+	old2 := testutil.CreateTestEvent(t, pool, pixel.ID)
+	_ = testutil.CreateTestEvent(t, pool, pixel.ID) // fresh
+	_ = testutil.CreateTestEvent(t, pool, pixel.ID) // fresh
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	oldTime := time.Now().Add(-30 * 24 * time.Hour)
+	_, err := pool.Exec(ctx, `UPDATE pixel_events SET created_at = $1 WHERE id IN ($2, $3)`,
+		oldTime, old1.ID, old2.ID)
+	require.NoError(t, err)
+
+	// Delete with batchSize=1 → should remove only one row at a time
+	before := time.Now().Add(-7 * 24 * time.Hour)
+	deleted, err := repo.DeleteOlderThan(ctx, before, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "batchSize=1 must cap deletion at 1 row")
+
+	// Delete the remaining old row
+	deleted, err = repo.DeleteOlderThan(ctx, before, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	// Third pass — nothing left to delete
+	deleted, err = repo.DeleteOlderThan(ctx, before, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), deleted)
+
+	// fresh events untouched
+	_, total, err := repo.ListByPixelID(ctx, pixel.ID, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "fresh events must remain")
+}
+
+func TestEventRepo_DeleteExpiredByRetention(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	repo := NewEventRepo(pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+
+	ctx, cancel := newCtx(t)
+	defer cancel()
+
+	// Force retention_days = 1 for this customer
+	_, err := pool.Exec(ctx, `UPDATE customers SET retention_days = 1 WHERE id = $1`, customer.ID)
+	require.NoError(t, err)
+
+	// Insert events; back-date 2 of them by 2 days (older than retention)
+	old1 := testutil.CreateTestEvent(t, pool, pixel.ID)
+	old2 := testutil.CreateTestEvent(t, pool, pixel.ID)
+	_ = testutil.CreateTestEvent(t, pool, pixel.ID) // fresh, must survive
+
+	twoDaysAgo := time.Now().Add(-2 * 24 * time.Hour)
+	_, err = pool.Exec(ctx, `UPDATE pixel_events SET created_at = $1 WHERE id IN ($2, $3)`,
+		twoDaysAgo, old1.ID, old2.ID)
+	require.NoError(t, err)
+
+	deleted, err := repo.DeleteExpiredByRetention(ctx, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted, "both back-dated rows should be deleted")
+
+	_, total, err := repo.ListByPixelID(ctx, pixel.ID, 100, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "fresh event should remain")
+}

--- a/backend/internal/repository/postgres/pixel_repo_integration_test.go
+++ b/backend/internal/repository/postgres/pixel_repo_integration_test.go
@@ -1,0 +1,340 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jaochai/pixlinks/backend/internal/crypto"
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+	"github.com/jaochai/pixlinks/backend/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newEncryptor builds a TokenEncryptor backed by a random 32-byte key.
+func newEncryptor(t *testing.T) *crypto.TokenEncryptor {
+	t.Helper()
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	enc, err := crypto.NewTokenEncryptor(key)
+	require.NoError(t, err)
+	return enc
+}
+
+// rawTokenFromDB reads fb_access_token directly via SQL, bypassing the repo.
+func rawTokenFromDB(t *testing.T, pool *pgxpool.Pool, pixelID string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var token string
+	err := pool.QueryRow(ctx,
+		`SELECT fb_access_token FROM pixels WHERE id = $1`, pixelID,
+	).Scan(&token)
+	require.NoError(t, err)
+	return token
+}
+
+func TestPixelRepo_Create_WithoutEncryptor(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	repo := NewPixelRepo(pool, nil)
+
+	ctx := context.Background()
+	p := &domain.Pixel{
+		CustomerID:    customer.ID,
+		FBPixelID:     "9999999999",
+		FBAccessToken: "plaintext-token",
+		Name:          "Plain Pixel",
+	}
+	require.NoError(t, repo.Create(ctx, p))
+
+	assert.NotEmpty(t, p.ID, "ID should be populated")
+	assert.True(t, p.IsActive, "IsActive should default to true")
+	assert.False(t, p.CreatedAt.IsZero(), "CreatedAt should be populated")
+	assert.False(t, p.UpdatedAt.IsZero(), "UpdatedAt should be populated")
+
+	// Verify stored value is plaintext (no enc: prefix).
+	raw := rawTokenFromDB(t, pool, p.ID)
+	assert.Equal(t, "plaintext-token", raw)
+	assert.False(t, crypto.IsEncrypted(raw))
+}
+
+func TestPixelRepo_Create_WithEncryptor(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	enc := newEncryptor(t)
+	repo := NewPixelRepo(pool, enc)
+
+	ctx := context.Background()
+	p := &domain.Pixel{
+		CustomerID:    customer.ID,
+		FBPixelID:     "1111111111",
+		FBAccessToken: "super-secret-token",
+		Name:          "Encrypted Pixel",
+	}
+	require.NoError(t, repo.Create(ctx, p))
+	require.NotEmpty(t, p.ID)
+
+	raw := rawTokenFromDB(t, pool, p.ID)
+	assert.True(t, crypto.IsEncrypted(raw), "stored token should have enc: prefix, got %q", raw)
+	assert.NotEqual(t, "super-secret-token", raw)
+}
+
+func TestPixelRepo_GetByID_WithEncryptor_DecryptsToken(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	enc := newEncryptor(t)
+	repo := NewPixelRepo(pool, enc)
+
+	ctx := context.Background()
+	original := "round-trip-token-xyz"
+	p := &domain.Pixel{
+		CustomerID:    customer.ID,
+		FBPixelID:     "2222222222",
+		FBAccessToken: original,
+		Name:          "Round Trip",
+	}
+	require.NoError(t, repo.Create(ctx, p))
+
+	// Sanity: stored encrypted.
+	raw := rawTokenFromDB(t, pool, p.ID)
+	require.True(t, crypto.IsEncrypted(raw))
+
+	got, err := repo.GetByID(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, original, got.FBAccessToken, "token should be decrypted back to plaintext")
+	assert.Equal(t, p.ID, got.ID)
+	assert.Equal(t, customer.ID, got.CustomerID)
+	assert.Equal(t, "2222222222", got.FBPixelID)
+}
+
+func TestPixelRepo_GetByID_NotFound_ReturnsNilNil(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	repo := NewPixelRepo(pool, nil)
+	ctx := context.Background()
+
+	// Use a syntactically valid UUID that does not exist.
+	got, err := repo.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestPixelRepo_GetByIDs_Batch(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	enc := newEncryptor(t)
+	repo := NewPixelRepo(pool, enc)
+
+	ctx := context.Background()
+	pixels := make([]*domain.Pixel, 3)
+	ids := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		p := &domain.Pixel{
+			CustomerID:    customer.ID,
+			FBPixelID:     "33333333" + string(rune('0'+i)),
+			FBAccessToken: "tok-" + string(rune('a'+i)),
+			Name:          "Batch Pixel",
+		}
+		require.NoError(t, repo.Create(ctx, p))
+		pixels[i] = p
+		ids[i] = p.ID
+	}
+
+	got, err := repo.GetByIDs(ctx, ids)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// Verify each token was decrypted.
+	tokens := map[string]string{}
+	for _, p := range got {
+		tokens[p.ID] = p.FBAccessToken
+	}
+	for i, p := range pixels {
+		assert.Equal(t, "tok-"+string(rune('a'+i)), tokens[p.ID])
+	}
+}
+
+func TestPixelRepo_GetByIDs_EmptyInput(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	repo := NewPixelRepo(pool, nil)
+	got, err := repo.GetByIDs(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = repo.GetByIDs(context.Background(), []string{})
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestPixelRepo_ListByCustomerID_OrderedAndScoped(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customerA := testutil.CreateTestCustomer(t, pool)
+	customerB := testutil.CreateTestCustomer(t, pool)
+	repo := NewPixelRepo(pool, nil)
+	ctx := context.Background()
+
+	// Create 3 pixels for A with deliberate delay so created_at differs.
+	var aIDs []string
+	for i := 0; i < 3; i++ {
+		p := &domain.Pixel{
+			CustomerID:    customerA.ID,
+			FBPixelID:     "44444444" + string(rune('0'+i)),
+			FBAccessToken: "a-tok",
+			Name:          "A Pixel",
+		}
+		require.NoError(t, repo.Create(ctx, p))
+		aIDs = append(aIDs, p.ID)
+		time.Sleep(10 * time.Millisecond)
+	}
+	// And 1 pixel for B (should not leak into A's list).
+	bPixel := &domain.Pixel{
+		CustomerID:    customerB.ID,
+		FBPixelID:     "5555555555",
+		FBAccessToken: "b-tok",
+		Name:          "B Pixel",
+	}
+	require.NoError(t, repo.Create(ctx, bPixel))
+
+	got, err := repo.ListByCustomerID(ctx, customerA.ID)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// All belong to customer A.
+	for _, p := range got {
+		assert.Equal(t, customerA.ID, p.CustomerID)
+	}
+
+	// Ordered created_at DESC → newest (last created) first.
+	assert.Equal(t, aIDs[2], got[0].ID)
+	assert.Equal(t, aIDs[1], got[1].ID)
+	assert.Equal(t, aIDs[0], got[2].ID)
+
+	// Sanity: B sees just its own.
+	gotB, err := repo.ListByCustomerID(ctx, customerB.ID)
+	require.NoError(t, err)
+	require.Len(t, gotB, 1)
+	assert.Equal(t, bPixel.ID, gotB[0].ID)
+}
+
+func TestPixelRepo_CountByCustomerID(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	repo := NewPixelRepo(pool, nil)
+	ctx := context.Background()
+
+	// Initially zero.
+	count, err := repo.CountByCustomerID(ctx, customer.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	// Insert 4 pixels.
+	for i := 0; i < 4; i++ {
+		testutil.CreateTestPixel(t, pool, customer.ID)
+	}
+
+	count, err = repo.CountByCustomerID(ctx, customer.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 4, count)
+
+	// Unrelated customer still sees zero.
+	other := testutil.CreateTestCustomer(t, pool)
+	count, err = repo.CountByCustomerID(ctx, other.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestPixelRepo_Update_ReEncryptsToken(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	enc := newEncryptor(t)
+	repo := NewPixelRepo(pool, enc)
+	ctx := context.Background()
+
+	p := &domain.Pixel{
+		CustomerID:    customer.ID,
+		FBPixelID:     "6666666666",
+		FBAccessToken: "old-token",
+		Name:          "Before",
+	}
+	require.NoError(t, repo.Create(ctx, p))
+
+	// Mutate fields and update.
+	p.FBAccessToken = "brand-new-token"
+	p.Name = "After"
+	p.IsActive = false
+	require.NoError(t, repo.Update(ctx, p))
+
+	// Raw stored value must be encrypted (not the plaintext).
+	raw := rawTokenFromDB(t, pool, p.ID)
+	assert.True(t, crypto.IsEncrypted(raw), "updated token should be encrypted, got %q", raw)
+	assert.NotEqual(t, "brand-new-token", raw)
+
+	// And decrypt back via GetByID.
+	got, err := repo.GetByID(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "brand-new-token", got.FBAccessToken)
+	assert.Equal(t, "After", got.Name)
+	assert.False(t, got.IsActive)
+}
+
+func TestPixelRepo_Delete_CascadesToEvents(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+
+	customer := testutil.CreateTestCustomer(t, pool)
+	repo := NewPixelRepo(pool, nil)
+	ctx := context.Background()
+
+	pixel := testutil.CreateTestPixel(t, pool, customer.ID)
+	// Insert two events for that pixel.
+	testutil.CreateTestEvent(t, pool, pixel.ID)
+	testutil.CreateTestEvent(t, pool, pixel.ID)
+
+	// Sanity: events exist.
+	var before int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM pixel_events WHERE pixel_id = $1`, pixel.ID,
+	).Scan(&before))
+	require.Equal(t, 2, before)
+
+	// Delete the pixel.
+	require.NoError(t, repo.Delete(ctx, pixel.ID))
+
+	// Pixel is gone.
+	got, err := repo.GetByID(ctx, pixel.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Events were cascaded.
+	var after int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM pixel_events WHERE pixel_id = $1`, pixel.ID,
+	).Scan(&after))
+	assert.Equal(t, 0, after, "pixel_events should be cascade-deleted")
+}

--- a/backend/internal/repository/postgres/replay_credit_repo_integration_test.go
+++ b/backend/internal/repository/postgres/replay_credit_repo_integration_test.go
@@ -1,0 +1,378 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+	"github.com/jaochai/pixlinks/backend/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newReplayCredit(customerID string) *domain.ReplayCredit {
+	return &domain.ReplayCredit{
+		CustomerID:         customerID,
+		PackType:           "pack_10",
+		TotalReplays:       10,
+		UsedReplays:        0,
+		MaxEventsPerReplay: 0,
+		ExpiresAt:          time.Now().Add(30 * 24 * time.Hour),
+	}
+}
+
+func TestReplayCreditRepo_CreateAndGetByID(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	require.NoError(t, repo.Create(ctx, c))
+	assert.NotEmpty(t, c.ID, "ID should be populated")
+	assert.False(t, c.CreatedAt.IsZero(), "CreatedAt should be populated")
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, c.ID, got.ID)
+	assert.Equal(t, customer.ID, got.CustomerID)
+	assert.Equal(t, "pack_10", got.PackType)
+	assert.Equal(t, 10, got.TotalReplays)
+	assert.Equal(t, 0, got.UsedReplays)
+	assert.Equal(t, 0, got.MaxEventsPerReplay)
+	assert.WithinDuration(t, c.ExpiresAt, got.ExpiresAt, time.Second)
+}
+
+func TestReplayCreditRepo_GetByID_NotFound(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	got, err := repo.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestReplayCreditRepo_GetActiveByCustomerID_FiltersExhaustedAndExpired(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	// A: active — still has replays and not expired
+	active := newReplayCredit(customer.ID)
+	active.PackType = "active"
+	active.ExpiresAt = time.Now().Add(30 * 24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, active))
+
+	// B: exhausted — used == total
+	exhausted := newReplayCredit(customer.ID)
+	exhausted.PackType = "exhausted"
+	exhausted.TotalReplays = 5
+	exhausted.UsedReplays = 5
+	require.NoError(t, repo.Create(ctx, exhausted))
+
+	// C: expired — expires_at in the past
+	expired := newReplayCredit(customer.ID)
+	expired.PackType = "expired"
+	expired.ExpiresAt = time.Now().Add(-24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, expired))
+
+	credits, err := repo.GetActiveByCustomerID(ctx, customer.ID)
+	require.NoError(t, err)
+	require.Len(t, credits, 1)
+	assert.Equal(t, active.ID, credits[0].ID)
+	assert.Equal(t, "active", credits[0].PackType)
+}
+
+func TestReplayCreditRepo_GetActiveByCustomerID_OrderedByExpiresAtASC(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	later := newReplayCredit(customer.ID)
+	later.PackType = "later"
+	later.ExpiresAt = time.Now().Add(60 * 24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, later))
+
+	sooner := newReplayCredit(customer.ID)
+	sooner.PackType = "sooner"
+	sooner.ExpiresAt = time.Now().Add(30 * 24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, sooner))
+
+	credits, err := repo.GetActiveByCustomerID(ctx, customer.ID)
+	require.NoError(t, err)
+	require.Len(t, credits, 2)
+	assert.Equal(t, sooner.ID, credits[0].ID, "earliest expiry should be first")
+	assert.Equal(t, later.ID, credits[1].ID)
+}
+
+func TestReplayCreditRepo_IncrementUsed_Normal(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	require.NoError(t, repo.Create(ctx, c))
+
+	require.NoError(t, repo.IncrementUsed(ctx, c.ID))
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.UsedReplays)
+}
+
+func TestReplayCreditRepo_IncrementUsed_Exhausted(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	c.TotalReplays = 3
+	c.UsedReplays = 3
+	require.NoError(t, repo.Create(ctx, c))
+
+	err := repo.IncrementUsed(ctx, c.ID)
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, got.UsedReplays, "used should not change on exhausted increment")
+}
+
+func TestReplayCreditRepo_IncrementUsed_Unlimited(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	c.TotalReplays = -1 // unlimited
+	c.UsedReplays = 1000
+	require.NoError(t, repo.Create(ctx, c))
+
+	// Should be able to increment many times without hitting a limit.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, repo.IncrementUsed(ctx, c.ID))
+	}
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1005, got.UsedReplays)
+}
+
+func TestReplayCreditRepo_RefundCredit(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	c.UsedReplays = 3
+	require.NoError(t, repo.Create(ctx, c))
+
+	require.NoError(t, repo.RefundCredit(ctx, c.ID))
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.UsedReplays)
+}
+
+func TestReplayCreditRepo_RefundCredit_ZeroUsed(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	c.UsedReplays = 0
+	require.NoError(t, repo.Create(ctx, c))
+
+	err := repo.RefundCredit(ctx, c.ID)
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.UsedReplays)
+}
+
+func TestReplayCreditRepo_ConsumeOneCredit_HappyPath(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	require.NoError(t, repo.Create(ctx, c))
+
+	consumed, err := repo.ConsumeOneCredit(ctx, customer.ID, 50)
+	require.NoError(t, err)
+	require.NotNil(t, consumed)
+	assert.Equal(t, c.ID, consumed.ID)
+	assert.Equal(t, 1, consumed.UsedReplays)
+
+	// Verify DB matches the returned value.
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.UsedReplays)
+}
+
+func TestReplayCreditRepo_ConsumeOneCredit_NoCredits(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	consumed, err := repo.ConsumeOneCredit(ctx, customer.ID, 50)
+	require.NoError(t, err)
+	assert.Nil(t, consumed)
+}
+
+func TestReplayCreditRepo_ConsumeOneCredit_RespectsMaxEventsPerReplay(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	c := newReplayCredit(customer.ID)
+	c.MaxEventsPerReplay = 100
+	require.NoError(t, repo.Create(ctx, c))
+
+	// Asking for more than the credit allows -> not eligible.
+	consumed, err := repo.ConsumeOneCredit(ctx, customer.ID, 200)
+	require.NoError(t, err)
+	assert.Nil(t, consumed, "credit with max=100 should not satisfy request for 200")
+
+	// Confirm used was not incremented.
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.UsedReplays)
+
+	// Within limit -> should succeed.
+	consumed, err = repo.ConsumeOneCredit(ctx, customer.ID, 50)
+	require.NoError(t, err)
+	require.NotNil(t, consumed)
+	assert.Equal(t, c.ID, consumed.ID)
+	assert.Equal(t, 1, consumed.UsedReplays)
+}
+
+func TestReplayCreditRepo_ConsumeOneCredit_PicksEarliestExpiry(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	later := newReplayCredit(customer.ID)
+	later.PackType = "later"
+	later.ExpiresAt = time.Now().Add(60 * 24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, later))
+
+	sooner := newReplayCredit(customer.ID)
+	sooner.PackType = "sooner"
+	sooner.ExpiresAt = time.Now().Add(30 * 24 * time.Hour)
+	require.NoError(t, repo.Create(ctx, sooner))
+
+	consumed, err := repo.ConsumeOneCredit(ctx, customer.ID, 10)
+	require.NoError(t, err)
+	require.NotNil(t, consumed)
+	assert.Equal(t, sooner.ID, consumed.ID, "should consume the credit expiring soonest")
+
+	// Verify the other credit was not touched.
+	gotLater, err := repo.GetByID(ctx, later.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, gotLater.UsedReplays)
+}
+
+func TestReplayCreditRepo_ConsumeOneCredit_ConcurrentSafety(t *testing.T) {
+	pool := testutil.NewTestPool(t)
+	testutil.TruncateAll(t, pool)
+	ctx := context.Background()
+
+	repo := NewReplayCreditRepo(pool)
+	customer := testutil.CreateTestCustomer(t, pool)
+
+	const totalReplays = 10
+	const goroutines = 20
+
+	c := newReplayCredit(customer.ID)
+	c.TotalReplays = totalReplays
+	require.NoError(t, repo.Create(ctx, c))
+
+	var (
+		wg           sync.WaitGroup
+		successCount int64
+		nilCount     int64
+	)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			consumed, err := repo.ConsumeOneCredit(ctx, customer.ID, 10)
+			if err != nil {
+				t.Errorf("ConsumeOneCredit returned error: %v", err)
+				return
+			}
+			if consumed != nil {
+				atomic.AddInt64(&successCount, 1)
+			} else {
+				atomic.AddInt64(&nilCount, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// FOR UPDATE SKIP LOCKED: when one goroutine holds the row lock, others skip
+	// and return immediately. Each goroutine attempts ONCE — there is no retry loop.
+	// So successCount may be anywhere from 1 to totalReplays depending on scheduling.
+	// The invariants we MUST verify:
+	//   1. successCount + nilCount == goroutines (no goroutine lost or errored)
+	//   2. successCount <= totalReplays (never over-consume)
+	//   3. DB used_replays == successCount (no lost updates)
+	successes := atomic.LoadInt64(&successCount)
+	nils := atomic.LoadInt64(&nilCount)
+	assert.Equal(t, int64(goroutines), successes+nils, "every goroutine accounted for")
+	assert.LessOrEqual(t, successes, int64(totalReplays), "must never exceed total_replays")
+	assert.Positive(t, successes, "at least one goroutine should succeed")
+
+	got, err := repo.GetByID(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int(successes), got.UsedReplays,
+		"DB used_replays must equal observed success count (no lost updates)")
+	assert.LessOrEqual(t, got.UsedReplays, totalReplays,
+		"used_replays must not exceed total_replays under concurrency")
+}

--- a/backend/internal/testutil/fixtures.go
+++ b/backend/internal/testutil/fixtures.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jaochai/pixlinks/backend/internal/domain"
+)
+
+// CreateTestCustomer inserts a customer with random email + API key and
+// returns the created row (with ID / timestamps populated).
+func CreateTestCustomer(t *testing.T, pool *pgxpool.Pool) *domain.Customer {
+	t.Helper()
+	c := &domain.Customer{
+		Email:         fmt.Sprintf("test-%s@keep-px.local", randomHex(8)),
+		Name:          "Test User",
+		APIKey:        "pk_" + randomHex(16),
+		Plan:          "free",
+		RetentionDays: 7,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pool.QueryRow(ctx,
+		`INSERT INTO customers (email, password_hash, name, api_key, plan, retention_days)
+		 VALUES ($1, '', $2, $3, $4, $5)
+		 RETURNING id, created_at, updated_at`,
+		c.Email, c.Name, c.APIKey, c.Plan, c.RetentionDays,
+	).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt)
+	if err != nil {
+		t.Fatalf("create test customer: %v", err)
+	}
+	return c
+}
+
+// CreateTestPixel inserts a pixel for the given customer with a fixed
+// fb_access_token "test-token" (plaintext — encryption is opt-in per repo).
+func CreateTestPixel(t *testing.T, pool *pgxpool.Pool, customerID string) *domain.Pixel {
+	t.Helper()
+	p := &domain.Pixel{
+		CustomerID:    customerID,
+		FBPixelID:     fmt.Sprintf("123456789%d", time.Now().UnixNano()%10000),
+		FBAccessToken: "test-token",
+		Name:          "Test Pixel",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pool.QueryRow(ctx,
+		`INSERT INTO pixels (customer_id, fb_pixel_id, fb_access_token, name)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id, is_active, created_at, updated_at`,
+		p.CustomerID, p.FBPixelID, p.FBAccessToken, p.Name,
+	).Scan(&p.ID, &p.IsActive, &p.CreatedAt, &p.UpdatedAt)
+	if err != nil {
+		t.Fatalf("create test pixel: %v", err)
+	}
+	return p
+}
+
+// CreateTestEvent inserts a pixel_event row and returns it. Caller may pass
+// an empty PixelEvent — required fields are filled with sensible defaults.
+func CreateTestEvent(t *testing.T, pool *pgxpool.Pool, pixelID string, overrides ...func(*domain.PixelEvent)) *domain.PixelEvent {
+	t.Helper()
+	e := &domain.PixelEvent{
+		PixelID:   pixelID,
+		EventName: "Purchase",
+		EventData: json.RawMessage(`{"value":100,"currency":"THB"}`),
+		UserData:  json.RawMessage(`{"em":["hashed-email"]}`),
+		SourceURL: "https://example.com/checkout",
+		EventTime: time.Now(),
+	}
+	for _, fn := range overrides {
+		fn(e)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := pool.QueryRow(ctx,
+		`INSERT INTO pixel_events (pixel_id, event_name, event_data, user_data, source_url, event_time, event_id, client_ip, client_user_agent)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (pixel_id, event_id) WHERE event_id IS NOT NULL DO NOTHING
+		 RETURNING id, forwarded_to_capi, created_at`,
+		e.PixelID, e.EventName, e.EventData, e.UserData, e.SourceURL, e.EventTime, nullableString(e.EventID), nullableString(e.ClientIP), nullableString(e.ClientUserAgent),
+	).Scan(&e.ID, &e.ForwardedToCAPI, &e.CreatedAt)
+	if err != nil {
+		t.Fatalf("create test event: %v", err)
+	}
+	return e
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/backend/internal/testutil/pgtest.go
+++ b/backend/internal/testutil/pgtest.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+// Package testutil provides shared helpers for integration tests that exercise
+// real Postgres. It is only compiled when the `integration` build tag is set.
+package testutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultTestDatabaseURL = "postgres://pixlinks:pixlinks_dev@localhost:5432/pixlinks?sslmode=disable"
+
+var (
+	migrationsOnce sync.Once
+	migrationsErr  error
+)
+
+// NewTestPool returns a pgxpool connected to the integration test database.
+// It runs migrations once per process and registers a cleanup that closes the
+// pool when the test finishes.
+//
+// Set TEST_DATABASE_URL to point at a Postgres instance (default:
+// `postgres://pixlinks:pixlinks_dev@localhost:5432/pixlinks?sslmode=disable`).
+// The test is skipped when the DB is unreachable so unit-only environments do
+// not fail.
+func NewTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		dbURL = defaultTestDatabaseURL
+	}
+
+	migrationsOnce.Do(func() {
+		migrationsErr = runMigrations(dbURL)
+	})
+	if migrationsErr != nil {
+		t.Skipf("skipping integration test — migrations failed (DB unreachable?): %v", migrationsErr)
+	}
+
+	cfg, err := pgxpool.ParseConfig(dbURL)
+	if err != nil {
+		t.Fatalf("parse test DB config: %v", err)
+	}
+	cfg.MaxConns = 10
+	cfg.MinConns = 1
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Skipf("skipping integration test — DB unreachable: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("skipping integration test — DB ping failed: %v", err)
+	}
+
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+// TruncateAll wipes every table affected by integration tests. Call at the
+// start of each test to guarantee isolation.
+func TruncateAll(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Discover tables at runtime — schema may drift over time.
+	// Excludes schema_migrations so golang-migrate keeps its bookkeeping.
+	rows, err := pool.Query(ctx,
+		`SELECT tablename FROM pg_tables
+		 WHERE schemaname = 'public' AND tablename != 'schema_migrations'`)
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			t.Fatalf("scan table name: %v", err)
+		}
+		tables = append(tables, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tables: %v", err)
+	}
+	if len(tables) == 0 {
+		return
+	}
+	// CASCADE handles FK chains. Order doesn't matter with CASCADE.
+	stmt := fmt.Sprintf("TRUNCATE %s RESTART IDENTITY CASCADE", joinTables(tables))
+	if _, err := pool.Exec(ctx, stmt); err != nil {
+		t.Fatalf("truncate tables: %v", err)
+	}
+}
+
+func joinTables(tables []string) string {
+	out := ""
+	for i, name := range tables {
+		if i > 0 {
+			out += ", "
+		}
+		out += name
+	}
+	return out
+}
+
+// runMigrations applies all up migrations from backend/db/migrations.
+// Path is resolved relative to this file so tests work from any working dir.
+func runMigrations(databaseURL string) error {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return errors.New("cannot resolve testutil file path")
+	}
+	// thisFile = .../backend/internal/testutil/pgtest.go
+	// migrations  = .../backend/db/migrations
+	backendRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	migrationsPath := filepath.Join(backendRoot, "db", "migrations")
+	if _, err := os.Stat(migrationsPath); err != nil {
+		return fmt.Errorf("stat migrations dir %q: %w", migrationsPath, err)
+	}
+
+	m, err := migrate.New("file://"+migrationsPath, databaseURL)
+	if err != nil {
+		return fmt.Errorf("create migrate instance: %w", err)
+	}
+	defer m.Close()
+
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add integration test infrastructure (`internal/testutil/`) — pgxpool helper that auto-runs migrations, skips on unreachable DB, and truncates all public tables between tests
- Add **35 integration tests** for 3 critical repos: `pixel_repo` (CRUD + token encryption), `event_repo` (dedup + retention), `replay_credit_repo` (incl. concurrent `ConsumeOneCredit` with 20 goroutines verifying `FOR UPDATE SKIP LOCKED` invariants)
- Wire CI to spin up a `postgres:17-alpine` service container and run `go test -tags=integration` after the existing unit suite

## Context

The repository layer (~2,977 lines of raw `pgx` SQL across 20 files) had **zero** integration tests — every service/handler test mocks the repos, so SQL errors, column typos, encryption logic, and concurrency bugs were never verified against a real database. Phase 1 covers the 3 highest-risk repos and lays infrastructure for the remaining 17 in Phase 2.

Tests use `//go:build integration` so the default `go test ./...` keeps running mock-based unit tests untouched.

## Known finding (not fixed here)

`EventRepo.Create` passes `e.EventID` directly as a Go string, so an empty value is stored as `''` rather than `NULL` — the partial unique index `WHERE event_id IS NOT NULL` still applies, meaning clients that omit `event_id` collide with each other. A test pins the current behavior with a comment; fix tracked separately.

## Test plan

- [x] Local: 35/35 integration tests pass (`docker run postgres:17-alpine` + `TEST_DATABASE_URL=... go test -tags=integration ./internal/repository/postgres/...`) in ~2.4s
- [x] No regressions in existing unit tests (`go test -race ./...`)
- [ ] CI: backend job runs unit tests + integration tests via postgres service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)