### PR TITLE
feat(replay): hint that replay does not fan out to backup pixel

### DIFF
--- a/frontend/src/pages/ReplayPage.tsx
+++ b/frontend/src/pages/ReplayPage.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link } from 'react-router'
-import { RotateCcw, Play, AlertTriangle, StopCircle, Eye, CreditCard } from 'lucide-react'
+import { RotateCcw, Play, AlertTriangle, StopCircle, Eye, CreditCard, Info } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -235,6 +235,13 @@ export function ReplayPage() {
                     ))}
                   </select>
                   {errors.target_pixel_id && <p className="text-sm text-red-500">{errors.target_pixel_id.message}</p>}
+                  <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+                    <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                    <span>
+                      Replay ส่งไปยังพิกเซลปลายทางที่เลือกเท่านั้น — ไม่ส่งต่อไปยัง Backup Pixel อัตโนมัติ
+                      หากต้องการ replay ไปยัง backup ด้วย ให้สร้าง replay session อีกชุดโดยเลือก backup เป็นปลายทาง
+                    </span>
+                  </p>
                 </div>
 
                 {eventTypes && eventTypes.length > 0 && (


### PR DESCRIPTION
## Summary

- Add an Info hint under the "พิกเซลปลายทาง" selector on `ReplayPage` explaining that replay only forwards to the chosen target pixel — it does **not** auto-fan-out to `backup_pixel_id` the way real-time ingestion does

## Context

Audit of the codebase surfaced an asymmetry that's not obvious to users:
- `/events/ingest` (real-time): event goes to **primary + backup** automatically (`event_service.go:168-174`)
- `/replays` (historical): event goes to **target only** (`replay_service.go:422`)

This is by design — replay consumes credits and uses the user-selected target — but users with a primary/backup setup may assume backup mirrors primary in all flows and be surprised when historical events don't appear in the backup pixel.

The hint tells them to create a second replay session targeting the backup if they want the same behavior.

## Test plan

- [x] `tsc -b` passes
- [x] Frontend production build passes (via pre-push hook)
- [ ] Visual check on `/replay` page: hint renders under the target pixel selector with `Info` icon and muted styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)