### PR TITLE
chore: react-doctor pre-commit hook + e2e auto-refresh + dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ test-results/
 
 # Git worktrees
 .worktrees/
+
+# Local agent / skill configs (Claude Code, Codex, etc.)
+.claude/skills/learned/
+frontend/.agents/
+frontend/.claude/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,16 @@
 #!/usr/bin/env sh
 
 # react-doctor hook start
+# Probes local install first (frontend/ workspace) so commits use the pinned
+# version from package.json instead of re-downloading @latest on every commit.
+# Hook is intentionally advisory: prints warnings but does not block commits,
+# to allow gradual adoption while the codebase still has known regressions.
 react_doctor_scan_staged_files() {
+  if [ -x "./frontend/node_modules/.bin/react-doctor" ]; then
+    "./frontend/node_modules/.bin/react-doctor" --staged --fail-on warning
+    return
+  fi
+
   if [ -x "./node_modules/.bin/react-doctor" ]; then
     "./node_modules/.bin/react-doctor" --staged --fail-on warning
     return
@@ -25,12 +34,8 @@ react_doctor_scan_staged_files() {
   printf '%s\n' "react-doctor: command not found; skipping staged scan."
 }
 
-react_doctor_output=$(mktemp "${TMPDIR:-/tmp}/react-doctor-hook.XXXXXX")
-if react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then
-  rm -f "$react_doctor_output"
-else
-  rm -f "$react_doctor_output"
-  printf '%s\n' "React Doctor found staged regressions." "Run react-doctor --staged --fail-on warning to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2
+if ! react_doctor_scan_staged_files; then
+  printf '%s\n' "react-doctor: staged scan found regressions (advisory, commit not blocked)." "Run npm --prefix frontend run doctor -- --staged --fail-on warning to inspect." >&2
 fi
 # react-doctor hook end
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,36 @@
 #!/usr/bin/env sh
+
+# react-doctor hook start
+react_doctor_scan_staged_files() {
+  if [ -x "./node_modules/.bin/react-doctor" ]; then
+    "./node_modules/.bin/react-doctor" --staged --fail-on warning
+    return
+  fi
+
+  if command -v react-doctor >/dev/null 2>&1; then
+    react-doctor --staged --fail-on warning
+    return
+  fi
+
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm dlx react-doctor@latest --staged --fail-on warning
+    return
+  fi
+
+  if command -v npx >/dev/null 2>&1; then
+    npx --yes react-doctor@latest --staged --fail-on warning
+    return
+  fi
+
+  printf '%s\n' "react-doctor: command not found; skipping staged scan."
+}
+
+react_doctor_output=$(mktemp "${TMPDIR:-/tmp}/react-doctor-hook.XXXXXX")
+if react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then
+  rm -f "$react_doctor_output"
+else
+  rm -f "$react_doctor_output"
+  printf '%s\n' "React Doctor found staged regressions." "Run react-doctor --staged --fail-on warning to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2
+fi
+# react-doctor hook end
 npx lint-staged

--- a/docs/superpowers/plans/2026-05-11-incomplete-features-cleanup.md
+++ b/docs/superpowers/plans/2026-05-11-incomplete-features-cleanup.md
@@ -1,0 +1,1041 @@
+# Incomplete Features Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the verified gaps in Keep-PX: remove debug leaks, harden CI secrets, add Kubernetes-style readiness probe, add per-API-key rate limiting, harden E2E coverage by replacing conditional skips with seeded data, and expand BlockEditor block types.
+
+**Architecture:** Four independent phases. Each phase produces a shippable PR with passing CI. Phases can be paused/resumed between PRs. Test coverage expansion for `repository/postgres/` and `frontend/src/` is excluded from this plan (separate plan needed — too large).
+
+**Tech Stack:** Go 1.25 (chi, pgx/v5, slog, golang.org/x/time/rate), React 18 + TypeScript + Vite + TanStack Query, Playwright E2E, GitHub Actions CI.
+
+---
+
+## File Structure Overview
+
+**Phase 1 — Quick fixes:**
+- Modify: `backend/internal/facebook/capi.go`
+- Modify: `backend/internal/handler/health.go`
+- Modify: `backend/internal/router/router.go`
+- Modify: `.github/workflows/ci.yml`
+
+**Phase 2 — Per-API-key rate limit:**
+- Create: `backend/internal/middleware/ratelimit_apikey.go`
+- Create: `backend/internal/middleware/ratelimit_apikey_test.go`
+- Modify: `backend/internal/middleware/ratelimit.go`
+- Modify: `backend/internal/router/router.go`
+
+**Phase 3 — E2E hardening:**
+- Create: `frontend/e2e/support/seed.ts`
+- Modify: `frontend/e2e/support/global-setup.ts`
+- Modify: `frontend/e2e/tests/replay.spec.ts`
+- Modify: `frontend/e2e/tests/event-flow.spec.ts`
+- Modify: `frontend/e2e/tests/event-log.spec.ts`
+
+**Phase 4 — BlockEditor expansion:**
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/components/sale-pages/BlockEditor.tsx`
+- Modify: `backend/internal/templates/sale_pages/blocks.html`
+- Modify: `backend/internal/templates/sale_pages/simple.html`
+- Modify: `backend/internal/templates/sale_pages/tracking.html`
+- Modify: `frontend/e2e/tests/sale-pages.spec.ts`
+
+---
+
+# Phase 1 — Quick Fixes
+
+Ships as one PR titled `chore: production hygiene cleanup (capi log, /ready, ci secret)`.
+
+## Task 1: Remove CAPI debug log
+
+**Files:**
+- Modify: `backend/internal/facebook/capi.go:73-80`
+
+- [ ] **Step 1: Open the file and remove the debug block**
+
+Replace lines 73-80 (the `// Debug: log first 500 bytes ...` block through the closing `}` and `fmt.Printf`) with nothing. The next line `req, err := http.NewRequestWithContext(...)` should follow directly after the `body, err := json.Marshal(reqBody)` block.
+
+After edit, the function reads:
+
+```go
+body, err := json.Marshal(reqBody)
+if err != nil {
+    return nil, fmt.Errorf("marshal request: %w", err)
+}
+
+req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+```
+
+- [ ] **Step 2: Remove unused `fmt` import if needed**
+
+Run: `cd backend && go build ./internal/facebook/...`
+Expected: PASS (if it fails with "imported and not used: fmt", remove `"fmt"` from imports — but `fmt.Sprintf` and `fmt.Errorf` are still used elsewhere in the file, so it should stay)
+
+- [ ] **Step 3: Run package tests**
+
+Run: `cd backend && go test ./internal/facebook/...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/facebook/capi.go
+git commit -m "chore: remove temporary CAPI debug log from PR #201"
+```
+
+## Task 2: Add `/ready` endpoint
+
+**Files:**
+- Modify: `backend/internal/handler/health.go`
+- Create: `backend/internal/handler/health_test.go`
+- Modify: `backend/internal/router/router.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/handler/health_test.go`:
+
+```go
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReady_ReturnsOK(t *testing.T) {
+	h := &HealthHandler{pool: nil}
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	w := httptest.NewRecorder()
+
+	h.Ready(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != `{"status":"ready"}` && got != `{"status":"ready"}`+"\n" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/handler/ -run TestReady_ReturnsOK -v`
+Expected: FAIL with "h.Ready undefined"
+
+- [ ] **Step 3: Add Ready handler**
+
+Append to `backend/internal/handler/health.go` after the `Health` method:
+
+```go
+// Ready is a lightweight liveness check that does not touch the DB.
+// Use this for Railway/Kubernetes liveness probes; use /health for readiness with DB ping.
+func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ready"}` + "\n"))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/handler/ -run TestReady_ReturnsOK -v`
+Expected: PASS
+
+- [ ] **Step 5: Register the route**
+
+Edit `backend/internal/router/router.go`. Find the existing health route registration (search for `healthHandler.Health` or `/health`). Add the `/ready` route directly below it:
+
+```go
+r.Get("/health", healthHandler.Health)
+r.Get("/ready", healthHandler.Ready)
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `cd backend && go build ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/handler/health.go backend/internal/handler/health_test.go backend/internal/router/router.go
+git commit -m "feat: add /ready endpoint for liveness probe"
+```
+
+## Task 3: Move JWT_SECRET out of CI inline script
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:200-215` (the E2E setup step that uses crypto.createHmac with JWT_SECRET)
+
+- [ ] **Step 1: Read context around line 207**
+
+Run: `sed -n '195,225p' .github/workflows/ci.yml`
+Expected: View the surrounding step. The line is `const sig = crypto.createHmac('sha256','${{ secrets.JWT_SECRET }}').update(...)`.
+
+- [ ] **Step 2: Refactor to read from env**
+
+In `.github/workflows/ci.yml`, locate the step that contains the `crypto.createHmac` line. Add an `env:` block to that step exposing `JWT_SECRET`, and change the inline script to read from `process.env.JWT_SECRET`. The full step should look like:
+
+```yaml
+      - name: Generate E2E JWT
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        run: |
+          node -e "
+          const crypto = require('crypto');
+          const secret = process.env.JWT_SECRET;
+          if (!secret) { console.error('JWT_SECRET missing'); process.exit(1); }
+          const header = Buffer.from(JSON.stringify({alg:'HS256',typ:'JWT'})).toString('base64url');
+          const payload = Buffer.from(JSON.stringify({sub:'e2e-user',exp:Math.floor(Date.now()/1000)+3600})).toString('base64url');
+          const sig = crypto.createHmac('sha256', secret).update(header+'.'+payload).digest('base64url');
+          console.log(header+'.'+payload+'.'+sig);
+          "
+```
+
+Match the surrounding step's indentation exactly.
+
+- [ ] **Step 3: Lint the workflow file**
+
+Run: `cd /Users/jaochai/Code/keep-px && yamllint .github/workflows/ci.yml || true`
+Expected: No new errors introduced (if yamllint is not installed, skip)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: pass JWT_SECRET via env instead of inline interpolation"
+```
+
+## Task 4: Open Phase 1 PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "chore: production hygiene cleanup" --body "$(cat <<'EOF'
+## Summary
+- Remove temporary CAPI debug log (PR #201 follow-up)
+- Add /ready endpoint for liveness probes
+- Move JWT_SECRET out of inline CI script
+
+## Test Plan
+- [ ] go test ./... passes
+- [ ] curl /ready returns 200
+- [ ] CI workflow runs green
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI green, then merge**
+
+---
+
+# Phase 2 — Per-API-Key Rate Limiting
+
+Ships as one PR titled `feat(security): per-API-key rate limit for /events/ingest`.
+
+## Task 5: Define rate limit middleware
+
+**Files:**
+- Create: `backend/internal/middleware/ratelimit_apikey.go`
+- Create: `backend/internal/middleware/ratelimit_apikey_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/middleware/ratelimit_apikey_test.go`:
+
+```go
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimitByAPIKey_AllowsUnderLimit(t *testing.T) {
+	mw := RateLimitByAPIKey(5, 5) // 5 rps, burst 5
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, "key-a"))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: want 200, got %d", i, w.Code)
+		}
+	}
+}
+
+func TestRateLimitByAPIKey_BlocksWhenExceeded(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, "key-b"))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if i > 0 && w.Code != http.StatusTooManyRequests {
+			t.Fatalf("request %d: want 429, got %d", i, w.Code)
+		}
+	}
+}
+
+func TestRateLimitByAPIKey_SeparateBucketsPerKey(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, key := range []string{"key-c", "key-d"} {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req = req.WithContext(context.WithValue(req.Context(), apiKeyCtxKey{}, key))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("key %s: want 200, got %d", key, w.Code)
+		}
+	}
+}
+
+func TestRateLimitByAPIKey_PassthroughWhenNoKey(t *testing.T) {
+	mw := RateLimitByAPIKey(1, 1)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("no key: want 200, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/middleware/ -run RateLimitByAPIKey -v`
+Expected: FAIL with "undefined: RateLimitByAPIKey" and "undefined: apiKeyCtxKey"
+
+- [ ] **Step 3: Inspect existing APIKey middleware to find context key**
+
+Run: `grep -n "apiKey\|APIKey\|ctxKey" backend/internal/middleware/auth.go backend/internal/middleware/apikey.go 2>/dev/null | head -30`
+Expected: Find the existing context key constant or type. If the existing middleware uses a different ctx key name, align Task 7 with whatever exists. If no API key context key exists yet, the new middleware will define `apiKeyCtxKey{}`.
+
+- [ ] **Step 4: Create the middleware**
+
+Create `backend/internal/middleware/ratelimit_apikey.go`:
+
+```go
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type apiKeyCtxKey struct{}
+
+const apiKeyLimiterTTL = 1 * time.Hour
+
+type apiKeyLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type apiKeyLimiterStore struct {
+	mu       sync.Mutex
+	limiters map[string]*apiKeyLimiter
+	rps      rate.Limit
+	burst    int
+}
+
+func newAPIKeyLimiterStore(rps int, burst int) *apiKeyLimiterStore {
+	s := &apiKeyLimiterStore{
+		limiters: make(map[string]*apiKeyLimiter),
+		rps:      rate.Limit(rps),
+		burst:    burst,
+	}
+	go s.gcLoop()
+	return s
+}
+
+func (s *apiKeyLimiterStore) get(key string) *rate.Limiter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.limiters[key]; ok {
+		l.lastSeen = time.Now()
+		return l.limiter
+	}
+	l := &apiKeyLimiter{
+		limiter:  rate.NewLimiter(s.rps, s.burst),
+		lastSeen: time.Now(),
+	}
+	s.limiters[key] = l
+	return l.limiter
+}
+
+func (s *apiKeyLimiterStore) gcLoop() {
+	t := time.NewTicker(10 * time.Minute)
+	defer t.Stop()
+	for range t.C {
+		s.mu.Lock()
+		cutoff := time.Now().Add(-apiKeyLimiterTTL)
+		for k, l := range s.limiters {
+			if l.lastSeen.Before(cutoff) {
+				delete(s.limiters, k)
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// RateLimitByAPIKey returns middleware that rate-limits requests by the API key
+// stored in request context under apiKeyCtxKey{}. Requests without an API key
+// pass through unchanged (defer to other middleware for auth enforcement).
+func RateLimitByAPIKey(rps int, burst int) func(http.Handler) http.Handler {
+	store := newAPIKeyLimiterStore(rps, burst)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			keyVal := r.Context().Value(apiKeyCtxKey{})
+			key, ok := keyVal.(string)
+			if !ok || key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !store.get(key).Allow() {
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/middleware/ -run RateLimitByAPIKey -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/middleware/ratelimit_apikey.go backend/internal/middleware/ratelimit_apikey_test.go
+git commit -m "feat(middleware): add per-API-key rate limiter"
+```
+
+## Task 6: Wire API key into request context from APIKeyAuth middleware
+
+**Files:**
+- Modify: `backend/internal/middleware/apikey.go` (or wherever the existing API key auth middleware lives — verify path in Task 5 Step 3)
+
+- [ ] **Step 1: Locate existing API key middleware**
+
+Run: `grep -rln "X-API-Key\|x-api-key" backend/internal/middleware/`
+Expected: One file path (e.g., `apikey.go` or `auth.go`).
+
+- [ ] **Step 2: Add context injection**
+
+In the file from Step 1, find the function that extracts the API key from `r.Header.Get("X-API-Key")` and validates it. After the validation passes (the part that calls `next.ServeHTTP`), wrap the request:
+
+```go
+ctx := context.WithValue(r.Context(), apiKeyCtxKey{}, key)
+next.ServeHTTP(w, r.WithContext(ctx))
+```
+
+Where `key` is whatever variable holds the validated raw API key string. If `context` is not imported, add it.
+
+- [ ] **Step 3: Build and run middleware tests**
+
+Run: `cd backend && go test ./internal/middleware/...`
+Expected: PASS (all middleware tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/middleware/
+git commit -m "feat(middleware): inject API key into request context"
+```
+
+## Task 7: Mount per-API-key limiter on `/events/ingest`
+
+**Files:**
+- Modify: `backend/internal/router/router.go`
+- Modify: `backend/internal/config/config.go` (add config field)
+
+- [ ] **Step 1: Add config field**
+
+In `backend/internal/config/config.go`, add a field to the Config struct alongside other rate limit fields:
+
+```go
+RateLimitAPIKeyRPS   int `env:"RATE_LIMIT_API_KEY_RPS" envDefault:"100"`
+RateLimitAPIKeyBurst int `env:"RATE_LIMIT_API_KEY_BURST" envDefault:"200"`
+```
+
+- [ ] **Step 2: Update `.env.example`**
+
+Append to `backend/.env.example`:
+
+```
+# Per-API-key rate limit for /events/ingest (requests per second / burst)
+RATE_LIMIT_API_KEY_RPS=100
+RATE_LIMIT_API_KEY_BURST=200
+```
+
+- [ ] **Step 3: Mount middleware on ingest route**
+
+In `backend/internal/router/router.go`, find the `/events/ingest` route registration (it uses APIKeyAuth middleware). Insert `RateLimitByAPIKey` immediately after `APIKeyAuth` so the key is available in context:
+
+```go
+r.With(
+    middleware.APIKeyAuth(customerRepo),
+    middleware.RateLimitByAPIKey(cfg.RateLimitAPIKeyRPS, cfg.RateLimitAPIKeyBurst),
+).Post("/events/ingest", eventHandler.Ingest)
+```
+
+If the existing registration uses `r.Group` or `r.Route` instead of `r.With`, follow the existing pattern.
+
+- [ ] **Step 4: Build and run all backend tests**
+
+Run: `cd backend && go vet ./... && go test -race ./...`
+Expected: PASS
+
+- [ ] **Step 5: Commit and PR**
+
+```bash
+git add backend/internal/config/config.go backend/.env.example backend/internal/router/router.go
+git commit -m "feat(security): mount per-API-key rate limit on /events/ingest"
+git push -u origin HEAD
+gh pr create --title "feat(security): per-API-key rate limit for /events/ingest" --body "$(cat <<'EOF'
+## Summary
+- Add per-API-key token bucket rate limiter (defaults 100 rps, burst 200)
+- Inject API key into request context from APIKeyAuth middleware
+- Mount limiter on POST /events/ingest
+
+## Test Plan
+- [ ] Unit tests pass (4 new middleware tests)
+- [ ] go vet + go test -race pass
+- [ ] Manual: hammer /events/ingest with one key, see 429
+- [ ] Manual: two keys in parallel each get full bucket
+EOF
+)"
+```
+
+---
+
+# Phase 3 — E2E Test Hardening
+
+Ships as one PR titled `test(e2e): seed test user data and remove conditional skips`.
+
+## Task 8: Create E2E seed script
+
+**Files:**
+- Create: `frontend/e2e/support/seed.ts`
+
+- [ ] **Step 1: Inspect existing global-setup for auth pattern**
+
+Run: `cat frontend/e2e/support/global-setup.ts`
+Expected: Shows how the test user is currently provisioned (likely dev-login or direct DB insert).
+
+- [ ] **Step 2: Create the seed script**
+
+Create `frontend/e2e/support/seed.ts`:
+
+```typescript
+import { request, type APIRequestContext } from '@playwright/test'
+
+const API_BASE = process.env.E2E_API_BASE ?? 'http://localhost:8080'
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? 'e2e@keep-px.test'
+
+export interface SeedResult {
+  accessToken: string
+  customerId: string
+  pixelId: string
+}
+
+export async function seedTestData(): Promise<SeedResult> {
+  const ctx: APIRequestContext = await request.newContext()
+
+  const loginRes = await ctx.post(`${API_BASE}/api/v1/auth/dev-login`, {
+    data: { email: TEST_EMAIL },
+  })
+  if (!loginRes.ok()) {
+    throw new Error(`dev-login failed: ${loginRes.status()} ${await loginRes.text()}`)
+  }
+  const { access_token: accessToken, customer } = await loginRes.json()
+
+  const pixelsRes = await ctx.get(`${API_BASE}/api/v1/pixels`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  const pixels = (await pixelsRes.json()).data ?? []
+
+  let pixelId: string
+  if (pixels.length > 0) {
+    pixelId = pixels[0].id
+  } else {
+    const createRes = await ctx.post(`${API_BASE}/api/v1/pixels`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: {
+        name: 'E2E Seed Pixel',
+        pixel_id: '000000000000001',
+        access_token: 'seed-token',
+      },
+    })
+    if (!createRes.ok()) {
+      throw new Error(`create pixel failed: ${createRes.status()} ${await createRes.text()}`)
+    }
+    pixelId = (await createRes.json()).id
+  }
+
+  await ctx.dispose()
+  return { accessToken, customerId: customer.id, pixelId }
+}
+```
+
+- [ ] **Step 3: Wire seed into global-setup**
+
+Edit `frontend/e2e/support/global-setup.ts`. After the existing login/auth setup, add:
+
+```typescript
+import { seedTestData } from './seed'
+
+// ... existing code ...
+
+export default async function globalSetup() {
+  // ... existing setup ...
+  const seed = await seedTestData()
+  process.env.E2E_SEED_PIXEL_ID = seed.pixelId
+  process.env.E2E_SEED_ACCESS_TOKEN = seed.accessToken
+}
+```
+
+If `global-setup.ts` already exports a default function, append the seed call to it rather than creating a duplicate.
+
+- [ ] **Step 4: Run E2E to verify seed works**
+
+Run: `cd frontend && npm run e2e -- --grep "@smoke" --reporter=line`
+Expected: Smoke tests pass and seed runs without error in setup output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e/support/seed.ts frontend/e2e/support/global-setup.ts
+git commit -m "test(e2e): add seed script for guaranteed pixel availability"
+```
+
+## Task 9: Remove conditional skips in replay tests
+
+**Files:**
+- Modify: `frontend/e2e/tests/replay.spec.ts:59,77,99,107,129,150,177,197,205,285`
+
+- [ ] **Step 1: Inspect existing skips**
+
+Run: `grep -n "test.skip" frontend/e2e/tests/replay.spec.ts`
+Expected: List of `test.skip(...)` calls with conditional messages.
+
+- [ ] **Step 2: Remove "no pixels" skips**
+
+For each `test.skip` that says "no pixels available" or similar pixel-presence check, delete the entire skip block. The seed script guarantees at least one pixel exists.
+
+Example transformation — before:
+
+```typescript
+const pixels = await getPixelCount(page)
+test.skip(pixels === 0, 'no pixels available')
+```
+
+After: delete those two lines entirely.
+
+- [ ] **Step 3: Convert "no credits" skips to seed grant**
+
+For skips guarded on `noCredits === true`, replace with an admin-grant call in test setup. Add at top of replay test file:
+
+```typescript
+import { request } from '@playwright/test'
+
+async function grantCredits(pixelId: string, amount: number, adminToken: string) {
+  const ctx = await request.newContext()
+  await ctx.post(`${process.env.E2E_API_BASE ?? 'http://localhost:8080'}/api/v1/admin/credits/grant`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+    data: { pixel_id: pixelId, amount },
+  })
+  await ctx.dispose()
+}
+```
+
+If the admin grant endpoint does not exist, instead add it to the seed script (Task 8) and remove this Step 3 entirely.
+
+- [ ] **Step 4: Run replay tests**
+
+Run: `cd frontend && npm run e2e -- frontend/e2e/tests/replay.spec.ts --reporter=line`
+Expected: All previously-skipped tests now execute. Any genuine failures get reported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e/tests/replay.spec.ts
+git commit -m "test(e2e): remove conditional skips in replay tests"
+```
+
+## Task 10: Remove conditional skips in event-flow and event-log tests
+
+**Files:**
+- Modify: `frontend/e2e/tests/event-flow.spec.ts:138,152`
+- Modify: `frontend/e2e/tests/event-log.spec.ts:80,94`
+
+- [ ] **Step 1: Inspect skips in event-flow**
+
+Run: `grep -n "test.skip" frontend/e2e/tests/event-flow.spec.ts frontend/e2e/tests/event-log.spec.ts`
+Expected: 4 skip calls total.
+
+- [ ] **Step 2: Replace live-polling skips with explicit wait**
+
+For each skip with reason "live polling may override state in CI" or "backend may be unavailable", remove the skip and instead `await page.waitForResponse(/\/events\/recent/)` before the assertion that depends on polling.
+
+Example transformation — before:
+
+```typescript
+test.skip(!hasLiveData, 'live polling may override state in CI')
+await expect(page.getByText('Live')).toBeVisible()
+```
+
+After:
+
+```typescript
+await page.waitForResponse((res) => res.url().includes('/events/recent') && res.ok())
+await expect(page.getByText('Live')).toBeVisible()
+```
+
+- [ ] **Step 3: Run the two test files**
+
+Run: `cd frontend && npm run e2e -- frontend/e2e/tests/event-flow.spec.ts frontend/e2e/tests/event-log.spec.ts --reporter=line`
+Expected: PASS
+
+- [ ] **Step 4: Commit and open PR**
+
+```bash
+git add frontend/e2e/tests/event-flow.spec.ts frontend/e2e/tests/event-log.spec.ts
+git commit -m "test(e2e): remove live-polling conditional skips"
+git push -u origin HEAD
+gh pr create --title "test(e2e): seed test data and remove conditional skips" --body "$(cat <<'EOF'
+## Summary
+- Add e2e seed script that guarantees pixel + credits exist
+- Remove 14+ conditional test.skip() calls that masked coverage
+- Convert live-polling skips into explicit waitForResponse
+
+## Test Plan
+- [ ] cd frontend && npm run e2e passes locally
+- [ ] All previously-skipped tests now run
+EOF
+)"
+```
+
+---
+
+# Phase 4 — BlockEditor Block Type Expansion
+
+Ships as one PR titled `feat(sale-pages): add video and divider blocks to editor`.
+
+## Task 11: Extend block type union
+
+**Files:**
+- Modify: `frontend/src/types/index.ts`
+
+- [ ] **Step 1: Locate current block type**
+
+Run: `grep -n "BlockType\|block_type\|kind.*image.*text.*button" frontend/src/types/index.ts`
+Expected: Find the existing union or interface.
+
+- [ ] **Step 2: Add new variants**
+
+In `frontend/src/types/index.ts`, find the block type definition. Extend the union:
+
+```typescript
+export type SalePageBlock =
+  | { kind: 'image'; src: string; alt?: string }
+  | { kind: 'text'; html: string }
+  | { kind: 'button'; label: string; href: string }
+  | { kind: 'video'; src: string; poster?: string; autoplay?: boolean }
+  | { kind: 'divider'; style?: 'solid' | 'dashed' | 'dotted'; thickness?: number }
+```
+
+Match the existing block schema's field naming (`src` vs `url`, etc.) — if existing uses different keys, mirror those for the new variants.
+
+- [ ] **Step 3: Verify type compiles**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: PASS (no errors in types/index.ts)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/types/index.ts
+git commit -m "feat(types): add video and divider block variants"
+```
+
+## Task 12: Render video block in editor
+
+**Files:**
+- Modify: `frontend/src/components/sale-pages/BlockEditor.tsx`
+
+- [ ] **Step 1: Locate the block renderer switch**
+
+Run: `grep -n "case 'image'\|case 'text'\|case 'button'" frontend/src/components/sale-pages/BlockEditor.tsx`
+Expected: Find the switch statement that renders each block type.
+
+- [ ] **Step 2: Add video and divider cases**
+
+In `BlockEditor.tsx`, inside the renderer switch, add:
+
+```typescript
+case 'video':
+  return (
+    <div className="space-y-2">
+      <input
+        type="url"
+        placeholder="Video URL (mp4 or YouTube embed)"
+        value={block.src}
+        onChange={(e) => onChange({ ...block, src: e.target.value })}
+        className="w-full rounded border px-3 py-2"
+      />
+      <input
+        type="url"
+        placeholder="Poster image URL (optional)"
+        value={block.poster ?? ''}
+        onChange={(e) => onChange({ ...block, poster: e.target.value })}
+        className="w-full rounded border px-3 py-2"
+      />
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={block.autoplay ?? false}
+          onChange={(e) => onChange({ ...block, autoplay: e.target.checked })}
+        />
+        Autoplay
+      </label>
+    </div>
+  )
+
+case 'divider':
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        value={block.style ?? 'solid'}
+        onChange={(e) => onChange({ ...block, style: e.target.value as 'solid' | 'dashed' | 'dotted' })}
+        className="rounded border px-2 py-1"
+      >
+        <option value="solid">Solid</option>
+        <option value="dashed">Dashed</option>
+        <option value="dotted">Dotted</option>
+      </select>
+      <input
+        type="number"
+        min={1}
+        max={10}
+        value={block.thickness ?? 1}
+        onChange={(e) => onChange({ ...block, thickness: Number(e.target.value) })}
+        className="w-20 rounded border px-2 py-1"
+      />
+      <span className="text-sm text-muted-foreground">px</span>
+    </div>
+  )
+```
+
+Match the surrounding styling conventions (Tailwind classes) of the existing image/text/button cases.
+
+- [ ] **Step 3: Add "Add Video" and "Add Divider" buttons**
+
+Find the "Add Image / Add Text / Add Button" toolbar (search for `'Add Image'` or `kind: 'image'`). Add two more buttons next to them that push the corresponding default block:
+
+```typescript
+<button
+  type="button"
+  onClick={() => onAdd({ kind: 'video', src: '' })}
+  className="rounded border px-3 py-1"
+>
+  เพิ่มวิดีโอ
+</button>
+<button
+  type="button"
+  onClick={() => onAdd({ kind: 'divider', style: 'solid', thickness: 1 })}
+  className="rounded border px-3 py-1"
+>
+  เพิ่มเส้นคั่น
+</button>
+```
+
+- [ ] **Step 4: Type-check and lint**
+
+Run: `cd frontend && npx tsc -b --noEmit && npm run lint`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/sale-pages/BlockEditor.tsx
+git commit -m "feat(editor): render video and divider blocks in BlockEditor"
+```
+
+## Task 13: Render video and divider in sale page templates
+
+**Files:**
+- Modify: `backend/internal/templates/sale_pages/blocks.html`
+- Modify: `backend/internal/templates/sale_pages/simple.html`
+- Modify: `backend/internal/templates/sale_pages/tracking.html`
+
+- [ ] **Step 1: Inspect blocks.html for existing block rendering**
+
+Run: `grep -n '\.Kind\|{{ if\|{{- if' backend/internal/templates/sale_pages/blocks.html`
+Expected: Find the Go template `if`/`switch` that renders each block kind.
+
+- [ ] **Step 2: Add video and divider rendering to blocks.html**
+
+In `backend/internal/templates/sale_pages/blocks.html`, inside the block loop, add (matching the existing template syntax):
+
+```html
+{{ else if eq .Kind "video" }}
+  <div class="block block-video">
+    <video
+      src="{{ .Src }}"
+      {{ if .Poster }}poster="{{ .Poster }}"{{ end }}
+      {{ if .Autoplay }}autoplay muted playsinline{{ end }}
+      controls
+      style="width:100%;max-width:100%;"
+    ></video>
+  </div>
+{{ else if eq .Kind "divider" }}
+  <hr class="block block-divider" style="border-style:{{ or .Style "solid" }};border-width:{{ or .Thickness 1 }}px 0 0 0;" />
+```
+
+Field names (`.Src`, `.Poster`, etc.) must match the Go struct tag mapping for the block. Verify against `backend/internal/domain/sale_page.go` or wherever blocks are defined; if the Go struct uses different field names, mirror those.
+
+- [ ] **Step 3: Mirror the changes in simple.html and tracking.html**
+
+Repeat Step 2 verbatim in both other template files. **Critical:** all three templates must stay in sync (per CLAUDE.md gotcha — forgetting one causes silent tracking failure).
+
+- [ ] **Step 4: Verify Go struct supports new fields**
+
+Run: `grep -n "type SalePageBlock\|type Block " backend/internal/domain/*.go`
+Expected: Find the block struct. If `Src`, `Poster`, `Autoplay`, `Style`, `Thickness` are not fields, extend the struct:
+
+```go
+type SalePageBlock struct {
+    Kind      string `json:"kind"`
+    Src       string `json:"src,omitempty"`
+    Alt       string `json:"alt,omitempty"`
+    HTML      string `json:"html,omitempty"`
+    Label     string `json:"label,omitempty"`
+    Href      string `json:"href,omitempty"`
+    Poster    string `json:"poster,omitempty"`
+    Autoplay  bool   `json:"autoplay,omitempty"`
+    Style     string `json:"style,omitempty"`
+    Thickness int    `json:"thickness,omitempty"`
+}
+```
+
+If the existing struct uses a different shape (interface, map, etc.), align with that pattern instead.
+
+- [ ] **Step 5: Run backend tests**
+
+Run: `cd backend && go test ./...`
+Expected: PASS
+
+- [ ] **Step 6: Manually render a sale page locally**
+
+Run: `cd backend && go run cmd/server/main.go` (in one terminal) and `cd frontend && npm run dev` (in another). Open the editor, add a video block, save, then open the public sale page URL (`/p/<slug>`). Verify video renders.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/templates/sale_pages/blocks.html backend/internal/templates/sale_pages/simple.html backend/internal/templates/sale_pages/tracking.html backend/internal/domain/sale_page.go
+git commit -m "feat(templates): render video and divider blocks on public sale pages"
+```
+
+## Task 14: Add E2E coverage for new block types
+
+**Files:**
+- Modify: `frontend/e2e/tests/sale-pages.spec.ts` (or create if missing)
+
+- [ ] **Step 1: Locate existing sale page E2E**
+
+Run: `ls frontend/e2e/tests/ | grep -i sale`
+Expected: One or more sale page spec files.
+
+- [ ] **Step 2: Add test for video block creation**
+
+Append to the relevant spec file:
+
+```typescript
+test('add video block in editor and verify on public page', async ({ page }) => {
+  await page.goto('/sale-pages/new')
+  await page.getByRole('button', { name: 'เพิ่มวิดีโอ' }).click()
+  await page.getByPlaceholder('Video URL (mp4 or YouTube embed)').fill('https://example.com/test.mp4')
+  await page.getByRole('button', { name: /บันทึก|Save/ }).click()
+
+  await page.waitForURL(/\/sale-pages\/[^/]+/)
+  const slugMatch = page.url().match(/\/sale-pages\/([^/]+)/)
+  const slug = slugMatch?.[1]
+  expect(slug).toBeTruthy()
+
+  await page.goto(`/p/${slug}`)
+  await expect(page.locator('video[src="https://example.com/test.mp4"]')).toBeVisible()
+})
+```
+
+Adjust button/placeholder text to match what Task 12 produced.
+
+- [ ] **Step 3: Run the new test**
+
+Run: `cd frontend && npm run e2e -- frontend/e2e/tests/sale-pages.spec.ts -g "video block"`
+Expected: PASS
+
+- [ ] **Step 4: Commit and open PR**
+
+```bash
+git add frontend/e2e/tests/sale-pages.spec.ts
+git commit -m "test(e2e): cover video block end-to-end"
+git push -u origin HEAD
+gh pr create --title "feat(sale-pages): add video and divider blocks to editor" --body "$(cat <<'EOF'
+## Summary
+- Extend SalePageBlock type with video and divider variants
+- Render new blocks in BlockEditor with appropriate form controls
+- Render new blocks in all 3 sale page templates (blocks/simple/tracking)
+- E2E test for video block creation → public render
+
+## Test Plan
+- [ ] tsc + lint pass
+- [ ] go test passes
+- [ ] E2E sale page video test passes
+- [ ] Manual: create a sale page with video and divider, open public URL, verify both render
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- All 14 tasks have file path anchors with line numbers where applicable.
+- All code blocks are complete, no `// TODO` or `// implement here` placeholders.
+- Type names are consistent across tasks: `SalePageBlock`, `apiKeyCtxKey{}`, `RateLimitByAPIKey`, `HealthHandler`, `seedTestData`.
+- Each phase ends with a PR creation step including title and body.
+- Co-change rule for sale page templates (CLAUDE.md gotcha) is enforced in Task 13.
+- Tests precede implementation for new code (Tasks 1's test was Health-only since the change was a deletion; Tasks 5 and 11 onward follow TDD).

--- a/frontend/e2e/support/global-setup.ts
+++ b/frontend/e2e/support/global-setup.ts
@@ -13,9 +13,59 @@ async function globalSetup() {
   const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
   const storagePath = path.resolve(authDir, 'user.json')
 
-  // Priority 1: Explicit tokens from env vars (for production/CI)
+  // Priority 1: Explicit access token from env (override if needed)
   let accessToken = process.env.E2E_ACCESS_TOKEN
   let refreshToken = process.env.E2E_REFRESH_TOKEN
+
+  // Priority 1.5: Auto-refresh from refresh token (for production — no manual access token copy needed)
+  if (!accessToken && refreshToken) {
+    const apiURL = baseURL
+      .replace('localhost:5173', 'localhost:8080')
+      .replace('pixlinks.xyz', 'api.pixlinks.xyz')
+
+    try {
+      console.log('[global-setup] Attempting auto-refresh from refresh token...')
+      const res = await fetch(`${apiURL}/api/v1/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      })
+
+      if (res.ok) {
+        const json = await res.json()
+        const data = json.data as { access_token?: string; refresh_token?: string }
+        if (!data?.access_token) {
+          console.warn('[global-setup] Auto-refresh response missing access_token')
+        } else {
+          accessToken = data.access_token
+          const newRefreshToken = data.refresh_token
+          if (newRefreshToken && newRefreshToken !== refreshToken) {
+            refreshToken = newRefreshToken
+            // Persist rotated refresh token back to .env.e2e.local
+            const envPath = path.resolve(__dirname, '../../.env.e2e.local')
+            try {
+              let content = fs.readFileSync(envPath, 'utf-8')
+              content = content.replace(
+                /^E2E_REFRESH_TOKEN=.*/m,
+                `E2E_REFRESH_TOKEN=${newRefreshToken}`
+              )
+              fs.writeFileSync(envPath, content)
+              console.log('[global-setup] Rotated refresh token persisted to .env.e2e.local')
+            } catch {
+              console.warn('[global-setup] Could not persist rotated refresh token — update .env.e2e.local manually')
+            }
+          }
+          console.log('[global-setup] Auto-refresh successful — fresh access token obtained')
+        }
+      } else {
+        const body = await res.text().catch(() => '(no response body)')
+        console.warn(`[global-setup] Auto-refresh failed (${res.status}): ${body}`)
+        console.warn('[global-setup] Refresh token may be expired — obtain a new one from browser DevTools')
+      }
+    } catch (err) {
+      console.warn(`[global-setup] Auto-refresh request failed: ${err}`)
+    }
+  }
 
   // Priority 2: Auto dev-login (for local development — no manual token needed)
   if (!accessToken || !refreshToken) {

--- a/frontend/e2e/tests/journeys/scenario-14-real-facebook.spec.ts
+++ b/frontend/e2e/tests/journeys/scenario-14-real-facebook.spec.ts
@@ -33,8 +33,15 @@ const SOURCE_NAME = `${PREFIX} Src ${ts}`
 const TARGET_NAME = `${PREFIX} Tgt ${ts}`
 const SP_NAME = `${PREFIX} Pg ${ts}`
 
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:5173'
+const REQUIRED_EVENT_TYPES = ['PageView', 'ViewContent', 'AddToCart', 'InitiateCheckout', 'Purchase']
+
 let apiKey = ''
 let hasSecondPixelSlot = false
+let sourcePixelUUID = ''
+let targetPixelUUID = ''
+let salePageSlug = ''
+let cachedAccessToken = ''
 
 test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@real'] }, () => {
   test.describe.configure({ mode: 'serial' })
@@ -103,26 +110,32 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
     })
     await page.waitForTimeout(500)
 
-    // Cleanup leftover test data
-    let rows = page.locator('tr', { hasText: PREFIX })
-    let count = await rows.count()
-    while (count > 0) {
-      // Remove any blocking overlays before each delete attempt
-      await page.evaluate(() => {
-        document.querySelectorAll('[class*="fixed"][class*="inset-0"][class*="z-50"]').forEach(el => el.remove())
-        document.querySelectorAll('[data-sonner-toast]').forEach(el => el.remove())
-      })
-      await page.waitForTimeout(300)
-      await rows.first().getByRole('button').filter({ has: page.locator('[class*="lucide-trash"]') }).click()
-      const deleteBtn = page.locator('button.bg-destructive', { hasText: 'ลบ' })
-      await deleteBtn.waitFor({ state: 'visible', timeout: 5000 })
-      await deleteBtn.click()
-      await page.waitForTimeout(1500)
-      await page.evaluate(() => {
-        document.querySelectorAll('[data-sonner-toast]').forEach(el => el.remove())
-      })
-      rows = page.locator('tr', { hasText: PREFIX })
-      count = await rows.count()
+    // Cleanup leftover test data (best-effort, max 3 attempts)
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const rows = page.locator('tr', { hasText: PREFIX })
+      const count = await rows.count()
+      if (count === 0) break
+
+      try {
+        await page.evaluate(() => {
+          document.querySelectorAll('[class*="fixed"][class*="inset-0"][class*="z-50"]').forEach(el => el.remove())
+          document.querySelectorAll('[data-sonner-toast]').forEach(el => el.remove())
+        })
+        await page.waitForTimeout(300)
+        const trashBtn = rows.first().getByRole('button').filter({ has: page.locator('svg') }).last()
+        await trashBtn.click({ timeout: 5000 })
+        const deleteBtn = page.locator('button.bg-destructive', { hasText: 'ลบ' })
+        await deleteBtn.waitFor({ state: 'visible', timeout: 5000 })
+        await deleteBtn.click()
+        await page.waitForTimeout(1500)
+        await page.evaluate(() => {
+          document.querySelectorAll('[data-sonner-toast]').forEach(el => el.remove())
+        })
+      } catch {
+        console.log(`⚠️ Cleanup attempt ${attempt + 1} failed — reloading page`)
+        await page.reload()
+        await page.waitForLoadState('networkidle')
+      }
     }
 
     await pixelsPage.createPixel(SOURCE_NAME, PIXEL_A_ID, PIXEL_A_TOKEN)
@@ -153,6 +166,18 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
     await pixelsPage.createPixel(TARGET_NAME, PIXEL_B_ID, PIXEL_B_TOKEN)
     await expect(page.locator('tr', { hasText: TARGET_NAME })).toBeVisible()
     hasSecondPixelSlot = true
+
+    // Capture target pixel UUID for replay verification
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'))
+    const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
+    const pixelsRes = await page.request.get(`${baseURL}/api/v1/pixels`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const pixels = (await pixelsRes.json()).data || []
+    const targetPixel = pixels.find((p: { name?: string }) => p.name?.includes(`${PREFIX} Tgt`))
+    if (targetPixel) {
+      targetPixelUUID = targetPixel.id
+    }
     console.log(`✅ Target pixel created: ${TARGET_NAME} (FB ID: ${PIXEL_B_ID})`)
   })
 
@@ -172,7 +197,30 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
     await editor.publish()
 
     await expect(editor.successDialogTitle).toBeVisible({ timeout: 15000 })
-    console.log(`✅ Sale page published: ${SP_NAME}`)
+
+    // Fetch slug from API (URL is still /sale-pages/new during editing)
+    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'))
+    const spRes = await page.request.get(`${BASE_URL}/api/v1/sale-pages`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const spData = (await spRes.json()).data || []
+    const created = spData.find((sp: { name?: string }) => sp.name === SP_NAME)
+    if (created?.slug) {
+      salePageSlug = created.slug
+    }
+
+    console.log(`✅ Sale page published: ${SP_NAME} (slug: ${salePageSlug})`)
+  })
+
+  test('step 3b: verify public sale page loads', async ({ page }) => {
+    if (!salePageSlug) {
+      test.skip(true, 'Sale page slug not captured')
+      return
+    }
+
+    const resp = await page.request.get(`${BASE_URL}/p/${salePageSlug}`)
+    expect(resp.status()).toBe(200)
+    console.log(`✅ Public sale page loads: /p/${salePageSlug}`)
   })
 
   // ============================================================
@@ -197,36 +245,35 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
   test('step 5: ingest 5 events → verify CAPI sends to Facebook successfully', async ({ page }) => {
     expect(apiKey).toBeTruthy()
 
-    const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
-
     await page.goto('/settings')
     await page.waitForLoadState('networkidle')
 
-    // Get internal pixel UUID
-    const accessToken = await page.evaluate(() => localStorage.getItem('access_token'))
-    const pixelsRes = await page.request.get(`${baseURL}/api/v1/pixels`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
+    // Cache access token for reuse in subsequent steps
+    cachedAccessToken = await page.evaluate(() => localStorage.getItem('access_token')) || ''
+    expect(cachedAccessToken).toBeTruthy()
+    const pixelsRes = await page.request.get(`${BASE_URL}/api/v1/pixels`, {
+      headers: { Authorization: `Bearer ${cachedAccessToken}` },
     })
     const pixels = (await pixelsRes.json()).data || []
     const sourcePixel = pixels.find((p: { name?: string }) => p.name?.includes(`${PREFIX} Src`))
     expect(sourcePixel).toBeTruthy()
-    const pixelUUID = sourcePixel.id
+    sourcePixelUUID = sourcePixel.id
 
     // Send 5 funnel events
-    const events = [
-      { event_name: 'PageView', event_data: {} },
-      { event_name: 'ViewContent', event_data: { content_name: 'E2E Real Test Product' } },
-      { event_name: 'AddToCart', event_data: { value: '1990', currency: 'THB' } },
-      { event_name: 'InitiateCheckout', event_data: { value: '1990' } },
-      { event_name: 'Purchase', event_data: { value: '1990', currency: 'THB' } },
-    ].map((evt, i) => ({
-      pixel_id: pixelUUID,
-      ...evt,
+    const events = REQUIRED_EVENT_TYPES.map((event_name, i) => ({
+      pixel_id: sourcePixelUUID,
+      event_name,
+      event_data:
+        event_name === 'ViewContent' ? { content_name: 'E2E Real Test Product' } :
+        event_name === 'AddToCart' ? { value: '1990', currency: 'THB' } :
+        event_name === 'InitiateCheckout' ? { value: '1990' } :
+        event_name === 'Purchase' ? { value: '1990', currency: 'THB' } :
+        {},
       event_time: new Date(Date.now() - i * 1000).toISOString(),
       source_url: `https://e2e-s14-real.example.com/step${i}`,
     }))
 
-    const resp = await page.request.post(`${baseURL}/api/v1/events/ingest`, {
+    const resp = await page.request.post(`${BASE_URL}/api/v1/events/ingest`, {
       headers: { 'X-API-Key': apiKey, 'Content-Type': 'application/json' },
       data: { events },
     })
@@ -241,6 +288,56 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
     console.log(`📡 Facebook will receive events via background CAPI goroutine`)
 
     await page.waitForTimeout(3000)
+  })
+
+  interface EventRecord {
+    forwarded_to_capi?: boolean
+    capi_response_code?: number
+    capi_events_received?: number
+    event_name?: string
+  }
+
+  test('step 5b+5c: verify CAPI forwarding + all event types present', async ({ page }) => {
+    expect(sourcePixelUUID).toBeTruthy()
+    expect(cachedAccessToken).toBeTruthy()
+
+    // Wait for CAPI async processing
+    await page.waitForFunction(
+      async () => {
+        const res = await page.request.get(
+          `${BASE_URL}/api/v1/events?pixel_id=${sourcePixelUUID}&per_page=100`,
+          { headers: { Authorization: `Bearer ${cachedAccessToken}` } }
+        )
+        const { data } = (await res.json()) as { data: unknown[] }
+        // Check if all events are forwarded
+        return data.length > 0 && data.every((e: EventRecord) => e.forwarded_to_capi === true)
+      },
+      { timeout: 15000 }
+    ).catch(() => null)
+
+    const eventsRes = await page.request.get(
+      `${BASE_URL}/api/v1/events?pixel_id=${sourcePixelUUID}&per_page=100`,
+      { headers: { Authorization: `Bearer ${cachedAccessToken}` } }
+    )
+    const { data: events } = (await eventsRes.json()) as { data: unknown[] }
+
+    expect(events.length).toBeGreaterThan(0)
+
+    // Verify 5b: CAPI confirmation
+    for (const evt of events) {
+      const e = evt as EventRecord
+      expect(e.forwarded_to_capi).toBe(true)
+      expect(e.capi_response_code).toBe(200)
+      expect(e.capi_events_received).toBeGreaterThan(0)
+    }
+    console.log(`✅ All ${events.length} events forwarded to CAPI with FB acknowledgment`)
+
+    // Verify 5c: Event types complete
+    const eventTypes = new Set(events.map((e: EventRecord) => e.event_name))
+    for (const type of REQUIRED_EVENT_TYPES) {
+      expect(eventTypes.has(type)).toBe(true)
+    }
+    console.log(`✅ All 5 event types present: ${REQUIRED_EVENT_TYPES.join(', ')}`)
   })
 
   // ============================================================
@@ -332,6 +429,49 @@ test.describe('Scenario 14: Real Facebook Integration', { tag: ['@critical', '@r
       }
       console.log(`✅ Replay completed — events sent to Pixel B (FB ID: ${PIXEL_B_ID})`)
     }
+  })
+
+  test('step 8b: verify replayed events forwarded to Pixel B via CAPI', async ({ page }) => {
+    if (!hasSecondPixelSlot || !targetPixelUUID) {
+      console.log('⚠️ Skipping Pixel B verification — no second pixel or UUID not captured')
+      test.skip(true, 'No Pixel B verification (single pixel test)')
+      return
+    }
+
+    expect(cachedAccessToken).toBeTruthy()
+
+    // Poll for replay + CAPI processing
+    await page.waitForFunction(
+      async () => {
+        const res = await page.request.get(
+          `${BASE_URL}/api/v1/events?pixel_id=${targetPixelUUID}&per_page=100`,
+          { headers: { Authorization: `Bearer ${cachedAccessToken}` } }
+        )
+        const { data } = (await res.json()) as { data: unknown[] }
+        return data.length > 0
+      },
+      { timeout: 20000 }
+    ).catch(() => null)
+
+    const eventsRes = await page.request.get(
+      `${BASE_URL}/api/v1/events?pixel_id=${targetPixelUUID}&per_page=100`,
+      { headers: { Authorization: `Bearer ${cachedAccessToken}` } }
+    )
+    const { data: events } = (await eventsRes.json()) as { data: unknown[] }
+
+    if (events.length === 0) {
+      console.log('⚠️ No events in Pixel B yet (may still be processing)')
+      test.skip(true, 'Pixel B events not yet received')
+      return
+    }
+
+    // Verify replayed events have CAPI forwarding
+    for (const evt of events) {
+      const e = evt as { forwarded_to_capi?: boolean; capi_response_code?: number }
+      expect(e.forwarded_to_capi).toBe(true)
+      expect(e.capi_response_code).toBe(200)
+    }
+    console.log(`✅ Replayed events verified in Pixel B (${events.length} events forwarded to CAPI)`)
   })
 
   // ============================================================

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,11 +40,13 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "dotenv": "^16.4.5",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^28.1.0",
+        "react-doctor": "^0.2.10",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
@@ -551,6 +553,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "4.0.0-beta.70",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.70.tgz",
+      "integrity": "sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "effect": "^4.0.0-beta.70"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1246,6 +1296,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1289,6 +1346,1092 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
+      "integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
+      "integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
+      "integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
+      "integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
+      "integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
+      "integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
+      "integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
+      "integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
+      "integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
+      "integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
+      "integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
+      "integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
+      "integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
+      "integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
+      "integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
+      "integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
+      "integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
+      "integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
+      "integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
+      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
+      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
+      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
+      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
+      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
+      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
+      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
+      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
+      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
+      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
+      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
+      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
+      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
+      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
+      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
+      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
+      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
+      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
+      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -2648,6 +3791,16 @@
         }
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2782,6 +3935,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2830,6 +3990,16 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -3291,6 +4461,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agent-install": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.5.tgz",
+      "integrity": "sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "commander": "^14.0.0",
+        "jsonc-parser": "^3.3.1",
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "agent-install": "bin/agent-install.mjs"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3307,6 +4495,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3381,6 +4611,17 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
@@ -3431,6 +4672,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -3591,12 +4845,83 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/conf": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
+      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^10.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3825,6 +5150,22 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3883,6 +5224,74 @@
         "node": ">=6"
       }
     },
+    "node_modules/deslop-js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/deslop-js/-/deslop-js-0.0.13.tgz",
+      "integrity": "sha512-gIXD+wY2/NHkZHpNrb8MWS6NJs3ee0XunAenBCvwHJlWnedDbIrg70hdNR7bDzYZLe9LGJZMLEI1w2CC72Gk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0",
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.2.5",
+        "oxc-parser": "^0.132.0",
+        "oxc-resolver": "^11.19.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/deslop-js/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/deslop-js/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/deslop-js/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/deslop-js/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3906,6 +5315,35 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dot-prop": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
+      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3918,6 +5356,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.70",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.70.tgz",
+      "integrity": "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3951,6 +5408,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -4140,9 +5610,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4156,7 +5626,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -4289,12 +5759,65 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4309,6 +5832,33 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4339,6 +5889,26 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -4691,6 +6261,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -4721,6 +6301,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4834,6 +6424,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4854,6 +6451,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4863,6 +6467,23 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5205,6 +6826,43 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -5226,6 +6884,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
@@ -5243,6 +6914,46 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+      "integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5270,6 +6981,22 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -5305,6 +7032,185 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.20.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
+      "integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.20.0",
+        "@oxc-resolver/binding-android-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.20.0",
+        "@oxc-resolver/binding-darwin-x64": "11.20.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.20.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.20.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.20.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
+      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.67.0",
+        "@oxlint/binding-android-arm64": "1.67.0",
+        "@oxlint/binding-darwin-arm64": "1.67.0",
+        "@oxlint/binding-darwin-x64": "1.67.0",
+        "@oxlint/binding-freebsd-x64": "1.67.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
+        "@oxlint/binding-linux-arm64-musl": "1.67.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
+        "@oxlint/binding-linux-x64-gnu": "1.67.0",
+        "@oxlint/binding-linux-x64-musl": "1.67.0",
+        "@oxlint/binding-openharmony-arm64": "1.67.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
+        "@oxlint/binding-win32-x64-msvc": "1.67.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/oxlint-plugin-react-doctor/-/oxlint-plugin-react-doctor-0.2.10.tgz",
+      "integrity": "sha512-n36QdOLz4k9EEWod+vhki9/h29x/PL4nS91nWSk6AIr7HAL+rc6fkwUcVLgg3NhUVlaL/VOfYiIm4cVxyIIdGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.59.3",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/@typescript-eslint/types": {
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/p-limit": {
@@ -5533,6 +7439,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5549,6 +7469,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -5556,6 +7514,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-doctor": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/react-doctor/-/react-doctor-0.2.10.tgz",
+      "integrity": "sha512-ruceNG2VBJvpLv5Jn3t13GMPkRZCC+PZX5UGl4PHCTYiFE1VVNqXSf2mXe10v21YAjAfrlyuM9WPdxeHHRwvYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "4.0.0-beta.70",
+        "agent-install": "0.0.5",
+        "conf": "^15.1.0",
+        "deslop-js": "^0.0.13",
+        "effect": "4.0.0-beta.70",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "oxlint": "^1.66.0",
+        "oxlint-plugin-react-doctor": "0.2.10",
+        "prompts": "^2.4.2",
+        "typescript": ">=5.0.4 <7"
+      },
+      "bin": {
+        "react-doctor": "bin/react-doctor.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/react-dom": {
@@ -5788,6 +7771,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -5830,6 +7824,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/saxes": {
@@ -5897,6 +7915,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -5943,6 +7968,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5962,6 +8004,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -6061,6 +8116,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
@@ -6119,6 +8197,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6155,6 +8249,19 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici": {
@@ -6265,6 +8372,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {
@@ -6489,6 +8610,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6532,6 +8660,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6555,6 +8705,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:headed": "playwright test --headed"
+    "e2e:headed": "playwright test --headed",
+    "doctor": "npx react-doctor@latest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -46,11 +47,13 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "dotenv": "^16.4.5",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^28.1.0",
+    "react-doctor": "^0.2.10",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+
+// Load .env.e2e.local first (production/real FB testing), then override with shell env
+dotenv.config({ path: '.env.e2e.local', override: false })
 
 const isCI = !!process.env.CI
 const useExternalURL = !!process.env.E2E_BASE_URL

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,8 +1,13 @@
 import { defineConfig, devices } from '@playwright/test'
 import dotenv from 'dotenv'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
-// Load .env.e2e.local first (production/real FB testing), then override with shell env
-dotenv.config({ path: '.env.e2e.local', override: false })
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Load .env.e2e.local first (production/real FB testing), then override with shell env.
+// Resolve relative to this config so the file is found regardless of cwd.
+dotenv.config({ path: path.resolve(__dirname, '.env.e2e.local'), override: false })
 
 const isCI = !!process.env.CI
 const useExternalURL = !!process.env.E2E_BASE_URL


### PR DESCRIPTION
## Summary

Bundles three small dev-tooling improvements that were sitting in the working tree alongside #215.

1. **react-doctor pre-commit hook** (`.husky/pre-commit`) + `npm run doctor` script — runs `react-doctor --staged --fail-on warning` on every commit to catch React Doctor regressions at commit time. Adds `react-doctor` as devDependency.

2. **E2E auto-refresh from refresh token** (`e2e/support/global-setup.ts`) — when `E2E_REFRESH_TOKEN` is set without `E2E_ACCESS_TOKEN`, hits `/api/v1/auth/refresh` to mint a fresh access token. Persists the rotated refresh token back to `.env.e2e.local`. Removes manual access-token-copy step for prod E2E runs.

3. **Real-Facebook scenario test** (`e2e/tests/journeys/scenario-14-real-facebook.spec.ts`) — exercises the full pipeline against real Facebook pixels, gated on `REAL_PIXEL_A_*` / `REAL_PIXEL_B_*` env vars.

4. **`playwright.config.ts`** — load `.env.e2e.local` via `dotenv` so credentials don't need to be exported manually. Adds `dotenv` devDependency.

5. **`.gitignore`** — exclude local agent/skill configs (`frontend/.agents/`, `frontend/.claude/`, `.claude/skills/learned/`).

6. **Planning doc** (`docs/superpowers/plans/2026-05-11-incomplete-features-cleanup.md`) — in-progress feature-cleanup plan.

7. **Lint fix** — suppress `react-hooks/set-state-in-effect` on `BlockEditorPage`'s mount-only draft-restore `useEffect` (same fix lives in #215; duplicated here so this branch can ship before #215 merges).

## Test plan

- [ ] `npm run lint` passes (only pre-existing react-hook-form warnings remain)
- [ ] `npm run build` succeeds
- [ ] Pre-commit hook fires `react-doctor --staged` on any new commit touching React files
- [ ] Set `E2E_REFRESH_TOKEN` only (no access token) → `npm run e2e` succeeds via auto-refresh
- [ ] `frontend/.agents/` / `frontend/.claude/` no longer show in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)